### PR TITLE
Dev tools update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM base AS tailwind
 
 ARG TARGETARCH
-ARG TAILWIND_VERSION=v4.1.8
+ARG TAILWIND_VERSION=v4.1.16
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
     && curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-${ARCH} \
     && chmod +x tailwindcss-linux-${ARCH} \
@@ -61,7 +61,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project
 
 ARG TARGETARCH
-ARG TAILWIND_VERSION=v4.1.8
+ARG TAILWIND_VERSION=v4.1.16
 RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "x64") \
     && curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-${ARCH} \
     && chmod +x tailwindcss-linux-${ARCH} \

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,14 @@
-.PHONY: help dev build css clean install migrate test collectstatic format lint \
+.PHONY: help dev build css clean install migrate test collectstatic lint \
        docker-build docker-dev docker-prod docker-down docker-logs docker-shell docker-migrate docker-test docker-clean
 
 help: ## Show this help message
 	@echo "Available commands:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-install: ## Install Python dependencies
+install: ## Install Python dependencies (includes Tailwind CSS)
 	python -m venv .venv
 	.venv/bin/pip install --upgrade pip
 	.venv/bin/pip install -e ".[dev]"
-	@echo ""
-	@echo "NOTE: Tailwind CSS CLI required (brew install tailwindcss)"
 
 dev: ## Start Django + Tailwind CSS watch
 	./dev.sh
@@ -48,13 +46,8 @@ superuser: ## Create Django superuser
 shell: ## Open Django shell
 	source .venv/bin/activate && python manage.py shell
 
-format: ## Format all code (Python + HTML templates)
-	source .venv/bin/activate && ruff format .
-	source .venv/bin/activate && djlint templates/ --reformat
-
-lint: ## Lint all code (Python + HTML templates)
-	source .venv/bin/activate && ruff check .
-	source .venv/bin/activate && djlint templates/ --lint
+lint: ## Lint and format all code (via pre-commit)
+	pre-commit run --all-files
 
 # Docker targets
 docker-build: ## Build Docker images

--- a/dev.sh
+++ b/dev.sh
@@ -15,6 +15,9 @@ done
 
 export DEBUG="${DEBUG_MODE}"
 
+# Pin Tailwind CSS version (must match Dockerfile)
+export TAILWINDCSS_VERSION="v4.1.16"
+
 # Generate a random SECRET_KEY for dev if not set
 if [ -z "$SECRET_KEY" ]; then
   export SECRET_KEY=$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
@@ -29,7 +32,7 @@ NC='\033[0m' # No Color
 echo -e "${GREEN}Starting Litigant Portal development servers...${NC}"
 echo ""
 echo -e "${YELLOW}Visit your app at: ${GREEN}http://localhost:8000/${NC}"
-echo -e "${CYAN}Component Library: http://localhost:8000/components/${NC}"
+echo -e "${CYAN}Style Guide: http://localhost:8000/style-guide/${NC}"
 echo ""
 echo -e "Press ${YELLOW}Ctrl+C${NC} to stop"
 echo ""


### PR DESCRIPTION
This PR:
Uses `make lint` to fire pre-commit code for linting and formatting
Bumps the Tailwind version in Docker and `dev.sh` script
