### PR TITLE
Migrate localStorage to server API calls

### DIFF
--- a/templates/cotton/organisms/header.html
+++ b/templates/cotton/organisms/header.html
@@ -58,8 +58,14 @@
         <c-atoms.icon name="x-mark" class="w-6 h-6" />
         </c-atoms.button>
       </div>
-      {# Timeline - refreshes from localStorage when menu opens #}
+      {# Timeline - fetches from server when menu opens #}
       <div class="p-4 space-y-3">
+        {# Loading state #}
+        <template x-if="isLoadingTimeline">
+          <div class="flex items-center justify-center py-8">
+            <c-atoms.icon name="arrow-path" class="w-6 h-6 text-greyscale-400 animate-spin" />
+          </div>
+        </template>
         {# Empty state #}
         <template x-if="noTimeline">
           <div class="text-center py-8">


### PR DESCRIPTION
## Summary
- Replace all localStorage usage for PII data (chatSessionId, caseInfo, caseTimeline) with fetch() calls to `/api/chat/case/` endpoints
- `chat.js`: init() fetches from server, confirmExtraction/addTimelineEvent/clearCaseInfo POST to server
- `components.js`: activityTimeline fetches on menu open with loading state, clearDemo POSTs to server
- Only localStorage remaining: theme preference (no PII)

Part of #137 — stack 3/4 for migrating localStorage to server-side storage.

## Stack
1. #138 Models ← `alpine-csp-restore`
2. #139 API endpoints ← #138
3. **JS migration (this PR)** ← #139
4. Auth migration ← this PR

## Test plan
- [ ] Chat flow works end-to-end (send message, case extraction, timeline)
- [ ] Activity timeline loads from server on menu open
- [ ] Clear demo resets server-side data
- [ ] Theme toggle still works (localStorage retained for non-PII)

🤖 Generated with [Claude Code](https://claude.com/claude-code)