### PR TITLE
Add auth migration for anonymous-to-user data

### DIFF
--- a/chat/apps.py
+++ b/chat/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ChatConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "chat"
+
+    def ready(self):
+        import chat.signals  # noqa: F401

--- a/chat/middleware.py
+++ b/chat/middleware.py
@@ -1,0 +1,26 @@
+"""Middleware for preserving anonymous session key across login."""
+
+
+class AnonymousSessionKeyMiddleware:
+    """Save the anonymous session key so the login signal can migrate data.
+
+    Django's login() calls session.cycle_key(), which changes the session
+    key but preserves session data. By storing the key as session data,
+    the user_logged_in signal handler can find anonymous records to
+    migrate.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if (
+            hasattr(request, "session")
+            and hasattr(request, "user")
+            and not request.user.is_authenticated
+            and request.session.session_key
+        ):
+            request.session["_anonymous_session_key"] = (
+                request.session.session_key
+            )
+        return self.get_response(request)

--- a/chat/signals.py
+++ b/chat/signals.py
@@ -1,0 +1,56 @@
+"""Signals for migrating anonymous data to authenticated users."""
+
+import logging
+
+from django.contrib.auth.signals import user_logged_in
+from django.dispatch import receiver
+
+from .models import CaseInfo, ChatSession
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(user_logged_in)
+def migrate_anonymous_data(request, user, **kwargs):
+    """Migrate ChatSession and CaseInfo from anonymous session to user.
+
+    When a user logs in, any data created during their anonymous session
+    (identified by session_key) gets transferred to their user account.
+    If the user already has a CaseInfo, the anonymous one is deleted to
+    avoid duplicates.
+    """
+    # login() calls session.cycle_key() before this signal fires,
+    # so session_key is the new one. The middleware saved the original
+    # anonymous key as session data (which survives cycle_key).
+    session_key = request.session.pop("_anonymous_session_key", None)
+    if not session_key:
+        return
+
+    # Migrate chat sessions
+    anonymous_sessions = ChatSession.objects.filter(
+        session_key=session_key, user__isnull=True
+    )
+    migrated_chats = anonymous_sessions.update(user=user, session_key="")
+    if migrated_chats:
+        logger.info(
+            "Migrated %d chat session(s) for user %s", migrated_chats, user
+        )
+
+    # Migrate case info
+    anonymous_case = CaseInfo.objects.filter(
+        session_key=session_key, user__isnull=True
+    ).first()
+
+    if not anonymous_case:
+        return
+
+    existing_case = CaseInfo.objects.filter(user=user).first()
+    if existing_case:
+        # User already has case info — delete the anonymous one
+        anonymous_case.delete()
+        logger.info("Deleted duplicate anonymous CaseInfo for user %s", user)
+    else:
+        anonymous_case.user = user
+        anonymous_case.session_key = ""
+        anonymous_case.save(update_fields=["user", "session_key"])
+        logger.info("Migrated CaseInfo to user %s", user)

--- a/chat/tests/test_signals.py
+++ b/chat/tests/test_signals.py
@@ -1,0 +1,122 @@
+"""Tests for anonymous-to-authenticated data migration signal."""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase, override_settings
+
+from chat.models import CaseInfo, ChatSession
+
+User = get_user_model()
+
+
+def _create_anonymous_session(client):
+    """Create an anonymous session and store the key for migration.
+
+    Simulates what happens in production: the middleware stores
+    _anonymous_session_key in session data on each anonymous request,
+    and cycle_key() preserves it across login.
+    """
+    session = client.session
+    session.create()
+    session["_anonymous_session_key"] = session.session_key
+    session.save()
+    # Set the session cookie so subsequent requests use this session
+    cookie_name = settings.SESSION_COOKIE_NAME
+    client.cookies[cookie_name] = session.session_key
+    return session.session_key
+
+
+@override_settings(
+    ACCOUNT_EMAIL_VERIFICATION="none",
+    ACCOUNT_AUTHENTICATION_METHOD="username",
+)
+class MigrateAnonymousDataTests(TestCase):
+    """Tests for the user_logged_in signal handler."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", password="testpass"
+        )
+
+    def test_migrates_anonymous_chat_sessions(self):
+        """Anonymous chat sessions should be linked to user on login."""
+        client = Client()
+        session_key = _create_anonymous_session(client)
+
+        chat_session = ChatSession.objects.create(session_key=session_key)
+
+        client.login(username="testuser", password="testpass")
+
+        chat_session.refresh_from_db()
+        self.assertEqual(chat_session.user, self.user)
+        self.assertEqual(chat_session.session_key, "")
+
+    def test_migrates_anonymous_case_info(self):
+        """Anonymous CaseInfo should be linked to user on login."""
+        client = Client()
+        session_key = _create_anonymous_session(client)
+
+        case = CaseInfo.objects.create(
+            session_key=session_key,
+            data={"case_type": "Eviction"},
+        )
+
+        client.login(username="testuser", password="testpass")
+
+        case.refresh_from_db()
+        self.assertEqual(case.user, self.user)
+        self.assertEqual(case.session_key, "")
+        self.assertEqual(case.data["case_type"], "Eviction")
+
+    def test_deletes_duplicate_anonymous_case(self):
+        """If user already has CaseInfo, anonymous one is deleted."""
+        client = Client()
+        session_key = _create_anonymous_session(client)
+
+        # User already has a case
+        CaseInfo.objects.create(
+            user=self.user,
+            data={"case_type": "Foreclosure"},
+        )
+        # Anonymous case exists too
+        CaseInfo.objects.create(
+            session_key=session_key,
+            data={"case_type": "Eviction"},
+        )
+
+        client.login(username="testuser", password="testpass")
+
+        # User's existing case should remain
+        self.assertEqual(CaseInfo.objects.count(), 1)
+        remaining = CaseInfo.objects.first()
+        self.assertEqual(remaining.user, self.user)
+        self.assertEqual(remaining.data["case_type"], "Foreclosure")
+
+    def test_noop_without_anonymous_data(self):
+        """Login without anonymous data should not error."""
+        client = Client()
+        client.login(username="testuser", password="testpass")
+
+        self.assertEqual(ChatSession.objects.count(), 0)
+        self.assertEqual(CaseInfo.objects.count(), 0)
+
+    def test_timeline_events_follow_case(self):
+        """TimelineEvents should follow their CaseInfo to the user."""
+        client = Client()
+        session_key = _create_anonymous_session(client)
+
+        case = CaseInfo.objects.create(
+            session_key=session_key,
+            data={"case_type": "Eviction"},
+        )
+        case.timeline_events.create(
+            event_type="upload",
+            title="Test upload",
+            content="Test content",
+        )
+
+        client.login(username="testuser", password="testpass")
+
+        case.refresh_from_db()
+        self.assertEqual(case.user, self.user)
+        self.assertEqual(case.timeline_events.count(), 1)

--- a/config/settings.py
+++ b/config/settings.py
@@ -83,6 +83,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "chat.middleware.AnonymousSessionKeyMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",


### PR DESCRIPTION
## Summary
- On login, migrate anonymous ChatSession and CaseInfo records to the authenticated user
- If the user already has a CaseInfo, the anonymous duplicate is deleted
- `AnonymousSessionKeyMiddleware` preserves pre-login session key across Django's `session.cycle_key()` call

Part of #137 — stack 4/4 for migrating localStorage to server-side storage.

## Stack
1. #138 Models ← `alpine-csp-restore`
2. #139 API endpoints ← #138
3. #140 JS migration ← #139
4. **Auth migration (this PR)** ← #140

## Test plan
- [ ] `make test` passes (122 lines of signal tests included)
- [ ] Login migrates anonymous session data to user
- [ ] Existing user data is preserved (anonymous duplicate deleted)
- [ ] Session key preserved through login cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)