### PR TITLE
i18n: mark Python strings for translation

### DIFF
--- a/portal/forms.py
+++ b/portal/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from .models import UserProfile
 
@@ -21,32 +22,32 @@ class UserProfileForm(forms.ModelForm):
         widgets = {
             "name": forms.TextInput(
                 attrs={
-                    "placeholder": "Your full legal name",
+                    "placeholder": _("Your full legal name"),
                     "autocomplete": "name",
                 }
             ),
             "phone": forms.TextInput(
                 attrs={
-                    "placeholder": "(555) 123-4567",
+                    "placeholder": _("(555) 123-4567"),
                     "autocomplete": "tel",
                     "type": "tel",
                 }
             ),
             "address_line1": forms.TextInput(
                 attrs={
-                    "placeholder": "123 Main Street",
+                    "placeholder": _("123 Main Street"),
                     "autocomplete": "address-line1",
                 }
             ),
             "address_line2": forms.TextInput(
                 attrs={
-                    "placeholder": "Apartment, suite, unit, etc.",
+                    "placeholder": _("Apartment, suite, unit, etc."),
                     "autocomplete": "address-line2",
                 }
             ),
             "city": forms.TextInput(
                 attrs={
-                    "placeholder": "City",
+                    "placeholder": _("City"),
                     "autocomplete": "address-level2",
                 }
             ),
@@ -57,13 +58,13 @@ class UserProfileForm(forms.ModelForm):
             ),
             "zip_code": forms.TextInput(
                 attrs={
-                    "placeholder": "12345",
+                    "placeholder": _("12345"),
                     "autocomplete": "postal-code",
                 }
             ),
             "county": forms.TextInput(
                 attrs={
-                    "placeholder": "e.g., Los Angeles County",
+                    "placeholder": _("e.g., Los Angeles County"),
                 }
             ),
         }

--- a/portal/models.py
+++ b/portal/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 
 class UserProfile(models.Model):
@@ -11,57 +12,57 @@ class UserProfile(models.Model):
     """
 
     STATE_CHOICES = [
-        ("AL", "Alabama"),
-        ("AK", "Alaska"),
-        ("AZ", "Arizona"),
-        ("AR", "Arkansas"),
-        ("CA", "California"),
-        ("CO", "Colorado"),
-        ("CT", "Connecticut"),
-        ("DE", "Delaware"),
-        ("FL", "Florida"),
-        ("GA", "Georgia"),
-        ("HI", "Hawaii"),
-        ("ID", "Idaho"),
-        ("IL", "Illinois"),
-        ("IN", "Indiana"),
-        ("IA", "Iowa"),
-        ("KS", "Kansas"),
-        ("KY", "Kentucky"),
-        ("LA", "Louisiana"),
-        ("ME", "Maine"),
-        ("MD", "Maryland"),
-        ("MA", "Massachusetts"),
-        ("MI", "Michigan"),
-        ("MN", "Minnesota"),
-        ("MS", "Mississippi"),
-        ("MO", "Missouri"),
-        ("MT", "Montana"),
-        ("NE", "Nebraska"),
-        ("NV", "Nevada"),
-        ("NH", "New Hampshire"),
-        ("NJ", "New Jersey"),
-        ("NM", "New Mexico"),
-        ("NY", "New York"),
-        ("NC", "North Carolina"),
-        ("ND", "North Dakota"),
-        ("OH", "Ohio"),
-        ("OK", "Oklahoma"),
-        ("OR", "Oregon"),
-        ("PA", "Pennsylvania"),
-        ("RI", "Rhode Island"),
-        ("SC", "South Carolina"),
-        ("SD", "South Dakota"),
-        ("TN", "Tennessee"),
-        ("TX", "Texas"),
-        ("UT", "Utah"),
-        ("VT", "Vermont"),
-        ("VA", "Virginia"),
-        ("WA", "Washington"),
-        ("WV", "West Virginia"),
-        ("WI", "Wisconsin"),
-        ("WY", "Wyoming"),
-        ("DC", "District of Columbia"),
+        ("AL", _("Alabama")),
+        ("AK", _("Alaska")),
+        ("AZ", _("Arizona")),
+        ("AR", _("Arkansas")),
+        ("CA", _("California")),
+        ("CO", _("Colorado")),
+        ("CT", _("Connecticut")),
+        ("DE", _("Delaware")),
+        ("FL", _("Florida")),
+        ("GA", _("Georgia")),
+        ("HI", _("Hawaii")),
+        ("ID", _("Idaho")),
+        ("IL", _("Illinois")),
+        ("IN", _("Indiana")),
+        ("IA", _("Iowa")),
+        ("KS", _("Kansas")),
+        ("KY", _("Kentucky")),
+        ("LA", _("Louisiana")),
+        ("ME", _("Maine")),
+        ("MD", _("Maryland")),
+        ("MA", _("Massachusetts")),
+        ("MI", _("Michigan")),
+        ("MN", _("Minnesota")),
+        ("MS", _("Mississippi")),
+        ("MO", _("Missouri")),
+        ("MT", _("Montana")),
+        ("NE", _("Nebraska")),
+        ("NV", _("Nevada")),
+        ("NH", _("New Hampshire")),
+        ("NJ", _("New Jersey")),
+        ("NM", _("New Mexico")),
+        ("NY", _("New York")),
+        ("NC", _("North Carolina")),
+        ("ND", _("North Dakota")),
+        ("OH", _("Ohio")),
+        ("OK", _("Oklahoma")),
+        ("OR", _("Oregon")),
+        ("PA", _("Pennsylvania")),
+        ("RI", _("Rhode Island")),
+        ("SC", _("South Carolina")),
+        ("SD", _("South Dakota")),
+        ("TN", _("Tennessee")),
+        ("TX", _("Texas")),
+        ("UT", _("Utah")),
+        ("VT", _("Vermont")),
+        ("VA", _("Virginia")),
+        ("WA", _("Washington")),
+        ("WV", _("West Virginia")),
+        ("WI", _("Wisconsin")),
+        ("WY", _("Wyoming")),
+        ("DC", _("District of Columbia")),
     ]
 
     user = models.OneToOneField(
@@ -72,23 +73,23 @@ class UserProfile(models.Model):
 
     # Contact information
     name = models.CharField(
-        max_length=255, blank=True, help_text="Full legal name"
+        max_length=255, blank=True, help_text=_("Full legal name")
     )
     phone = models.CharField(
-        max_length=20, blank=True, help_text="Phone number"
+        max_length=20, blank=True, help_text=_("Phone number")
     )
 
     # Address fields
     address_line1 = models.CharField(
-        max_length=255, blank=True, verbose_name="Street address"
+        max_length=255, blank=True, verbose_name=_("Street address")
     )
     address_line2 = models.CharField(
-        max_length=255, blank=True, verbose_name="Apt, suite, etc."
+        max_length=255, blank=True, verbose_name=_("Apt, suite, etc.")
     )
     city = models.CharField(max_length=100, blank=True)
     state = models.CharField(max_length=2, choices=STATE_CHOICES, blank=True)
     zip_code = models.CharField(
-        max_length=10, blank=True, verbose_name="ZIP code"
+        max_length=10, blank=True, verbose_name=_("ZIP code")
     )
     county = models.CharField(max_length=100, blank=True)
 
@@ -96,8 +97,8 @@ class UserProfile(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        verbose_name = "User Profile"
-        verbose_name_plural = "User Profiles"
+        verbose_name = _("User Profile")
+        verbose_name_plural = _("User Profiles")
 
     def __str__(self):
         return f"{self.name or 'Unnamed'} ({self.user.email})"

--- a/portal/views.py
+++ b/portal/views.py
@@ -3,6 +3,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse_lazy
+from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, UpdateView
 
 from chat.agents import agent_registry
@@ -12,46 +14,70 @@ from .models import UserProfile
 
 TOPICS = {
     "housing": {
-        "title": "Housing & Eviction",
-        "subtitle": "Understanding the eviction process, tenant rights, and landlord obligations",
-        "description": "Landlord disputes, eviction defense, tenant rights",
+        "title": _("Housing & Eviction"),
+        "subtitle": _(
+            "Understanding the eviction process, tenant rights, and landlord obligations"
+        ),
+        "description": _("Landlord disputes, eviction defense, tenant rights"),
         "icon": "home",
-        "meta_description": "Learn about the eviction process, tenant rights, and landlord obligations. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about the eviction process, tenant rights, and landlord obligations. General legal information for self-represented litigants."
+        ),
     },
     "family": {
-        "title": "Family & Divorce",
-        "subtitle": "Divorce, custody, child support, and domestic violence resources",
-        "description": "Divorce, custody, child support, domestic issues",
+        "title": _("Family & Divorce"),
+        "subtitle": _(
+            "Divorce, custody, child support, and domestic violence resources"
+        ),
+        "description": _("Divorce, custody, child support, domestic issues"),
         "icon": "users",
-        "meta_description": "Learn about divorce, child custody, child support, and family court. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about divorce, child custody, child support, and family court. General legal information for self-represented litigants."
+        ),
     },
     "small-claims": {
-        "title": "Small Claims",
-        "subtitle": "Resolving disputes and understanding the small claims court process",
-        "description": "Disputes under $10,000, debt collection defense",
+        "title": _("Small Claims"),
+        "subtitle": _(
+            "Resolving disputes and understanding the small claims court process"
+        ),
+        "description": _("Disputes under $10,000, debt collection defense"),
         "icon": "currency-dollar",
-        "meta_description": "Learn about filing or defending a small claims case. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about filing or defending a small claims case. General legal information for self-represented litigants."
+        ),
     },
     "consumer": {
-        "title": "Consumer Rights",
-        "subtitle": "Debt collection rules, contract disputes, and consumer protections",
-        "description": "Scams, unfair business practices, contracts",
+        "title": _("Consumer Rights"),
+        "subtitle": _(
+            "Debt collection rules, contract disputes, and consumer protections"
+        ),
+        "description": _("Scams, unfair business practices, contracts"),
         "icon": "shield-check",
-        "meta_description": "Learn about consumer rights, debt collection rules, and contract disputes. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about consumer rights, debt collection rules, and contract disputes. General legal information for self-represented litigants."
+        ),
     },
     "expungement": {
-        "title": "Expungement",
-        "subtitle": "Clearing or sealing your criminal record and restoring opportunities",
-        "description": "Clear your record, seal court files",
+        "title": _("Expungement"),
+        "subtitle": _(
+            "Clearing or sealing your criminal record and restoring opportunities"
+        ),
+        "description": _("Clear your record, seal court files"),
         "icon": "document-text",
-        "meta_description": "Learn about expungement, record sealing, and eligibility requirements. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about expungement, record sealing, and eligibility requirements. General legal information for self-represented litigants."
+        ),
     },
     "traffic": {
-        "title": "Traffic & Fines",
-        "subtitle": "Traffic violations, fines, license issues, and your options",
-        "description": "Tickets, license issues, court fines",
+        "title": _("Traffic & Fines"),
+        "subtitle": _(
+            "Traffic violations, fines, license issues, and your options"
+        ),
+        "description": _("Tickets, license issues, court fines"),
         "icon": "truck",
-        "meta_description": "Learn about traffic tickets, fines, license suspension, and your options. General legal information for self-represented litigants.",
+        "meta_description": _(
+            "Learn about traffic tickets, fines, license suspension, and your options. General legal information for self-represented litigants."
+        ),
     },
 }
 
@@ -131,5 +157,7 @@ class ProfileEditView(LoginRequiredMixin, UpdateView):
         return profile
 
     def form_valid(self, form):
-        messages.success(self.request, "Profile updated successfully.")
+        messages.success(
+            self.request, gettext("Profile updated successfully.")
+        )
         return super().form_valid(form)


### PR DESCRIPTION
## Summary
- `portal/models.py`: wrap STATE_CHOICES, help_text, verbose_name with `gettext_lazy`
- `portal/forms.py`: wrap placeholder strings with `gettext_lazy`
- `portal/views.py`: wrap TOPICS text and success message
- `chat/views.py`: wrap error/validation messages with `gettext`

Part of #101 — PR 2 of 6

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes