### PR TITLE
refactor(button): extract inline styles into @apply CSS classes

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -235,6 +235,95 @@
    ========================================================================== */
 
 @layer components {
+  /* ==========================================================================
+     BUTTON ATOM
+     ========================================================================== */
+
+  /* Base */
+  .btn {
+    @apply rounded-lg w-fit font-normal flex gap-1 items-center transition-colors duration-200;
+  }
+
+  .btn:disabled {
+    @apply cursor-not-allowed;
+  }
+
+  .btn[aria-disabled='true'] {
+    @apply pointer-events-none;
+  }
+
+  /* Sizes */
+  .btn-sm {
+    @apply py-1.5 px-2.5 text-xs;
+  }
+
+  .btn-md {
+    @apply py-2.5 px-3.5 text-sm;
+  }
+
+  .btn-xl {
+    @apply py-3 px-4.5 text-md;
+  }
+
+  .btn-icon {
+    @apply p-2.5;
+  }
+
+  .btn-icon-xl {
+    @apply p-3;
+  }
+
+  /* Variants */
+  .btn-primary {
+    @apply text-white bg-primary-600 outline-none;
+    @apply hover:bg-primary-700 focus-visible:ring-4 focus-visible:ring-primary-300;
+  }
+
+  .btn-primary:disabled,
+  .btn-primary[aria-disabled='true'] {
+    @apply bg-primary-100 text-primary-400;
+  }
+
+  .btn-outline {
+    @apply bg-white text-greyscale-700 border border-greyscale-300 outline-none;
+    @apply hover:bg-greyscale-100 focus-visible:ring-4 focus-visible:ring-greyscale-300;
+  }
+
+  .btn-outline:disabled,
+  .btn-outline[aria-disabled='true'] {
+    @apply bg-white text-greyscale-400 border-greyscale-200;
+  }
+
+  .btn-dark {
+    @apply text-white bg-greyscale-900 outline-none;
+    @apply hover:bg-greyscale-800 focus-visible:ring-4 focus-visible:ring-greyscale-400;
+  }
+
+  .btn-dark:disabled,
+  .btn-dark[aria-disabled='true'] {
+    @apply bg-greyscale-400 text-greyscale-200;
+  }
+
+  .btn-ghost {
+    @apply text-greyscale-700;
+    @apply hover:bg-greyscale-100 focus-visible:ring-4 focus-visible:ring-greyscale-200;
+  }
+
+  .btn-ghost:disabled,
+  .btn-ghost[aria-disabled='true'] {
+    @apply text-greyscale-400;
+  }
+
+  .btn-danger {
+    @apply text-white bg-red-500 outline-none;
+    @apply hover:bg-red-600 focus-visible:ring-4 focus-visible:ring-red-300;
+  }
+
+  .btn-danger:disabled,
+  .btn-danger[aria-disabled='true'] {
+    @apply bg-red-200 text-red-400;
+  }
+
   /* Skip Link - Accessibility */
   .skip-link {
     @apply transition-all ease-in-out pointer-events-none;

--- a/templates/cotton/atoms/button.html
+++ b/templates/cotton/atoms/button.html
@@ -1,20 +1,20 @@
 <c-vars type="button" variant="primary" size="" href="" />
-{# Base: shared across all variants #}
 {# Variant: primary|outline|dark|ghost|danger #}
 {# Size: sm|xl|icon|icon-xl (default is medium) #}
 {# href: when set, renders as <a> link instead of <button> #}
 {% if href %}
   <a href="{{ href }}"
      {% if id %}id="{{ id }}"{% endif %}
+     {% if disabled %}aria-disabled="true" tabindex="-1"{% endif %}
      {% if aria_label %}aria-label="{{ aria_label }}"{% endif %}
-     class="{% if size == 'sm' %}py-1.5 px-2.5 text-xs{% elif size == 'xl' %}py-3 px-4.5 text-md{% elif size == 'icon' %}p-2.5{% elif size == 'icon-xl' %}p-3{% else %}py-2.5 px-3.5 text-sm{% endif %} rounded-lg w-fit font-normal flex gap-1 items-center transition-colors duration-200 {% if variant == 'primary' %}text-white bg-primary-600 hover:bg-primary-700 outline-none focus-visible:ring-4 focus-visible:ring-primary-300{% elif variant == 'outline' %}bg-white text-greyscale-700 border border-greyscale-300 hover:bg-greyscale-100 outline-none focus-visible:ring-4 focus-visible:ring-greyscale-300{% elif variant == 'dark' %}text-white bg-greyscale-900 hover:bg-greyscale-800 outline-none focus-visible:ring-4 focus-visible:ring-greyscale-400{% elif variant == 'ghost' %}text-greyscale-700 hover:bg-greyscale-100 focus-visible:ring-4 focus-visible:ring-greyscale-200{% elif variant == 'danger' %}text-white bg-red-500 hover:bg-red-600 outline-none focus-visible:ring-4 focus-visible:ring-red-300{% else %}text-white bg-primary-600 hover:bg-primary-700 outline-none focus-visible:ring-4 focus-visible:ring-primary-300{% endif %}{% if full_width %} w-full{% endif %} {{ class }}"
+     class="btn btn-{% if size %}{{ size }}{% else %}md{% endif %} btn-{{ variant }}{% if full_width %} w-full{% endif %} {{ class }}"
      {{ attrs }}>{{ slot }}</a>
 {% else %}
   <button type="{{ type }}"
           {% if id %}id="{{ id }}"{% endif %}
           {% if disabled %}disabled{% endif %}
           {% if aria_label %}aria-label="{{ aria_label }}"{% endif %}
-          class="{% if size == 'sm' %}py-1.5 px-2.5 text-xs{% elif size == 'xl' %}py-3 px-4.5 text-md{% elif size == 'icon' %}p-2.5{% elif size == 'icon-xl' %}p-3{% else %}py-2.5 px-3.5 text-sm{% endif %} rounded-lg w-fit font-normal flex gap-1 items-center transition-colors duration-200 disabled:cursor-not-allowed {% if variant == 'primary' %}text-white bg-primary-600 hover:bg-primary-700 outline-none focus-visible:ring-4 focus-visible:ring-primary-300 disabled:bg-primary-100 disabled:text-primary-400{% elif variant == 'outline' %}bg-white text-greyscale-700 border border-greyscale-300 hover:bg-greyscale-100 outline-none focus-visible:ring-4 focus-visible:ring-greyscale-300 disabled:border-greyscale-200 disabled:text-greyscale-400{% elif variant == 'dark' %}text-white bg-greyscale-900 hover:bg-greyscale-800 outline-none focus-visible:ring-4 focus-visible:ring-greyscale-400 disabled:bg-greyscale-400 disabled:text-greyscale-200{% elif variant == 'ghost' %}text-greyscale-700 hover:bg-greyscale-100 focus-visible:ring-4 focus-visible:ring-greyscale-200 disabled:text-greyscale-400{% elif variant == 'danger' %}text-white bg-red-500 hover:bg-red-600 outline-none focus-visible:ring-4 focus-visible:ring-red-300 disabled:bg-red-200 disabled:text-red-400{% else %}text-white bg-primary-600 hover:bg-primary-700 outline-none focus-visible:ring-4 focus-visible:ring-primary-300 disabled:bg-primary-100 disabled:text-primary-400{% endif %}{% if full_width %} w-full{% endif %} {{ class }}"
+          class="btn btn-{% if size %}{{ size }}{% else %}md{% endif %} btn-{{ variant }}{% if full_width %} w-full{% endif %} {{ class }}"
           {{ attrs }}>{{ slot }}
   </button>
 {% endif %}

--- a/templates/pages/style_guide.html
+++ b/templates/pages/style_guide.html
@@ -416,8 +416,16 @@
               <c-atoms.button variant="primary">Default</c-atoms.button>
               <c-atoms.button variant="primary" size="xl">Extra Large</c-atoms.button>
             </div>
-            <div class="mb-6">
-              <c-atoms.button variant="primary" disabled>Disabled</c-atoms.button>
+            <div class="flex flex-wrap gap-3 mb-6">
+              <c-atoms.button variant="primary" disabled>Primary</c-atoms.button>
+              <c-atoms.button variant="outline" disabled>Outline</c-atoms.button>
+              <c-atoms.button variant="dark" disabled>Dark</c-atoms.button>
+              <c-atoms.button variant="ghost" disabled>Ghost</c-atoms.button>
+              <c-atoms.button variant="danger" disabled>Danger</c-atoms.button>
+            </div>
+            <div class="flex flex-wrap gap-3 mb-6">
+              <c-atoms.button variant="primary" href="#">Link Button</c-atoms.button>
+              <c-atoms.button variant="primary" href="#" disabled>Disabled Link</c-atoms.button>
             </div>
             <h4 class="mt-8">Props</h4>
             <div class="bg-greyscale-100 rounded-xl p-4 my-3">
@@ -427,11 +435,15 @@
               </div>
               <div class="flex flex-col md:flex-row border-b border-greyscale-200">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>size</code></span>
-                <span class="p-2.5">"sm" | "" | "xl"</span>
+                <span class="p-2.5">"sm" | "" | "xl" | "icon" | "icon-xl"</span>
+              </div>
+              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>href</code></span>
+                <span class="p-2.5">URL string — renders as &lt;a&gt; instead of &lt;button&gt;</span>
               </div>
               <div class="flex flex-col md:flex-row">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>disabled</code></span>
-                <span class="p-2.5">Boolean</span>
+                <span class="p-2.5">Boolean — uses <code>aria-disabled</code> for links</span>
               </div>
             </div>
             <details class="mt-4">


### PR DESCRIPTION
Move button variant, size, and disabled styles from inline Tailwind conditionals in the template into .btn-* component classes in main.css using @apply. This simplifies the button atom from ~800-char class attributes to composable class names (btn btn-{size} btn-{variant}). Disabled <a> tags use aria-disabled + [aria-disabled] CSS selectors to match the native :disabled behavior on <button>. Style guide updated with all disabled variants, link button examples, and href/icon-xl prop docs.