### PR TITLE
fix(docker): allow dev profile to start without DOMAIN env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - '80:80'
       - '443:443'
     environment:
-      - DOMAIN=${DOMAIN:?Set DOMAIN in .env or environment}
+      - DOMAIN=${DOMAIN:-}
     volumes:
       - ./deploy/caddy/Caddyfile.prod:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -48,7 +48,7 @@ run_compilemessages() {
 
 case "$1" in
     web-dev)
-        echo "Starting development server..."
+        echo "Starting development server at http://localhost ..."
         # Start Tailwind watch in background
         tailwindcss -i src/css/main.css -o static/css/main.built.css --watch &
 


### PR DESCRIPTION
Docker Compose interpolates all variables regardless of active profile, so the ${DOMAIN:?} required-variable syntax on caddy-prod caused make docker-dev to fail. Use empty default instead. Also update entrypoint startup message to show http://localhost since Caddy proxies on port 80.