### PR TITLE
refactor(chat): UX copy, hierarchy, and onboarding improvements

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -547,7 +547,7 @@
   }
 
   .topic-prompt-btn {
-    @apply w-full flex items-center gap-3 text-left;
+    @apply w-full flex items-center justify-between gap-3 text-left;
     @apply px-4 py-3 rounded-lg;
     @apply bg-white border border-greyscale-200 text-greyscale-700;
     @apply hover:border-primary-300 hover:bg-primary-25;
@@ -572,13 +572,19 @@
   }
 
   .topic-context-toggle {
-    @apply inline-flex items-center gap-1.5 py-0.5 rounded;
-    @apply text-xs font-medium text-greyscale-400 cursor-pointer;
-    @apply hover:text-greyscale-600 transition-colors;
+    @apply inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md;
+    @apply bg-greyscale-100 border border-greyscale-200;
+    @apply text-xs font-medium text-greyscale-600 cursor-pointer;
+    @apply hover:bg-greyscale-200 transition-colors;
   }
 
   .topic-context-body {
-    @apply pt-2 pb-1 space-y-3 text-left;
+    @apply pt-3 pb-1 space-y-3 text-left;
+    @apply max-h-44 overflow-y-auto;
+  }
+
+  .topic-context-body h3 {
+    @apply text-xs font-semibold uppercase tracking-wider text-greyscale-500;
   }
   /* ==========================================================================
      FALLBACK RESOURCES SECTION
@@ -678,10 +684,14 @@
   .chat-input {
     @apply w-full text-md font-normal py-3 px-4 rounded-lg;
     @apply border border-greyscale-300 bg-white text-greyscale-900;
-    @apply placeholder:text-greyscale-400;
+    @apply placeholder:text-greyscale-500;
     @apply transition-colors duration-200;
     @apply focus:outline-none focus:ring-2 focus:ring-primary-600 focus:border-primary-600;
     min-height: 48px; /* 44px touch target + padding */
+  }
+
+  .chat-disclaimer {
+    @apply max-w-2xl mx-auto px-2 text-xs text-greyscale-400 text-center;
   }
 
   /* Mobile Footer */

--- a/templates/cotton/organisms/activity_panel.html
+++ b/templates/cotton/organisms/activity_panel.html
@@ -2,8 +2,8 @@
 
 {# Activity panel - right-side timeline of session events (uploads, summaries, fact updates) #}
 <aside class="activity-panel bg-white border-l border-greyscale-200 {{ class }}" {{ attrs }}>
-  <div class="p-4 border-b border-greyscale-200">
-    <h2 class="text-lg font-semibold text-greyscale-800">{% trans "Activity" %}</h2>
+  <div class="px-4 pt-4 pb-3 border-b border-greyscale-200">
+    <h2 class="text-xs font-semibold uppercase tracking-wider text-greyscale-400">{% trans "Activity" %}</h2>
   </div>
   <div class="flex-1 overflow-y-auto p-4 space-y-2">{{ slot }}</div>
 </aside>

--- a/templates/cotton/organisms/case_sidebar.html
+++ b/templates/cotton/organisms/case_sidebar.html
@@ -6,8 +6,8 @@
 <aside class="case-sidebar bg-white border-l border-greyscale-200 {{ class }}"
        {{ attrs }}>
   {# Header #}
-  <div class="p-4 border-b border-greyscale-200">
-    <h2 class="text-lg font-semibold text-greyscale-800">{% trans "Your Case" %}</h2>
+  <div class="px-4 pt-4 pb-3 border-b border-greyscale-200">
+    <h2 class="text-xs font-semibold uppercase tracking-wider text-greyscale-400">{% trans "Your Case" %}</h2>
     {% if case_type or county %}
       <p class="mt-1 text-sm text-greyscale-500">
         {% if case_type %}{{ case_type }}{% endif %}

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -11,7 +11,7 @@
 {% endblock title %}
 
 {% trans "Upload PDF document" as upload_pdf_label %}
-{% trans "What do you need help with?" as input_placeholder %}
+{% trans "Describe your situation — what happened?" as input_placeholder %}
 {% trans "Ask a question" as input_aria_label %}
 
 {% block content %}
@@ -54,10 +54,12 @@
       <c-organisms.case-sidebar class="h-full">
         {# Empty state #}
         <div x-show="noCaseInfo" class="text-center py-8 px-4">
-          <c-atoms.icon name="folder-open" class="w-12 h-12 text-greyscale-300 mx-auto mb-3" />
-          <p class="text-sm font-medium text-greyscale-600 mb-2">{% trans "No active case" %}</p>
-          <p class="text-xs text-greyscale-500">
-            {% trans "Describe your situation or upload a document and your case details will appear here." %}
+          <div class="w-10 h-10 rounded-lg bg-primary-50 flex items-center justify-center mx-auto mb-3">
+            <c-atoms.icon name="folder-open" class="w-5 h-5 text-primary-300" />
+          </div>
+          <p class="text-sm font-medium text-greyscale-600 mb-2">{% trans "Your case details" %}</p>
+          <p class="text-xs text-greyscale-400">
+            {% trans "Answer a few questions below and I'll fill this in as we go." %}
           </p>
         </div>
         {# Case info display #}
@@ -185,22 +187,6 @@
               <div class="flex-1 min-w-0">
                 <h1 class="topic-entry-title">{{ topic.title }}</h1>
                 <p class="topic-entry-subtitle">{{ topic.subtitle }}</p>
-                {% if topic.context_sections %}
-                  <details class="group topic-context-card">
-                    <summary class="topic-context-toggle">
-                      <c-atoms.icon name="chevron-right" class="w-3.5 h-3.5 text-greyscale-400 transition-transform duration-200 group-open:rotate-90" />
-                      <span>{% trans "What you should know" %}</span>
-                    </summary>
-                    <div class="topic-context-body">
-                      {% for section in topic.context_sections %}
-                        <div>
-                          <h3 class="text-sm font-semibold text-greyscale-800">{{ section.heading }}</h3>
-                          <p class="text-sm text-greyscale-600 mt-1">{{ section.body }}</p>
-                        </div>
-                      {% endfor %}
-                    </div>
-                  </details>
-                {% endif %}
               </div>
             </div>
             <c-atoms.button type="button"
@@ -237,20 +223,44 @@
       {# Chat content — scrollable, messages + input flow together #}
       <div class="chat-content" x-ref="messagesArea">
         <div class="max-w-2xl mx-auto px-4 py-4 space-y-4">
-          {# Guided prompts — topic only, before first message #}
-          {% if topic.prompts %}
-            <div x-show="noMessages" class="topic-prompts">
-              {% for prompt in topic.prompts %}
-                <button type="button"
-                        class="topic-prompt-btn"
-                        data-prompt="{{ prompt }}"
-                        x-on:click="sendPrompt">
-                  <c-atoms.icon name="chat-bubble-left-right" class="w-5 h-5 text-greyscale-400 flex-shrink-0" />
-                  <span>{{ prompt }}</span>
-                </button>
-              {% endfor %}
-            </div>
-          {% endif %}
+          {# Warm handoff + prompts + context — only before first message #}
+          <div x-show="noMessages" x-cloak>
+            <p class="text-sm text-greyscale-500 mb-4">
+              {% trans "I'm here to help. Describe your situation below and I'll help you understand your rights and next steps." %}
+            </p>
+            {# Guided prompts — topic only #}
+            {% if topic.prompts %}
+              <div class="topic-prompts">
+                {% for prompt in topic.prompts %}
+                  <button type="button"
+                          class="topic-prompt-btn"
+                          data-prompt="{{ prompt }}"
+                          x-on:click="sendPrompt">
+                    <c-atoms.icon name="chat-bubble-left-right" class="w-4 h-4 text-greyscale-400 flex-shrink-0" />
+                    <span class="flex-1">{{ prompt }}</span>
+                    <c-atoms.icon name="chevron-right" class="w-4 h-4 text-greyscale-300 flex-shrink-0" />
+                  </button>
+                {% endfor %}
+              </div>
+            {% endif %}
+            {# Topic context disclosure — below prompts, renamed, capped height #}
+            {% if topic.context_sections %}
+              <details class="group topic-context-card mt-4">
+                <summary class="topic-context-toggle">
+                  <c-atoms.icon name="chevron-right" class="w-3 h-3 text-greyscale-400 transition-transform duration-200 group-open:rotate-90" />
+                  <span>{% trans "Learn the basics" %}</span>
+                </summary>
+                <div class="topic-context-body">
+                  {% for section in topic.context_sections %}
+                    <div>
+                      <h3>{{ section.heading }}</h3>
+                      <p class="text-sm text-greyscale-600 mt-1">{{ section.body }}</p>
+                    </div>
+                  {% endfor %}
+                </div>
+              </details>
+            {% endif %}
+          </div>
           {# Messages #}
           <template x-for="msg in messages" :key="msg.id">
             <div class="chat-message"
@@ -302,7 +312,10 @@
               </div>
             </div>
           </div>
-          {# Chat input — flows at end of conversation #}
+          {# Disclaimer + chat input — flows at end of conversation #}
+          <p class="chat-disclaimer">
+            {% trans "General legal information only — not legal advice. For urgent matters, contact a local legal aid organization." %}
+          </p>
           <form x-on:submit.prevent="askQuestion"
                 class="chat-input-form"
                 role="search">
@@ -349,10 +362,10 @@
       <c-organisms.activity-panel class="h-full">
         {# Empty state #}
         <div x-show="noTimeline" class="text-center py-8 px-4">
-          <c-atoms.icon name="clock" class="w-12 h-12 text-greyscale-300 mx-auto mb-3" />
-          <p class="text-sm font-medium text-greyscale-600 mb-2">{% trans "No activity yet" %}</p>
-          <p class="text-xs text-greyscale-500">
-            {% trans "Uploads, summaries, and case updates will appear here." %}
+          <c-atoms.icon name="clock" class="w-6 h-6 text-greyscale-300 mx-auto mb-3" />
+          <p class="text-sm font-medium text-greyscale-500 mb-2">{% trans "Your documents & deadlines" %}</p>
+          <p class="text-xs text-greyscale-400">
+            {% trans "I'll save important information here as we talk." %}
           </p>
         </div>
         {# Timeline events #}


### PR DESCRIPTION
Addresses findings from UX/design audit of the home→chat transition. Improves
empty states, onboarding flow, and visual hierarchy for the 3-column chat layout.

- Remove negation from empty states (positive framing)
- Warm handoff sentence above prompts sets expectation before conversation
- Topic context disclosure: chip toggle below prompts (max-h-44 with scroll)
- Sidebar + activity headings demoted to uppercase label style
- Prompt cards: trailing chevron + justify-between for clear CTA affordance
- Placeholder color greyscale-400 → greyscale-500 for WCAG AA compliance
- Legal disclaimer bar above input form

Part of #182

Test plan:
- Verify empty states use positive framing in sidebar and activity panel
- Check topic context disclosure appears as chip toggle, scrolls, hides after first message
- Confirm legal disclaimer renders above input form
- Verify placeholder color contrast meets WCAG AA