### PR TITLE
fix(chat): restore upload progress overlay

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -426,6 +426,7 @@ function createHomePage() {
     // --- Upload state ---
     selectedFile: null,
     isUploading: false,
+    uploadStatus: '', // 'uploading' | 'analyzing' | ''
     uploadError: null,
     extractedText: null,
     extractedData: null,
@@ -558,6 +559,12 @@ function createHomePage() {
     },
     get notUploading() {
       return !this.isUploading
+    },
+
+    // Upload overlay text (CSP build can't evaluate ternaries in templates)
+    get uploadStatusText() {
+      if (this.uploadStatus === 'analyzing') return 'Analyzing document…'
+      return 'Uploading document…'
     },
 
     // --- Initialization ---
@@ -759,6 +766,7 @@ function createHomePage() {
       if (!this.selectedFile || this.isUploading) return
 
       this.isUploading = true
+      this.uploadStatus = 'uploading'
       this.uploadError = null
       const fileName = this.selectedFile.name
 
@@ -767,11 +775,17 @@ function createHomePage() {
         formData.append('file', this.selectedFile)
         formData.append('csrfmiddlewaretoken', chatUtils.getCsrfToken())
 
+        // Upload completes quickly; analysis takes longer
+        const analyzeTimer = setTimeout(() => {
+          this.uploadStatus = 'analyzing'
+        }, 1000)
+
         const response = await fetch('/api/chat/upload/', {
           method: 'POST',
           body: formData,
         })
 
+        clearTimeout(analyzeTimer)
         const data = await response.json()
         if (!response.ok)
           throw new Error(data.error || gettext('Upload failed'))
@@ -839,6 +853,7 @@ function createHomePage() {
         )
       } finally {
         this.isUploading = false
+        this.uploadStatus = ''
       }
     },
 

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -49,6 +49,16 @@
         </div>
       </div>
     </div>
+    {# Upload progress overlay #}
+    <div x-show="isUploading"
+         x-cloak
+         class="fixed inset-0 z-50 flex items-center justify-center bg-greyscale-900/70">
+      <div class="bg-white rounded-lg p-6 shadow-xl max-w-sm mx-4 text-center">
+        <c-atoms.icon name="arrow-path" class="w-10 h-10 text-primary-600 mx-auto mb-3 animate-spin" />
+        <p class="text-lg font-medium text-greyscale-900" x-text="uploadStatusText"></p>
+        <p class="text-sm text-greyscale-500 mt-1">{% trans "This may take a moment" %}</p>
+      </div>
+    </div>
     {# Left column — sidebar, ~20% #}
     <div class="hidden lg:flex w-1/5 flex-shrink-0 flex-col border-r border-greyscale-200 overflow-y-auto">
       <c-organisms.case-sidebar class="h-full">


### PR DESCRIPTION
## Summary

- Re-add the full-screen upload progress overlay dropped during the vanilla JS refactor (`fb421be`)
- Two-phase status: "Uploading document…" immediately, "Analyzing document…" after 1s
- Dark backdrop prevents interaction until complete
- CSP-safe: uses pre-computed `uploadStatusText` getter instead of inline ternary

## Test plan

- [x] Upload a PDF — overlay appears with "Uploading document…"
- [x] After ~1s, text switches to "Analyzing document…"
- [x] Overlay dismisses when server responds
- [x] Upload button spinner still works alongside overlay
- [x] Error case: overlay dismisses on upload failure

Closes #132