### PR TITLE
docs: briefcase architecture and demo strategy

### DIFF
--- a/docs/briefcase-architecture.md
+++ b/docs/briefcase-architecture.md
@@ -1,0 +1,142 @@
+# Briefcase Architecture: Three-Pocket Model
+
+## Overview
+
+The briefcase is the unified session state model for everything the portal knows about a user's situation. It has three "pockets" — raw data, working state, and analog/portable — so that data is never lost, the user experience is restorable, and warm handoffs to legal aid or analog processes work without our system.
+
+---
+
+## The Three Pockets
+
+### Pocket 1: Raw Record (append-only event log)
+
+**Purpose:** Immutable source of truth. Every input captured with full fidelity. If we change the RAG pipeline, legal flow, or AI models, we replay this log through the new system and lose nothing.
+
+**Design principle: Pocket 1 is the test fixture for the pipeline.** If the RAG/agent processing is tight, re-feeding the same raw data from Pocket 1 through the pipeline should produce very nearly the same Pocket 2 and Pocket 3 outputs. This is functional testing for the legal flow — "Jane's raw inputs, processed through pipeline v2, should produce the same case facts, spotted issues, and action items as pipeline v1." This means:
+
+- **Pocket 1 stores inputs, not outputs.** User messages, document content, user actions, and system context — not AI responses or tool call results. AI outputs are derived data that belong in Pocket 2.
+- **Pipeline changes are testable.** Diff Pocket 2 outputs from old pipeline vs. new pipeline, using the same Pocket 1 inputs. Regressions are visible.
+- **No circular data.** If AI outputs are in Pocket 1, replaying through a new pipeline mixes old AI reasoning with new — the test is meaningless.
+
+**Storage:** Append-only event log. Each entry is timestamped and typed. Never modified or deleted (except by data retention policy or user deletion request).
+
+**Event types (inputs only):**
+
+- `user_message` — what the user typed, verbatim
+- `document_upload` — file metadata + raw extracted text (the source content, not AI analysis)
+- `user_action` — confirmed extraction, dismissed suggestion, marked item complete, corrected a fact
+- `system_context` — topic entry, jurisdiction detection, session start/end, auth state change
+
+**What it captures that Pocket 2 doesn't:**
+
+- Superseded user inputs (user corrected a date — Pocket 2 has the correction, Pocket 1 has both the original and correction as separate events)
+- Full conversation inputs (Pocket 2 may summarize for context window)
+- Raw document text before AI extraction (the PDF content, not structured output)
+- User decisions that shaped the flow (which prompt they clicked, what they confirmed/rejected)
+
+---
+
+### Pocket 2: Working State (mutable, restorable)
+
+**Purpose:** Current state of the user's experience. What they see on screen, what the AI knows about them, what gets restored on login or briefcase import. This is the "save file."
+
+**Contents:**
+
+- **Case data** — case type, parties, court info, key dates
+- **Spotted issues** — defenses, rights, legal theories the AI has identified
+- **Action items** — next steps, deadlines, checklists with completion state
+- **Eligibility** — programs the user qualifies for, application status
+- **AI context** — conversation summary, memory/insights the AI needs to resume intelligently
+- **Session metadata** — active topic, last interaction, conversation stage in legal flow
+- **Timeline** — derived from Pocket 1 events, filtered/formatted for display
+
+**Mutability:** Freely updated as the user progresses. Old states are recoverable from Pocket 1 replay.
+
+**Persistence:**
+
+- Authenticated users: saved to DB, restored on login
+- Anonymous users: held in session, exportable as encrypted briefcase file
+- Briefcase import: restores Pocket 2 state so the user picks up where they left off
+
+---
+
+### Pocket 3: Analog Package (hybrid: structured data + on-demand export)
+
+**Purpose:** Everything a human needs to continue without our system. For warm handoff to legal aid, lawyer intake, or the user going to court with printed materials.
+
+**Always maintained (structured data):**
+
+- Forms in any state of completion (blank, partial, ready to file)
+- Key deadlines and court dates
+- Action items with current status
+- Resource links and referral information
+- Case summary in plain language
+
+**Assembled on demand (export):**
+
+- Full PDF/ZIP package combining the structured data above with:
+  - Conversation highlights (key Q&A, not raw log)
+  - Document summaries
+  - Court logistics (address, parking, what to bring)
+  - Legal issue summary with identified defenses/rights
+- Formatted for: print, email, legal aid intake form, lawyer handoff
+
+**Dual-audience clarity:** Plain language throughout, but never at the cost of legal precision. If Pockets 1 and 2 captured statutes, legal terms, form numbers, case citations, or procedural requirements, Pocket 3 preserves that detail — a lawyer or legal aid org reading the export should see the same specificity they'd expect from an intake file. Plain language supports and contextualizes the legal detail, it doesn't replace it. Example: "You need to file an Appearance (form IL-AP-001) — this tells the court you plan to contest the eviction, per 735 ILCS 5/2-201."
+
+**Overlap with Pocket 2:** Pocket 3's structured data _is_ a subset of Pocket 2, maintained alongside it. The export assembler reads from Pocket 2 (current state) and selectively from Pocket 1 (conversation highlights, document content) to produce the package.
+
+---
+
+## Overlap Between Pockets
+
+```
+Pocket 1 (Raw Inputs)        Pipeline            Pocket 2 (Working)        Pocket 3 (Analog)
+──────────────────────   ───────────────→   ──────────────────        ─────────────────
+User messages                                AI summary/memory    ───→  Key Q&A highlights
+Document text (raw)                          Current case facts   ───→  Case summary
+User actions/decisions                       Spotted issues       ───→  Legal issue brief
+System context                               Action items         ───→  Checklist + deadlines
+                                             Timeline display     ───→  Court prep package
+                                             Eligibility status   ───→  Program applications
+                                             Form state           ───→  Forms (printable)
+```
+
+**Data flow:**
+
+- Pocket 1 → Pipeline → Pocket 2 (inputs processed by AI/RAG into working state)
+- Pocket 2 → Pocket 3 (working state filtered/formatted for analog use)
+- Pocket 1 → _new_ Pipeline → Pocket 2' (replay test: same inputs, compare outputs)
+
+**The replay guarantee:** `Pipeline(Pocket1) ≈ Pocket2`. If we change the pipeline and the outputs diverge beyond acceptable thresholds, that's a regression. Pocket 1 is the golden dataset.
+
+---
+
+## Anonymous Export
+
+Full export includes all 3 pockets — the user gets complete fidelity. On re-import:
+
+- Pocket 1 events are replayed/restored (immutable log intact)
+- Pocket 2 state is restored directly (no reprocessing needed for immediate use)
+- Pocket 3 structured data is restored alongside Pocket 2
+
+Export format: encrypted JSON (or ZIP with JSON + any document files). The encryption key is user-provided or derived from a passphrase — we never store it.
+
+---
+
+## Open Questions (Not Covered Here)
+
+- Django model definitions (depends on #197 schema research)
+- Migration path from current CaseInfo/TimelineEvent
+- Export file format specifics (encryption, compression, versioning)
+- Multi-issue briefcases (eviction + child support in one briefcase)
+- Data retention and deletion policies
+
+---
+
+## References
+
+- [#177](https://github.com/freelawproject/litigant-portal/issues/177) — Briefcase issue
+- [#197](https://github.com/freelawproject/litigant-portal/issues/197) — Schema research/POC
+- [Happy Path](happy-path-jane.md) — Jane's end-to-end story
+- [Legal Flow](overview-mapped-legal-flow.md) — 9-stage flow
+- [Demo Strategy](demo-strategy.md) — how to demo the full flow before AI tools land

--- a/docs/demo-strategy.md
+++ b/docs/demo-strategy.md
@@ -1,0 +1,52 @@
+# Demo Strategy: Full Flow Without AI Tools
+
+## Problem
+
+The beta demo needs to show the complete arc — Jane arrives → describes her situation → facts surface → action plan assembles → she can act on it. But the AI tools (RAG, case law search, web search, MCP tooling) and court corpus won't be ready in time.
+
+## Approaches
+
+### 1. Enhanced System Prompt as "Fake RAG"
+
+Bake DuPage County eviction knowledge directly into the system prompt — statutes, notice periods, ILRPP eligibility thresholds, court address/hours, filing requirements. The LLM already knows most of this from training data; the prompt makes it reliable and specific.
+
+When real RAG lands, the prompt shrinks and the knowledge comes from API calls instead. The conversation quality is nearly identical for the demo.
+
+**Covers:** Issue spotting, fact discovery, eligibility surfacing, filing requirements.
+
+### 2. Fixture-Driven Action Plan
+
+The sidebar/action plan (#193) renders from structured data. After the AI finishes issue spotting (via `UpdateCaseFacts`), a new `UpdateActionPlan` tool call populates the action plan with fixture-quality data — deadlines, checklist items, resources. The "knowledge" comes from the prompt rather than RAG.
+
+**Covers:** Stages 5–8 of the legal flow (guided next steps → resolution).
+
+### 3. Seeded Briefcase for Demo Fast-Forward
+
+A management command (`manage.py seed_jane_demo`) that pre-populates a briefcase at any stage of Jane's journey. Demo presenter can start fresh or jump to "Jane has uploaded her notice, facts are captured, action plan is assembled" and show the resolution phase directly.
+
+**Covers:** Court partner demos where you don't want to wait for a live AI conversation.
+
+## Recommended Sprint Plan
+
+1. **#87 prompt work** — DuPage eviction knowledge in the system prompt (highest leverage, makes the whole flow feel real)
+2. **New tool: `UpdateActionPlan`** — schema for action items, deadlines, resources, checklists. Same pattern as `UpdateCaseFacts`, same SSE pipeline, writes to a different part of the briefcase
+3. **Fixture/seed command** — pre-populated case at each stage of Jane's journey
+
+## Key Insight
+
+The prompt _is_ the temporary RAG. When real tools land (#68, #69, #70), the prompt knowledge gets replaced by API calls, but the tool schemas, display components, and briefcase models stay the same. Nothing gets thrown away.
+
+## Related Issues
+
+- #87 — Enhanced system prompt for eviction scenarios
+- #177 — Briefcase: unified session state model
+- #179 — Court-configurable topic context
+- #193 — Action plan sidebar
+- #197 — Research/POC: court-configurable schemas
+- #68–#70 — nadahlberg's AI tool issues (web search, case law search, memory)
+
+## References
+
+- [Legal Flow](overview-mapped-legal-flow.md) — 9-stage flow
+- [Happy Path](happy-path-jane.md) — what the AI surfaces for Jane
+- [Demo Flow](demo-flow-jane.md) — 8-step abbreviated demo


### PR DESCRIPTION
Two design documents for the beta demo sprint:

- **`briefcase-architecture.md`** — Three-pocket model for unified session state: raw record (append-only inputs, pipeline-testable), working state (mutable, restorable), analog package (plain language + full legal precision for warm handoffs). `Pipeline(Pocket1) ≈ Pocket2` is the testability invariant.
- **`demo-strategy.md`** — How to demo the full eviction flow before RAG/agentic tools land: enhanced prompts as temporary RAG, fixture-driven action plan, seeded briefcase for fast-forward.

Part of #177

Test plan: Team review of design docs — no code changes.