### PR TITLE
build: run make test inside Docker dev container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,9 @@ css-prod: ## Build production CSS (minified)
 migrate: ## Run Django migrations
 	source .venv/bin/activate && python manage.py migrate
 
-test: ## Run tests (builds CSS + collectstatic first, uses tox)
-	tailwindcss -i src/css/main.css -o static/css/main.built.css --minify
-	SECRET_KEY=test .venv/bin/python manage.py collectstatic --noinput --clear
-	tox
+test: ## Run tests in Docker dev container (builds CSS + collectstatic first)
+	@docker compose --profile dev exec django-dev /docker-entrypoint.sh test portal chat || \
+	  (echo "\n  Docker dev container is not running. Start it with: make docker-dev\n" && exit 1)
 
 collectstatic: ## Collect static files (builds CSS first)
 	tailwindcss -i src/css/main.css -o static/css/main.built.css --minify
@@ -85,8 +84,7 @@ docker-shell: ## Open shell in Django dev container
 docker-migrate: ## Run migrations in Docker
 	docker compose --profile dev exec django-dev python manage.py migrate
 
-docker-test: ## Run tests in Docker
-	docker compose --profile dev exec django-dev python manage.py test
+docker-test: test ## Alias for 'make test' (runs in Docker)
 
 docker-clean: ## Remove containers, volumes, and images
 	docker compose --profile dev --profile prod down -v --rmi local


### PR DESCRIPTION
`make test` now execs into the running Docker dev container instead of requiring a local venv, tox, and Postgres. The entrypoint's existing `test` command handles CSS build, collectstatic, and `manage.py test`. Shows a helpful error if the container isn't running.

`docker-test` becomes an alias for `test` — one obvious way to run tests.

This unblocks contributors who don't have a local Postgres after the SQLite → PostgreSQL migration (#206). Clone, `make docker-dev`, `make test` — that's it.

Test plan:
- `make docker-dev` in one terminal, `make test` in another
- Tests run inside the container with Postgres available
- Without the container running, `make test` prints guidance