### PR TITLE
Pin Docker volume names to Postgres major version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,4 +517,4 @@ docker compose --profile prod up --build -d    # Rebuild and restart
 
 ### Database
 
-PostgreSQL (pgvector) on a Docker volume (`postgres_data`). Separate services per profile (`postgres-dev`, `postgres-prod`); prod uses Docker secrets for the password via `POSTGRES_PASSWORD_FILE`.
+PostgreSQL (pgvector) on Docker volumes named with the PG major version (e.g., `postgres_data_dev_pg17`). When upgrading Postgres (e.g., pg17 → pg18), update both the image tag and volume name in `docker-compose.yml` so Docker creates a fresh volume instead of failing on incompatible data files. Separate services per profile (`postgres-dev`, `postgres-prod`); prod uses Docker secrets for the password via `POSTGRES_PASSWORD_FILE`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,10 @@ services:
       timeout: 3s
       retries: 5
     volumes:
-      - postgres_data_dev:/var/lib/postgresql/data
+      # Volume name includes PG major version — when upgrading (e.g., pg17 → pg18),
+      # update both the image tag and volume name so Docker creates a fresh volume
+      # instead of failing on incompatible data files.
+      - postgres_data_dev_pg17:/var/lib/postgresql/data
 
   # ---------------------------------------------------------------------------
   # PostgreSQL Database — Production (pgvector)
@@ -46,7 +49,8 @@ services:
     secrets:
       - db_password
     volumes:
-      - postgres_data_prod:/var/lib/postgresql/data
+      # See postgres-dev comment — keep volume name in sync with image tag.
+      - postgres_data_prod_pg17:/var/lib/postgresql/data
 
   # ---------------------------------------------------------------------------
   # Development Django Server
@@ -153,8 +157,8 @@ secrets:
     file: ./secrets/openai_api_key.txt
 
 volumes:
-  postgres_data_dev:
-  postgres_data_prod:
+  postgres_data_dev_pg17:
+  postgres_data_prod_pg17:
   staticfiles:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
Renames `postgres_data_dev` → `postgres_data_dev_pg17` (and prod equivalent) so a PG major version bump gets a fresh volume instead of crashing with "database files are incompatible with server."

Closes #217

Test plan: `docker compose --profile dev down -v && make docker-dev` — postgres starts clean