### PR TITLE
fix(tests): add missing postgres marker to action_plan tests

### DIFF
--- a/chat/tests/test_action_plan.py
+++ b/chat/tests/test_action_plan.py
@@ -1,5 +1,6 @@
 """Tests for action_plan view context building."""
 
+import pytest
 from django.test import Client, TestCase
 
 from chat.models import CaseInfo
@@ -16,6 +17,7 @@ SAMPLE_CASE_DATA = {
 }
 
 
+@pytest.mark.postgres
 class ActionPlanViewTests(TestCase):
     """Tests for action_plan view context with and without case data."""
 


### PR DESCRIPTION
`ActionPlanViewTests` uses `CaseInfo` (Postgres model) but had no `@pytest.mark.postgres` marker, so both tests errored with `OperationalError` in the fast suite (`make test`).

Closes #251

Test plan: `make test` passes (29 passed, 98 deselected, 0 errors)