### PR TITLE
fix(chat): read correct field in SSE error handler

### DIFF
--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -268,11 +268,11 @@ function createChat() {
 
                 case 'error':
                   console.error('Stream error:', event.error)
-                  if (event.message) {
+                  if (event.error) {
                     this.messages[msgIndex] = {
                       ...msg,
-                      content: event.message,
-                      renderedContent: chatUtils.escapeHtml(event.message),
+                      content: event.error,
+                      renderedContent: chatUtils.escapeHtml(event.error),
                     }
                   }
                   break


### PR DESCRIPTION
Backend sends `{type: 'error', error: '...'}` but the SSE handler checked `event.message` — stream errors were logged to console but never shown to the user.

Closes #245

Test plan: Verified field names align between `chat/agents/base.py` (sends `error`) and `static/js/chat.js` (now reads `error`).