### PR TITLE
chore: add QA round issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/qa-round.md
+++ b/.github/ISSUE_TEMPLATE/qa-round.md
@@ -1,0 +1,24 @@
+---
+name: QA Round
+about: QA testing round for dev requests and tester feedback
+title: 'QA: [Month Year] testing round'
+labels: question
+---
+
+QA testing round for the current sprint/milestone.
+
+**QA environment:** https://litigant-portal.nates.ai
+
+## How to use this issue
+
+- **Devs:** file specific QA requests as checklist items below when features land on QA
+- **Jessica:** leave notes, screenshots, and feedback as comments or edit checklist items directly
+- If a feedback item is an actual bug, break it into its own issue (link back here)
+
+## QA requests
+
+- [ ] _Add items here as features are deployed to QA_
+
+## Notes
+
+_Jessica: leave general notes, impressions, or questions here_


### PR DESCRIPTION
Reusable template for recurring QA testing rounds with QA URL, dev checklist, and tester feedback sections. Closes #255