### PR TITLE
chore: unify make test to auto-detect Docker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,14 +52,13 @@ make docker-down            # Stop containers
 ### Testing & Linting
 
 ```sh
-make test                   # Run non-postgres tests locally (no Docker needed)
-make docker-test            # Run full test suite in Docker (includes postgres tests)
-make docker-test fast       # Pass extra tox args through make
-make -- docker-test -e fast -- -k "ReadSecretTests"
+make test                   # Auto-detects Docker: full suite if running, fast suite otherwise
+make test fast              # Pass extra tox args through make
+make -- test -e fast -- -k "ReadSecretTests"
 make lint                   # Lint and format all code (via pre-commit)
 ```
 
-`make docker-test ...` forwards extra positional args to `tox`. Caveat: args that start with `-` are parsed by `make` itself, so use `make -- docker-test ...` when passing tox or pytest flags.
+`make test ...` forwards extra positional args to `tox` when running in Docker. Args that start with `-` are parsed by `make` itself, so use `make -- test ...` when passing tox or pytest flags.
 
 ### Direct Python commands (use .venv/bin/python)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help build css clean install migrate test collectstatic lint fmt-check fmt \
        messages compilemessages \
-       docker-build docker-dev docker-prod docker-down docker-logs docker-shell docker-migrate docker-test docker-clean
+       docker-build docker-dev docker-prod docker-down docker-logs docker-shell docker-migrate docker-clean
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -23,8 +23,14 @@ css-prod: ## Build production CSS (minified)
 migrate: ## Run Django migrations
 	source .venv/bin/activate && python manage.py migrate
 
-test: ## Run non-postgres tests locally (no Docker needed)
-	tox -e fast
+test: ## Run tests (full suite if Docker running, fast suite otherwise)
+	@if docker compose --profile dev exec -T django-dev true 2>/dev/null; then \
+	  echo "\n  \033[36mDocker detected\033[0m — running full test suite\n"; \
+	  docker compose --profile dev exec django-dev /docker-entrypoint.sh test $(filter-out $@,$(MAKECMDGOALS)); \
+	else \
+	  echo "\n  \033[33mNo Docker\033[0m — running fast suite only (skipping postgres tests)\n"; \
+	  tox -e fast; \
+	fi
 
 collectstatic: ## Collect static files (builds CSS first)
 	tailwindcss -i src/css/main.css -o static/css/main.built.css --minify
@@ -82,10 +88,6 @@ docker-shell: ## Open shell in Django dev container
 
 docker-migrate: ## Run migrations in Docker
 	docker compose --profile dev exec django-dev python manage.py migrate
-
-docker-test: ## Run full test suite in Docker (includes postgres tests)
-	@docker compose --profile dev exec django-dev /docker-entrypoint.sh test $(filter-out $@,$(MAKECMDGOALS)) || \
-	  (echo "\n  Docker dev container is not running. Start it with: make docker-dev\n" && exit 1)
 
 docker-clean: ## Remove containers, volumes, and images
 	docker compose --profile dev --profile prod down -v --rmi local

--- a/chat/tests/test_middleware.py
+++ b/chat/tests/test_middleware.py
@@ -1,11 +1,13 @@
 """Tests for AnonymousSessionKeyMiddleware."""
 
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 User = get_user_model()
 
 
+@pytest.mark.postgres
 class AnonymousSessionKeyMiddlewareTests(TestCase):
     """Tests for session key preservation on anonymous requests."""
 

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -475,6 +475,7 @@ class ChatPageTopicTests(TestCase):
 # =============================================================================
 
 
+@pytest.mark.postgres
 class ToastMessagesTests(TestCase):
     """Tests for toast_messages context processor tag-to-variant mapping."""
 


### PR DESCRIPTION
Single `make test` replaces `make test` + `make docker-test`. Auto-detects whether the Docker dev container is running — full suite if yes, fast suite (non-postgres) otherwise. Also fixes missing `@pytest.mark.postgres` markers on middleware and toast tests that were breaking the fast suite.

Closes #263

Test plan: `make test` with Docker running (full suite), `make test` without Docker (fast suite only)