### PR TITLE
chore: make test defaults to quiet output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build css clean install migrate test collectstatic lint fmt-check fmt \
+.PHONY: help build css clean install migrate test test-v collectstatic lint fmt-check fmt \
        messages compilemessages \
        docker-build docker-dev docker-prod docker-down docker-logs docker-shell docker-migrate docker-clean
 
@@ -23,12 +23,17 @@ css-prod: ## Build production CSS (minified)
 migrate: ## Run Django migrations
 	source .venv/bin/activate && python manage.py migrate
 
-test: ## Run tests (full suite if Docker running, fast suite otherwise)
+test: ## Run tests — dots + warnings + failures + summary
 	@if docker compose --profile dev exec -T django-dev true 2>/dev/null; then \
-	  echo "\n  \033[36mDocker detected\033[0m — running full test suite\n"; \
+	  docker compose --profile dev exec django-dev /docker-entrypoint.sh test -q -- -q --tb=short $(filter-out $@,$(MAKECMDGOALS)); \
+	else \
+	  tox -q -e fast -- -q --tb=short; \
+	fi
+
+test-v: ## Run tests — verbose output (full tox + pytest details)
+	@if docker compose --profile dev exec -T django-dev true 2>/dev/null; then \
 	  docker compose --profile dev exec django-dev /docker-entrypoint.sh test $(filter-out $@,$(MAKECMDGOALS)); \
 	else \
-	  echo "\n  \033[33mNo Docker\033[0m — running fast suite only (skipping postgres tests)\n"; \
 	  tox -e fast; \
 	fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ setenv =
     POSTGRES_HOST = {env:POSTGRES_HOST:postgres-dev}
     POSTGRES_PASSWORD = postgres
     CHAT_ENABLED = false
-commands = pytest --verbosity=1
+commands = pytest {posargs:--verbosity=1}
 
 [testenv:fast]
 # Non-DB tests only — no postgres required
@@ -25,4 +25,4 @@ setenv =
     SECRET_KEY = test-secret-key-for-ci
     POSTGRES_PASSWORD = postgres
     CHAT_ENABLED = false
-commands = pytest -m "not postgres" --verbosity=1
+commands = pytest -m "not postgres" {posargs:--verbosity=1}


### PR DESCRIPTION
`make test` now shows dots + warnings + failures + summary (no per-test lines). `make test-v` for full verbose output. Uses `{posargs}` in tox.ini so Makefile flags cleanly override the default verbosity. Works for both Docker and non-Docker paths.

Closes #274

Test plan: `make test` shows dots/summary, `make test-v` shows full output.