### PR TITLE
refactor: extract c-molecules.form-errors from 5 form templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,7 @@ Components live in `templates/cotton/` using Atomic Design hierarchy:
 ```
 templates/cotton/
 ├── atoms/      # Basic elements: alert, auto_dismiss, button, chat_bubble, checkbox, icon, input, link, nav_link, search_input, select, typing_indicator
-├── molecules/  # Combinations: action_item, deadline_card, form_field, form_field_select, logo, search_bar, search_result, sidebar_section, toast_container, topic_card, user_menu
+├── molecules/  # Combinations: action_item, deadline_card, form_errors, form_field, form_field_select, logo, search_bar, search_result, sidebar_section, toast_container, topic_card, user_menu
 └── organisms/  # Complex sections: footer, header, hero, topic_grid
 ```
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -9,12 +9,7 @@
 {% block auth_content %}
   <h1 class="text-2xl font-semibold text-greyscale-900 mb-2">{% trans "Sign in" %}</h1>
   <p class="text-greyscale-600 mb-6">{% trans "Access your legal assistance portal" %}</p>
-  {# Error messages #}
-  {% if form.non_field_errors %}
-    <c-atoms.alert variant="danger" class="mb-4">
-    {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-    </c-atoms.alert>
-  {% endif %}
+  <c-molecules.form-errors :form="form" />
   <form method="post" action="{% url 'account_login' %}" class="space-y-4">
     {% csrf_token %}
     {% trans "Email address" as email_label %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -9,12 +9,7 @@
 {% block auth_content %}
   <h1 class="text-2xl font-semibold text-greyscale-900 mb-2">{% trans "Reset your password" %}</h1>
   <p class="text-greyscale-600 mb-6">{% trans "Enter your email and we'll send you a link to reset your password." %}</p>
-  {# Error messages #}
-  {% if form.non_field_errors %}
-    <c-atoms.alert variant="danger" class="mb-4">
-    {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-    </c-atoms.alert>
-  {% endif %}
+  <c-molecules.form-errors :form="form" />
   <form method="post" action="{% url 'account_reset_password' %}" class="space-y-4">
     {% csrf_token %}
     {% trans "Email address" as email_label %}

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -23,12 +23,7 @@
   {% else %}
     <h1 class="text-2xl font-semibold text-greyscale-900 mb-2">{% trans "Set new password" %}</h1>
     <p class="text-greyscale-600 mb-6">{% trans "Enter your new password below." %}</p>
-    {# Error messages #}
-    {% if form.non_field_errors %}
-      <c-atoms.alert variant="danger" class="mb-4">
-      {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-      </c-atoms.alert>
-    {% endif %}
+    <c-molecules.form-errors :form="form" />
     <form method="post" action="{{ action_url }}" class="space-y-4">
       {% csrf_token %}
       {% trans "New password" as password_label %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -9,12 +9,7 @@
 {% block auth_content %}
   <h1 class="text-2xl font-semibold text-greyscale-900 mb-2">{% trans "Create account" %}</h1>
   <p class="text-greyscale-600 mb-6">{% trans "Get free legal assistance today" %}</p>
-  {# Error messages #}
-  {% if form.non_field_errors %}
-    <c-atoms.alert variant="danger" class="mb-4">
-    {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-    </c-atoms.alert>
-  {% endif %}
+  <c-molecules.form-errors :form="form" />
   <form method="post" action="{% url 'account_signup' %}" class="space-y-4">
     {% csrf_token %}
     {% trans "Email address" as email_label %}

--- a/templates/cotton/molecules/form_errors.html
+++ b/templates/cotton/molecules/form_errors.html
@@ -1,0 +1,6 @@
+<c-vars :form />
+{% if form.non_field_errors %}
+  <c-atoms.alert variant="danger" class="mb-4">
+  {% for error in form.non_field_errors %}{{ error }}{% endfor %}
+  </c-atoms.alert>
+{% endif %}

--- a/templates/pages/profile/edit.html
+++ b/templates/pages/profile/edit.html
@@ -12,12 +12,7 @@
     <p class="text-greyscale-600 mb-6">
       {% trans "All fields are optional. The more you share, the more personalized assistance we can provide." %}
     </p>
-    {# Form errors #}
-    {% if form.non_field_errors %}
-      <c-atoms.alert variant="danger" class="mb-4">
-      {% for error in form.non_field_errors %}{{ error }}{% endfor %}
-      </c-atoms.alert>
-    {% endif %}
+    <c-molecules.form-errors :form="form" />
     <form method="post" class="space-y-8">
       {% csrf_token %}
       {# Contact Information #}

--- a/templates/pages/style_guide.html
+++ b/templates/pages/style_guide.html
@@ -102,6 +102,10 @@
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Topic Card</a>
             </li>
             <li>
+              <a href="#form-errors"
+                 class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Form Errors</a>
+            </li>
+            <li>
               <a href="#form-field"
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Form Field</a>
             </li>
@@ -857,6 +861,30 @@
             <div class="grid gap-3 max-w-md mb-6">
               <c-molecules.topic-card icon="home" title="Housing & Eviction" description="Landlord disputes, eviction defense" href="#" />
               <c-molecules.topic-card icon="users" title="Family & Divorce" description="Divorce, custody, child support" href="#" />
+            </div>
+          </section>
+          <section id="form-errors" class="mb-12" aria-labelledby="form-errors-heading">
+            <h3 id="form-errors-heading" class="mb-4">Form Errors</h3>
+            <p class="text-greyscale-600 mb-6">
+              Renders non-field errors from a Django form as a danger alert.
+              Outputs nothing when there are no errors. Pass the form object
+              via the <code>:form</code> prop.
+            </p>
+            <div class="space-y-4 max-w-md mb-6">
+              <c-atoms.alert variant="danger" class="mb-4">
+                Example: Your password must contain at least 8 characters.
+              </c-atoms.alert>
+            </div>
+            <h4 class="mt-8">Usage</h4>
+            <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+              <code>&lt;c-molecules.form-errors :form="form" /&gt;</code>
+            </div>
+            <h4 class="mt-8">Props</h4>
+            <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+              <div class="flex flex-col md:flex-row">
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>:form</code></span>
+                <span class="p-2.5">Django form instance (reads <code>form.non_field_errors</code>)</span>
+              </div>
             </div>
           </section>
           <section id="form-field" class="mb-12" aria-labelledby="form-field-heading">


### PR DESCRIPTION
Extract identical non_field_errors alert block into a new `c-molecules.form-errors` molecule. Replaces duplicated 5-line pattern in login, signup, password reset, password reset from key, and profile edit templates with a single `<c-molecules.form-errors :form="form" />` call. Updated style guide and CLAUDE.md component listing.

Closes #278

Test plan: visual check on each form page (login, signup, password reset, profile edit) — error alert renders on invalid submission, nothing renders when no errors.