### PR TITLE
refactor: wire Cotton sidebar molecules into chat page

### DIFF
--- a/templates/cotton/molecules/action_item.html
+++ b/templates/cotton/molecules/action_item.html
@@ -1,24 +1,31 @@
-<c-vars title="" description="" completed="false" href="" />
-{# Action item - checkbox-style item with optional link #}
-<div class="flex items-start gap-3 p-3 rounded-lg hover:bg-greyscale-50 transition-colors {{ class }}"
+<c-vars title="" description="" deadline="" priority="normal" href="" completed="false" />
+{# Action item with priority coloring. priority: urgent | normal (default) #}
+{# Props mode: pass title (+ optional description, deadline, href, completed). #}
+{# Slot mode: omit title, provide content via slot. Pass x-bind:class via attrs for dynamic wrapper styling. #}
+<div class="flex items-start gap-2 p-2 rounded-lg {% if priority == 'urgent' %}bg-red-50 border border-red-100{% elif title %}bg-greyscale-50 border border-greyscale-200{% endif %} {{ class }}"
      {{ attrs }}>
-  <div class="flex-shrink-0 mt-0.5">
+  {% if title %}
     {% if completed == "true" %}
-      <c-atoms.icon name="check-circle" style="solid" class="w-5 h-5 text-green-500" />
+      <c-atoms.icon name="check-circle" style="solid" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
     {% else %}
-      <div class="w-5 h-5 rounded-full border-2 border-greyscale-300"></div>
+      <div class="w-4 h-4 rounded-full border-2 flex-shrink-0 mt-0.5 {% if priority == 'urgent' %}border-red-400{% else %}border-greyscale-300{% endif %}"></div>
     {% endif %}
-  </div>
-  <div class="flex-1 min-w-0">
-    {% if href %}
-      <c-atoms.link href="{{ href }}" variant="unstyled" class="text-sm font-medium text-greyscale-800 hover:text-primary-600 {% if completed == 'true' %}line-through text-greyscale-400{% endif %}">
-      {{ title }}
-      </c-atoms.link>
-    {% else %}
-      <p class="text-sm font-medium text-greyscale-800 {% if completed == 'true' %}line-through text-greyscale-400{% endif %}">
-        {{ title }}
-      </p>
-    {% endif %}
-    {% if description %}<p class="mt-0.5 text-xs text-greyscale-500">{{ description }}</p>{% endif %}
-  </div>
+    <div class="min-w-0 flex-1">
+      {% if href %}
+        <a href="{{ href }}" class="text-sm font-medium hover:underline {% if priority == 'urgent' %}text-red-800{% else %}text-greyscale-800{% endif %} {% if completed == 'true' %}line-through text-greyscale-400{% endif %}">{{ title }}</a>
+      {% else %}
+        <p class="text-sm font-medium {% if priority == 'urgent' %}text-red-800{% else %}text-greyscale-800{% endif %} {% if completed == 'true' %}line-through text-greyscale-400{% endif %}">{{ title }}</p>
+      {% endif %}
+      {% if description %}
+        <p class="text-xs mt-0.5 {% if priority == 'urgent' %}text-red-600{% else %}text-greyscale-500{% endif %}">{{ description }}</p>
+      {% endif %}
+      {% if deadline %}
+        <p class="text-xs mt-0.5 {% if priority == 'urgent' %}text-red-500 font-medium{% else %}text-greyscale-400{% endif %}">
+          <c-atoms.icon name="clock" class="w-3 h-3 inline -mt-0.5 mr-0.5" />{{ deadline }}
+        </p>
+      {% endif %}
+    </div>
+  {% else %}
+    {{ slot }}
+  {% endif %}
 </div>

--- a/templates/cotton/molecules/deadline_card.html
+++ b/templates/cotton/molecules/deadline_card.html
@@ -1,28 +1,21 @@
-<c-vars title="" date="" status="pending" icon="calendar" />
-{# Deadline card - displays a deadline with date and status #}
-{# status: urgent|pending|completed #}
-<div class="flex items-start gap-3 p-3 rounded-lg bg-greyscale-50 border border-greyscale-200 {{ class }}"
+<c-vars variant="default" title="" date="" />
+{# Deadline/date card. variant: urgent (red bg, exclamation) | default (plain, calendar) #}
+{# Props mode: pass title + date. Slot mode: omit title, provide content via slot. #}
+<div class="flex items-start gap-2 {% if variant == 'urgent' %}p-2 bg-red-50 border border-red-100 rounded-lg{% endif %} {{ class }}"
      {{ attrs }}>
-  <div class="flex-shrink-0 mt-0.5">
-    <c-atoms.icon name="{{ icon }}" class="w-5 h-5 {% if status == 'urgent' %}text-red-500{% elif status == 'completed' %}text-green-500{% else %}text-greyscale-400{% endif %}" />
-  </div>
-  <div class="flex-1 min-w-0">
-    <div class="flex items-center justify-between gap-2">
-      <p class="text-sm font-medium text-greyscale-800 truncate">{{ title }}</p>
-      <c-atoms.badge variant="{{ status }}">
-      {% if status == 'urgent' %}
-        Urgent
-      {% elif status == 'completed' %}
-        Done
-      {% else %}
-        Pending
+  {% if variant == "urgent" %}
+    <c-atoms.icon name="exclamation-circle" class="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" />
+  {% else %}
+    <c-atoms.icon name="calendar" class="w-4 h-4 text-greyscale-400 flex-shrink-0 mt-0.5" />
+  {% endif %}
+  <div class="min-w-0">
+    {% if title %}
+      <p class="text-sm {% if variant == 'urgent' %}font-medium text-red-700{% else %}text-greyscale-700{% endif %}">{{ title }}</p>
+      {% if date %}
+        <p class="text-xs {% if variant == 'urgent' %}text-red-600{% else %}text-greyscale-500{% endif %} truncate">{{ date }}</p>
       {% endif %}
-      </c-atoms.badge>
-    </div>
-    {% if date %}
-      <p class="mt-1 text-xs text-greyscale-500">
-        <c-atoms.icon name="clock" class="w-3 h-3 inline -mt-0.5 mr-1" />{{ date }}
-      </p>
+    {% else %}
+      {{ slot }}
     {% endif %}
   </div>
 </div>

--- a/templates/cotton/molecules/sidebar_section.html
+++ b/templates/cotton/molecules/sidebar_section.html
@@ -5,22 +5,22 @@
     <summary class="flex w-full items-center justify-between cursor-pointer text-left !px-0 list-none [&::-webkit-details-marker]:hidden">
       <div class="flex items-center gap-2">
         {% if icon %}<c-atoms.icon name="{{ icon }}" class="w-4 h-4 text-greyscale-400" />{% endif %}
-        <h3 class="text-sm font-semibold text-greyscale-700 uppercase tracking-wide">{{ title }}</h3>
+        <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{{ title }}</h4>
         {% if count %}<span class="text-xs text-greyscale-400">({{ count }})</span>{% endif %}
       </div>
       <c-atoms.icon name="chevron-down" class="w-4 h-4 text-greyscale-400 transition-transform group-open:rotate-180" />
     </summary>
     <div class="grid grid-rows-[0fr] group-open:grid-rows-[1fr] transition-[grid-template-rows] duration-200">
       <div class="overflow-hidden">
-        <div class="mt-3 space-y-2">{{ slot }}</div>
+        <div class="mt-2 space-y-2">{{ slot }}</div>
       </div>
     </div>
   </details>
 {% else %}
   <div class="{{ class }}" {{ attrs }}>
-    <div class="flex items-center gap-2 mb-3">
+    <div class="flex items-center gap-2 mb-2">
       {% if icon %}<c-atoms.icon name="{{ icon }}" class="w-4 h-4 text-greyscale-400" />{% endif %}
-      <h3 class="text-sm font-semibold text-greyscale-700 uppercase tracking-wide">{{ title }}</h3>
+      <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{{ title }}</h4>
       {% if count %}<span class="text-xs text-greyscale-400">({{ count }})</span>{% endif %}
     </div>
     <div class="space-y-2">{{ slot }}</div>

--- a/templates/pages/action_plan.html
+++ b/templates/pages/action_plan.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load i18n %}
+{% load cotton i18n %}
 
 {% block title %}
   {% trans "Case Summary" %} - {% trans "Litigant Portal" %}
@@ -73,17 +73,11 @@
           </h2>
           <div class="space-y-2">
             {% for date in key_dates %}
-              <div class="flex items-start gap-3 p-3 rounded-lg border {% if date.is_deadline %}border-red-200 bg-red-50{% else %}border-greyscale-200 bg-greyscale-50{% endif %}">
-                <span class="font-medium text-sm {% if date.is_deadline %}text-red-700{% else %}text-greyscale-700{% endif %}">
-                  {{ date.date }}
-                </span>
-                <span class="text-sm {% if date.is_deadline %}text-red-600{% else %}text-greyscale-600{% endif %}">
-                  {{ date.label }}
-                  {% if date.is_deadline %}
-                    <span class="inline-block ml-1 text-xs font-semibold uppercase text-red-500">{% trans "Deadline" %}</span>
-                  {% endif %}
-                </span>
-              </div>
+              <c-molecules.deadline-card
+                variant="{% if date.is_deadline %}urgent{% else %}default{% endif %}"
+                title="{{ date.date }}"
+                date="{{ date.label }}"
+              />
             {% endfor %}
           </div>
         </div>
@@ -119,24 +113,12 @@
           </h2>
           <div class="space-y-2">
             {% for item in action_items %}
-              <div class="flex items-start gap-3 p-3 rounded-lg border {% if item.priority == 'urgent' %}border-red-200 bg-red-50{% else %}border-greyscale-200 bg-greyscale-50{% endif %}">
-                <div class="w-5 h-5 rounded-full border-2 flex-shrink-0 mt-0.5 {% if item.priority == 'urgent' %}border-red-400{% else %}border-greyscale-300{% endif %}"></div>
-                <div class="flex-1">
-                  <p class="text-sm font-medium {% if item.priority == 'urgent' %}text-red-800{% else %}text-greyscale-800{% endif %}">
-                    {{ item.title }}
-                  </p>
-                  {% if item.description %}
-                    <p class="text-sm mt-0.5 {% if item.priority == 'urgent' %}text-red-600{% else %}text-greyscale-600{% endif %}">
-                      {{ item.description }}
-                    </p>
-                  {% endif %}
-                  {% if item.deadline %}
-                    <p class="text-xs mt-1 {% if item.priority == 'urgent' %}text-red-500 font-medium{% else %}text-greyscale-400{% endif %}">
-                      {% trans "Due:" %} {{ item.deadline }}
-                    </p>
-                  {% endif %}
-                </div>
-              </div>
+              <c-molecules.action-item
+                title="{{ item.title }}"
+                description="{{ item.description }}"
+                deadline="{{ item.deadline }}"
+                priority="{{ item.priority|default:'normal' }}"
+              />
             {% endfor %}
           </div>
         </div>

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -13,6 +13,11 @@
 {% trans "Upload PDF document" as upload_pdf_label %}
 {% trans "Describe your situation — what happened?" as input_placeholder %}
 {% trans "Ask a question" as input_aria_label %}
+{% trans "Deadlines" as deadlines_heading %}
+{% trans "Other Dates" as other_dates_heading %}
+{% trans "Your Rights & Defenses" as rights_heading %}
+{% trans "Possible Next Steps" as next_steps_heading %}
+{% trans "Resources" as resources_heading %}
 
 {% block content %}
   {{ topic_context|json_script:"topic-context-data" }}
@@ -154,40 +159,29 @@
           </div>
           {# Key deadlines #}
           <template x-if="hasDeadlines">
-            <div class="space-y-2">
-              <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Deadlines" %}</h4>
+            <c-molecules.sidebar-section title="{{ deadlines_heading }}">
               <template x-for="deadline in deadlines" :key="deadline.label">
-                <div class="flex items-start gap-2 p-2 bg-red-50 border border-red-100 rounded-lg">
-                  <c-atoms.icon name="exclamation-circle" class="w-4 h-4 text-red-500 flex-shrink-0 mt-0.5" />
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium text-red-700" x-text="deadline.date"></p>
-                    <p class="text-xs text-red-600 truncate" x-text="deadline.label"></p>
-                  </div>
-                </div>
+                <c-molecules.deadline-card variant="urgent">
+                  <p class="text-sm font-medium text-red-700" x-text="deadline.date"></p>
+                  <p class="text-xs text-red-600 truncate" x-text="deadline.label"></p>
+                </c-molecules.deadline-card>
               </template>
-            </div>
+            </c-molecules.sidebar-section>
           </template>
           {# Other dates #}
           <template x-if="hasOtherDates">
-            <div class="space-y-2">
-              <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Other Dates" %}</h4>
+            <c-molecules.sidebar-section title="{{ other_dates_heading }}">
               <template x-for="date in otherDates" :key="date.label">
-                <div class="flex items-start gap-2">
-                  <c-atoms.icon name="calendar" class="w-4 h-4 text-greyscale-400 flex-shrink-0 mt-0.5" />
-                  <div class="min-w-0">
-                    <p class="text-sm text-greyscale-700" x-text="date.date"></p>
-                    <p class="text-xs text-greyscale-500 truncate" x-text="date.label"></p>
-                  </div>
-                </div>
+                <c-molecules.deadline-card>
+                  <p class="text-sm text-greyscale-700" x-text="date.date"></p>
+                  <p class="text-xs text-greyscale-500 truncate" x-text="date.label"></p>
+                </c-molecules.deadline-card>
               </template>
-            </div>
+            </c-molecules.sidebar-section>
           </template>
           {# Action plan — spotted issues #}
           <template x-if="hasSpottedIssues">
-            <div class="space-y-2">
-              <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">
-                {% trans "Your Rights & Defenses" %}
-              </h4>
+            <c-molecules.sidebar-section title="{{ rights_heading }}">
               <template x-for="issue in spottedIssues" :key="issue.title">
                 <div class="flex items-start gap-2 p-2 bg-blue-50 border border-blue-100 rounded-lg">
                   <c-atoms.icon name="shield-check" class="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
@@ -202,17 +196,13 @@
                   </div>
                 </div>
               </template>
-            </div>
+            </c-molecules.sidebar-section>
           </template>
           {# Action plan — action items #}
           <template x-if="hasActionItems">
-            <div class="space-y-2">
-              <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">
-                {% trans "Possible Next Steps" %}
-              </h4>
+            <c-molecules.sidebar-section title="{{ next_steps_heading }}">
               <template x-for="item in actionItems" :key="item.title">
-                <div class="flex items-start gap-2 p-2 rounded-lg"
-                     x-bind:class="item.bgClass">
+                <c-molecules.action-item x-bind:class="item.bgClass">
                   <div class="w-4 h-4 rounded-full border-2 flex-shrink-0 mt-0.5"
                        x-bind:class="item.borderClass"></div>
                   <div class="min-w-0">
@@ -230,16 +220,13 @@
                       <span x-text="item.deadline"></span>
                     </p>
                   </div>
-                </div>
+                </c-molecules.action-item>
               </template>
-            </div>
+            </c-molecules.sidebar-section>
           </template>
           {# Action plan — resources #}
           <template x-if="hasResources">
-            <div class="space-y-2">
-              <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">
-                {% trans "Resources" %}
-              </h4>
+            <c-molecules.sidebar-section title="{{ resources_heading }}">
               <template x-for="resource in resources" :key="resource.title">
                 <div class="flex items-start gap-2 p-2 bg-green-50 border border-green-100 rounded-lg">
                   <c-atoms.icon name="link" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
@@ -251,7 +238,7 @@
                   </div>
                 </div>
               </template>
-            </div>
+            </c-molecules.sidebar-section>
           </template>
           {# Printable document link #}
           <div class="pt-3 border-t border-greyscale-200">

--- a/templates/pages/style_guide.html
+++ b/templates/pages/style_guide.html
@@ -965,36 +965,47 @@
                    class="mb-12"
                    aria-labelledby="deadline-card-heading">
             <h3 id="deadline-card-heading" class="mb-4">Deadline Card</h3>
-            <p class="text-greyscale-600 mb-6">Displays a deadline with date and status badge.</p>
+            <p class="text-greyscale-600 mb-6">
+              Displays a date or deadline. Use <code>variant="urgent"</code> for
+              deadlines (red background, exclamation icon) or omit for regular dates
+              (calendar icon). Supports props mode (server-rendered) and slot mode
+              (Alpine-driven content).
+            </p>
             <div class="space-y-3 max-w-sm mb-6">
-              <c-molecules.deadline-card title="File Answer" date="Due Jan 20, 2026" status="urgent" />
-              <c-molecules.deadline-card title="Review Documents" date="Due Jan 25, 2026" status="pending" />
-              <c-molecules.deadline-card title="Initial Consultation" date="Completed Jan 10" status="completed" />
+              <c-molecules.deadline-card variant="urgent" title="Mar 15, 2026" date="Answer deadline" />
+              <c-molecules.deadline-card title="Apr 1, 2026" date="Hearing date" />
             </div>
             <h4 class="mt-8">Props</h4>
             <div class="bg-greyscale-100 rounded-xl p-4 my-3">
               <div class="flex flex-col md:flex-row border-b border-greyscale-200">
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>variant</code></span>
+                <span class="p-2.5">"urgent" | "default" (default) — controls background + icon</span>
+              </div>
+              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>title</code></span>
-                <span class="p-2.5">Deadline title</span>
-              </div>
-              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>date</code></span>
-                <span class="p-2.5">Date text (e.g., "Due Jan 20, 2026")</span>
-              </div>
-              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>status</code></span>
-                <span class="p-2.5">"urgent" | "pending" | "completed"</span>
+                <span class="p-2.5">Primary text (date or label). Enables props mode when set.</span>
               </div>
               <div class="flex flex-col md:flex-row">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>icon</code></span>
-                <span class="p-2.5">Heroicon name (default: "calendar")</span>
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>date</code></span>
+                <span class="p-2.5">Secondary text (label or date)</span>
               </div>
             </div>
+            <h4 class="mt-8">Slot mode</h4>
+            <p class="text-greyscale-600 my-3">
+              Omit <code>title</code> and provide content via the default slot.
+              The molecule renders the structural wrapper (icon, background) and
+              the slot fills the content area — useful inside Alpine
+              <code>x-for</code> loops with <code>x-text</code> bindings.
+            </p>
           </section>
           <section id="action-item" class="mb-12" aria-labelledby="action-item-heading">
             <h3 id="action-item-heading" class="mb-4">Action Item</h3>
-            <p class="text-greyscale-600 mb-6">Checkbox-style action item with optional link.</p>
+            <p class="text-greyscale-600 mb-6">
+              Checkbox-style action item with priority coloring. Supports props
+              mode (server-rendered) and slot mode (Alpine-driven).
+            </p>
             <div class="space-y-2 max-w-sm mb-6">
+              <c-molecules.action-item priority="urgent" title="File an Appearance" description="Submit to the clerk's office" deadline="Due May 1, 2026" />
               <c-molecules.action-item title="Gather income documents" description="Pay stubs, tax returns" />
               <c-molecules.action-item title="Review lease agreement" href="#" />
               <c-molecules.action-item title="Submit initial paperwork" completed="true" />
@@ -1003,21 +1014,35 @@
             <div class="bg-greyscale-100 rounded-xl p-4 my-3">
               <div class="flex flex-col md:flex-row border-b border-greyscale-200">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>title</code></span>
-                <span class="p-2.5">Action item title</span>
+                <span class="p-2.5">Action item title. Enables props mode when set.</span>
+              </div>
+              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>priority</code></span>
+                <span class="p-2.5">"urgent" | "normal" (default) — controls background + circle color</span>
               </div>
               <div class="flex flex-col md:flex-row border-b border-greyscale-200">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>description</code></span>
                 <span class="p-2.5">Optional description text</span>
               </div>
               <div class="flex flex-col md:flex-row border-b border-greyscale-200">
+                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>deadline</code></span>
+                <span class="p-2.5">Optional deadline text (shown with clock icon)</span>
+              </div>
+              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>href</code></span>
-                <span class="p-2.5">Optional link URL</span>
+                <span class="p-2.5">Optional link URL (renders title as link)</span>
               </div>
               <div class="flex flex-col md:flex-row">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>completed</code></span>
-                <span class="p-2.5">"true" | "false" (default)</span>
+                <span class="p-2.5">"true" | "false" (default) — shows green checkmark</span>
               </div>
             </div>
+            <h4 class="mt-8">Slot mode</h4>
+            <p class="text-greyscale-600 my-3">
+              Omit <code>title</code> and provide content via the default slot.
+              Pass <code>x-bind:class</code> through attrs for dynamic wrapper
+              styling in Alpine <code>x-for</code> loops.
+            </p>
           </section>
           <section id="sidebar-section"
                    class="mb-12"
@@ -1026,10 +1051,11 @@
             <p class="text-greyscale-600 mb-6">Collapsible section with title and optional count badge.</p>
             <div class="max-w-sm mb-6 space-y-4">
               <c-molecules.sidebar-section title="Deadlines" icon="calendar" count="2">
-              <c-molecules.deadline-card title="File Answer" date="Due Jan 20" status="urgent" />
-              <c-molecules.deadline-card title="Review Docs" date="Due Jan 25" status="pending" />
+              <c-molecules.deadline-card variant="urgent" title="Jan 20, 2026" date="File Answer" />
+              <c-molecules.deadline-card title="Jan 25, 2026" date="Review Documents" />
               </c-molecules.sidebar-section>
               <c-molecules.sidebar-section title="Action Items" icon="clipboard-document-check" collapsible="true">
+              <c-molecules.action-item priority="urgent" title="File an Appearance" deadline="Due Jan 20" />
               <c-molecules.action-item title="Gather documents" />
               <c-molecules.action-item title="Review lease" completed="true" />
               </c-molecules.sidebar-section>
@@ -1260,10 +1286,11 @@
             <div class="border border-greyscale-200 rounded-lg overflow-hidden mb-6">
               <c-organisms.case-sidebar case_type="Eviction" county="Bexar County" class="w-80">
               <c-molecules.sidebar-section title="Deadlines" icon="calendar" count="2">
-              <c-molecules.deadline-card title="File Answer" date="Due Jan 20, 2026" status="urgent" />
-              <c-molecules.deadline-card title="Court Hearing" date="Feb 5, 2026" status="pending" />
+              <c-molecules.deadline-card variant="urgent" title="Jan 20, 2026" date="File Answer" />
+              <c-molecules.deadline-card title="Feb 5, 2026" date="Court Hearing" />
               </c-molecules.sidebar-section>
               <c-molecules.sidebar-section title="Action Items" icon="clipboard-document-check" collapsible="true">
+              <c-molecules.action-item priority="urgent" title="File an Appearance" deadline="Due Jan 20" />
               <c-molecules.action-item title="Gather income documents" description="Pay stubs, tax returns" />
               <c-molecules.action-item title="Review lease agreement" />
               <c-molecules.action-item title="Submit initial paperwork" completed="true" />


### PR DESCRIPTION
Replace hand-rolled inline HTML in chat.html sidebar with existing Cotton molecules (deadline_card, action_item, sidebar_section). Redesign molecules to support both server-rendered props mode (action_plan.html) and Alpine-driven slot mode (chat.html x-for loops). Style guide updated.

Closes #259

## Test plan

- [ ] **Chat sidebar** — start a chat, verify deadlines/dates/action items render correctly with live SSE updates
- [ ] **Action plan page** (`/chat/action-plan/`) — verify the print view still renders with server-rendered molecules
- [ ] **Style guide** (`/style-guide/`) — verify redesigned molecule examples (deadline card, action item, sidebar section) look correct
- [ ] `make lint`
- [ ] `make test`