### PR TITLE
feat(chat): status-aware endpoints, action item toggle, archive

### DIFF
--- a/chat/agents/litigant_assistant.py
+++ b/chat/agents/litigant_assistant.py
@@ -232,7 +232,9 @@ class UpdateCaseFacts(Tool):
                 if session.user
                 else {"session_key": session.session_key}
             )
-            case, _ = CaseInfo.objects.get_or_create(**ownership)
+            case, _ = CaseInfo.objects.get_or_create(
+                status="active", **ownership
+            )
             data = dict(case.data) if case.data else {}
 
             if "case_type" in patch:
@@ -328,7 +330,9 @@ class UpdateActionPlan(Tool):
                 if session.user
                 else {"session_key": session.session_key}
             )
-            case, _ = CaseInfo.objects.get_or_create(**ownership)
+            case, _ = CaseInfo.objects.get_or_create(
+                status="active", **ownership
+            )
             data = dict(case.data) if case.data else {}
 
             # action_items → ActionItemModel (not JSON)

--- a/chat/tests/test_case_views.py
+++ b/chat/tests/test_case_views.py
@@ -11,7 +11,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 
-from chat.models import CaseInfo, TimelineEvent
+from chat.models import ActionItemModel, CaseInfo, Deadline, TimelineEvent
 
 User = get_user_model()
 
@@ -217,35 +217,31 @@ class CaseTimelineAddTests(TestCase):
 
 @pytest.mark.postgres
 class CaseClearTests(TestCase):
-    """Tests for POST /api/chat/case/clear/."""
+    """Tests for POST /api/chat/case/clear/ — archives instead of deleting."""
 
     def setUp(self):
         self.client = Client()
 
-    def test_deletes_case_and_timeline(self):
-        """Should delete CaseInfo and cascade to TimelineEvents."""
+    def test_archives_case_instead_of_deleting(self):
+        """Should set status='archived' rather than deleting."""
         self.client.post(
             "/api/chat/case/save/",
             {"data": json.dumps(SAMPLE_CASE_DATA)},
         )
-        self.client.post(
-            "/api/chat/case/timeline/",
-            {"event_type": "upload", "title": "Test"},
-        )
 
         response = self.client.post("/api/chat/case/clear/")
 
         data = json.loads(response.content)
-        self.assertTrue(data["deleted"])
-        self.assertEqual(CaseInfo.objects.count(), 0)
-        self.assertEqual(TimelineEvent.objects.count(), 0)
+        self.assertTrue(data["archived"])
+        self.assertEqual(CaseInfo.objects.count(), 1)
+        self.assertEqual(CaseInfo.objects.first().status, "archived")
 
-    def test_returns_false_when_nothing_to_delete(self):
-        """Should return deleted=false when no case exists."""
+    def test_returns_false_when_nothing_to_archive(self):
+        """Should return archived=false when no active case exists."""
         response = self.client.post("/api/chat/case/clear/")
 
         data = json.loads(response.content)
-        self.assertFalse(data["deleted"])
+        self.assertFalse(data["archived"])
 
     def test_clears_chat_session_id(self):
         """Should remove chat_session_id from Django session."""
@@ -255,11 +251,22 @@ class CaseClearTests(TestCase):
 
         self.client.post("/api/chat/case/clear/")
 
-        # Re-fetch session — Django test client persists cookies
         response = self.client.get("/api/chat/case/")
         self.assertEqual(response.status_code, 200)
-        # Session should not contain chat_session_id
         self.assertNotIn("chat_session_id", self.client.session)
+
+    def test_archived_case_not_returned_by_case_get(self):
+        """After archiving, case_get should return null (only active cases)."""
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+        self.client.post("/api/chat/case/clear/")
+
+        response = self.client.get("/api/chat/case/")
+
+        data = json.loads(response.content)
+        self.assertIsNone(data["case_info"])
 
 
 @pytest.mark.postgres
@@ -309,7 +316,7 @@ class OwnershipIsolationTests(TestCase):
         self.assertIsNone(data_b["case_info"])
 
     def test_clear_only_affects_own_data(self):
-        """Clear should only delete the requesting user's case."""
+        """Clear should only archive the requesting user's case."""
         client_a = Client()
         client_b = Client()
 
@@ -324,10 +331,190 @@ class OwnershipIsolationTests(TestCase):
 
         client_a.post("/api/chat/case/clear/")
 
-        # A should be empty
+        # A's case should be archived (not visible via case_get)
         data_a = json.loads(client_a.get("/api/chat/case/").content)
         self.assertIsNone(data_a["case_info"])
 
-        # B should still have data
+        # B should still have active data
         data_b = json.loads(client_b.get("/api/chat/case/").content)
         self.assertEqual(data_b["case_info"]["case_type"], "Foreclosure")
+
+
+@pytest.mark.postgres
+class CaseGetStatusFilterTests(TestCase):
+    """Tests that case_get only returns active cases."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_case_get_includes_status_field(self):
+        """Response should include the status field."""
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+
+        response = self.client.get("/api/chat/case/")
+
+        data = json.loads(response.content)
+        self.assertEqual(data["case_info"]["status"], "active")
+
+    def test_case_save_after_archive_creates_new_active(self):
+        """Saving after archive should create a new active case."""
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+        self.client.post("/api/chat/case/clear/")
+
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps({"case_type": "Small Claims"})},
+        )
+
+        response = self.client.get("/api/chat/case/")
+        data = json.loads(response.content)
+        self.assertEqual(data["case_info"]["case_type"], "Small Claims")
+        self.assertEqual(data["case_info"]["status"], "active")
+        # Archived + new active = 2 total
+        self.assertEqual(CaseInfo.objects.count(), 2)
+
+
+@pytest.mark.postgres
+class CaseResolveTests(TestCase):
+    """Tests for POST /api/chat/case/resolve/."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_resolves_active_case(self):
+        """Should set status to 'resolved' and create timeline event."""
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+
+        response = self.client.post("/api/chat/case/resolve/")
+
+        data = json.loads(response.content)
+        self.assertTrue(data["resolved"])
+        case = CaseInfo.objects.first()
+        self.assertEqual(case.status, "resolved")
+        self.assertTrue(
+            case.timeline_events.filter(event_type="resolution").exists()
+        )
+
+    def test_returns_false_when_no_active_case(self):
+        response = self.client.post("/api/chat/case/resolve/")
+
+        data = json.loads(response.content)
+        self.assertFalse(data["resolved"])
+
+
+@pytest.mark.postgres
+class ActionItemToggleTests(TestCase):
+    """Tests for POST /api/chat/case/action-item/<id>/toggle/."""
+
+    def setUp(self):
+        self.client = Client()
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+        self.case = CaseInfo.objects.first()
+        self.item = ActionItemModel.objects.create(
+            case=self.case, title="File paperwork"
+        )
+
+    def test_toggles_completed_false_to_true(self):
+        response = self.client.post(
+            f"/api/chat/case/action-item/{self.item.id}/toggle/"
+        )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["completed"])
+        self.item.refresh_from_db()
+        self.assertTrue(self.item.completed)
+
+    def test_toggles_completed_true_to_false(self):
+        self.item.completed = True
+        self.item.save()
+
+        response = self.client.post(
+            f"/api/chat/case/action-item/{self.item.id}/toggle/"
+        )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["completed"])
+
+    def test_returns_404_for_nonexistent_item(self):
+        import uuid
+
+        response = self.client.post(
+            f"/api/chat/case/action-item/{uuid.uuid4()}/toggle/"
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+@pytest.mark.postgres
+class DeadlineReminderToggleTests(TestCase):
+    """Tests for POST /api/chat/case/deadline/<id>/remind/."""
+
+    def setUp(self):
+        self.client = Client()
+        self.client.post(
+            "/api/chat/case/save/",
+            {"data": json.dumps(SAMPLE_CASE_DATA)},
+        )
+        self.case = CaseInfo.objects.first()
+        self.deadline = Deadline.objects.create(
+            case=self.case,
+            label="Answer deadline",
+            date="2026-05-01",
+            is_deadline=True,
+        )
+
+    def test_toggles_reminder_false_to_true(self):
+        response = self.client.post(
+            f"/api/chat/case/deadline/{self.deadline.id}/remind/"
+        )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["reminder_requested"])
+        self.deadline.refresh_from_db()
+        self.assertTrue(self.deadline.reminder_requested)
+
+    def test_toggles_reminder_true_to_false(self):
+        self.deadline.reminder_requested = True
+        self.deadline.save()
+
+        response = self.client.post(
+            f"/api/chat/case/deadline/{self.deadline.id}/remind/"
+        )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["reminder_requested"])
+
+    def test_returns_404_for_nonexistent_deadline(self):
+        import uuid
+
+        response = self.client.post(
+            f"/api/chat/case/deadline/{uuid.uuid4()}/remind/"
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+@pytest.mark.postgres
+class TimelineResolutionTypeTests(TestCase):
+    """Tests that timeline endpoint accepts 'resolution' event type."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_accepts_resolution_event_type(self):
+        response = self.client.post(
+            "/api/chat/case/timeline/",
+            {"event_type": "resolution", "title": "Case resolved"},
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/chat/urls.py
+++ b/chat/urls.py
@@ -16,4 +16,15 @@ urlpatterns = [
     path("case/save/", views.case_save, name="case_save"),
     path("case/timeline/", views.case_timeline_add, name="case_timeline_add"),
     path("case/clear/", views.case_clear, name="case_clear"),
+    path("case/resolve/", views.case_resolve, name="case_resolve"),
+    path(
+        "case/action-item/<uuid:item_id>/toggle/",
+        views.action_item_toggle,
+        name="action_item_toggle",
+    ),
+    path(
+        "case/deadline/<uuid:deadline_id>/remind/",
+        views.deadline_reminder_toggle,
+        name="deadline_reminder_toggle",
+    ),
 ]

--- a/chat/views.py
+++ b/chat/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django_ratelimit.decorators import ratelimit
 
 from .agents import agent_registry
-from .models import CaseInfo, TimelineEvent
+from .models import ActionItemModel, CaseInfo, Deadline, TimelineEvent
 from .services.chat_service import ChatService
 from .services.pdf_service import pdf_service
 from .services.search_service import search_service
@@ -234,13 +234,14 @@ def summarize_conversation(request: HttpRequest) -> JsonResponse:
 def case_get(request: HttpRequest) -> JsonResponse:
     """Return case info + timeline for the current user/session."""
     ownership = _ownership_filter(request)
-    case = CaseInfo.objects.filter(**ownership).first()
+    case = CaseInfo.objects.filter(status="active", **ownership).first()
 
     if not case:
         return JsonResponse({"case_info": None, "timeline": []})
 
     # Assemble case_info: JSON fields + model-backed fields
     case_info = dict(case.data)
+    case_info["status"] = case.status
     case_info["key_dates"] = [d.to_dict() for d in case.deadlines.all()]
     case_info["action_items"] = [a.to_dict() for a in case.action_items.all()]
 
@@ -281,6 +282,7 @@ def case_save(request: HttpRequest) -> JsonResponse:
 
     ownership = _ownership_filter(request)
     case, created = CaseInfo.objects.update_or_create(
+        status="active",
         defaults={"data": data},
         **ownership,
     )
@@ -321,7 +323,7 @@ def case_timeline_add(request: HttpRequest) -> JsonResponse:
     content = request.POST.get("content", "")
     raw_metadata = request.POST.get("metadata", "{}")
 
-    valid_types = {"upload", "summary", "change"}
+    valid_types = {"upload", "summary", "change", "resolution"}
     if event_type not in valid_types:
         return JsonResponse(
             {
@@ -382,9 +384,80 @@ def action_plan(request: HttpRequest):
 @require_POST
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 def case_clear(request: HttpRequest) -> JsonResponse:
-    """Delete case info + cascade timeline. Clear chat session from Django session."""
+    """Archive active case info. Clear chat session from Django session."""
     ownership = _ownership_filter(request)
-    deleted, _ = CaseInfo.objects.filter(**ownership).delete()
+    archived = CaseInfo.objects.filter(status="active", **ownership).update(
+        status="archived"
+    )
     request.session.pop("chat_session_id", None)
 
-    return JsonResponse({"deleted": deleted > 0})
+    return JsonResponse({"archived": archived > 0})
+
+
+@require_POST
+@ratelimit(key="ip", rate="30/m", method="POST", block=True)
+def case_resolve(request: HttpRequest) -> JsonResponse:
+    """Mark the active case as resolved and create a resolution timeline event."""
+    ownership = _ownership_filter(request)
+    case = CaseInfo.objects.filter(status="active", **ownership).first()
+
+    if not case:
+        return JsonResponse({"resolved": False})
+
+    case.status = "resolved"
+    case.save(update_fields=["status"])
+
+    TimelineEvent.objects.create(
+        case=case,
+        event_type="resolution",
+        title="Case marked as resolved",
+    )
+
+    return JsonResponse({"resolved": True})
+
+
+@require_POST
+@ratelimit(key="ip", rate="30/m", method="POST", block=True)
+def action_item_toggle(request: HttpRequest, item_id: str) -> JsonResponse:
+    """Toggle an action item's completed state."""
+    ownership = _ownership_filter(request)
+    item = ActionItemModel.objects.filter(
+        id=item_id,
+        case__status="active",
+        **{"case__" + k: v for k, v in ownership.items()},
+    ).first()
+
+    if not item:
+        return JsonResponse({"error": "Not found"}, status=404)
+
+    item.completed = not item.completed
+    item.save(update_fields=["completed"])
+
+    return JsonResponse({"id": str(item.id), "completed": item.completed})
+
+
+@require_POST
+@ratelimit(key="ip", rate="30/m", method="POST", block=True)
+def deadline_reminder_toggle(
+    request: HttpRequest, deadline_id: str
+) -> JsonResponse:
+    """Toggle a deadline's reminder_requested state."""
+    ownership = _ownership_filter(request)
+    deadline = Deadline.objects.filter(
+        id=deadline_id,
+        case__status="active",
+        **{"case__" + k: v for k, v in ownership.items()},
+    ).first()
+
+    if not deadline:
+        return JsonResponse({"error": "Not found"}, status=404)
+
+    deadline.reminder_requested = not deadline.reminder_requested
+    deadline.save(update_fields=["reminder_requested"])
+
+    return JsonResponse(
+        {
+            "id": str(deadline.id),
+            "reminder_requested": deadline.reminder_requested,
+        }
+    )


### PR DESCRIPTION
Make case endpoints status-aware, add toggle endpoints for action items and deadline reminders, and change case_clear from destructive delete to archive.

- `case_get`/`case_save` filter by `status="active"`
- `case_clear` archives instead of deleting
- New: `case_resolve`, `action_item_toggle`, `deadline_reminder_toggle`
- Litigant assistant `get_or_create` calls scoped to active cases

Part of #261, closes #284

Test plan: 5 new test classes + updated CaseClearTests and OwnershipIsolationTests for archive behavior