### PR TITLE
ci: QA/Staging CI/CD pipeline and deploy workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,70 @@
+name: CD
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # PR: validate Docker build (no push)
+  # ---------------------------------------------------------------------------
+  docker-build:
+    name: Docker build validation
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+
+  # ---------------------------------------------------------------------------
+  # Main: build, push to GHCR, deploy to QA
+  # ---------------------------------------------------------------------------
+  build-and-deploy:
+    name: Build, push, deploy to QA
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/freelawproject/litigant-portal
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Deploy to QA
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.QA_HOST }}
+          username: ${{ secrets.QA_USER }}
+          key: ${{ secrets.QA_SSH_KEY }}
+          script: |
+            cd /opt/litigant-portal
+            docker compose pull django-prod
+            docker compose --profile prod up -d --no-build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ Keep configuration **simple and consistent** across dev, CI/CD, and QA. Docker e
 | ----------- | ------------- | ------------------------------------------ |
 | Local dev   | OpenAI        | docker-compose.yml + `.env` (secrets only) |
 | CI/CD       | None (mocked) | tox.ini - tests mock all providers         |
+| QA/Staging  | OpenAI        | docker-compose prod profile + secrets/     |
 | Production  | OpenAI        | docker-compose.yml + `.env` + secrets/     |
+
+**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to main via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
 
 **Local dev setup:**
 
@@ -458,7 +461,15 @@ curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.js" -o stat
 curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js" -o static/js/alpine.min.js
 ```
 
-## Deployment (Self-Hosted)
+## Deployment
+
+### QA/Staging
+
+QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to main via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
+
+Manual deploy on the QA server: `make docker-rebuild`
+
+### Production (Self-Hosted)
 
 Production runs on a self-hosted server with Docker Compose and Caddy for automatic HTTPS.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help build css clean install migrate test test-v collectstatic lint fmt-check fmt \
        messages compilemessages \
-       docker-build docker-dev docker-prod docker-down docker-logs docker-shell docker-migrate docker-clean
+       docker-build docker-dev docker-prod docker-rebuild docker-down docker-logs docker-shell docker-migrate docker-clean
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -81,6 +81,10 @@ docker-prod: ## Start production environment (Caddy + Gunicorn)
 
 docker-prod-build: ## Build and start production environment
 	docker compose --profile prod up --build
+
+docker-rebuild: ## Rebuild and restart prod (for QA deploys)
+	docker compose --profile prod down
+	docker compose --profile prod up -d --build
 
 docker-down: ## Stop all containers
 	docker compose --profile dev --profile prod down

--- a/config/settings.py
+++ b/config/settings.py
@@ -248,6 +248,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 if not DEBUG:
     # HTTPS/SSL
     SECURE_SSL_REDIRECT = True
+    SECURE_REDIRECT_EXEMPT = [r"^health/$"]
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
     # HSTS (HTTP Strict Transport Security)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
   # Production Django Server
   # ---------------------------------------------------------------------------
   django-prod:
+    image: ghcr.io/freelawproject/litigant-portal:latest
     build: .
     profiles: ['prod']
     command: web-prod

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -1,6 +1,6 @@
 # QA Environment Setup
 
-One-time setup for the QA/staging server at `qa.litigant-portal.com`. After setup, deploys are automatic — merge to main triggers a new Docker image build and deploy via GitHub Actions.
+One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to main triggers a new Docker image build and deploy via GitHub Actions.
 
 ## Architecture
 
@@ -58,8 +58,8 @@ cd /opt/litigant-portal
 
 # Non-secret config
 cat > .env << 'EOF'
-DOMAIN=qa.litigant-portal.com
-ALLOWED_HOSTS=qa.litigant-portal.com
+DOMAIN=qa.litigantportal.com
+ALLOWED_HOSTS=qa.litigantportal.com
 CHAT_ENABLED=true
 CHAT_MODEL=openai/gpt-4o-mini
 EOF
@@ -87,7 +87,7 @@ Caddy will auto-provision a Let's Encrypt certificate once DNS resolves.
 
 ## DNS
 
-Point an A record for `qa.litigant-portal.com` at the VPS IP address.
+Point an A record for `qa.litigantportal.com` at the VPS IP address.
 
 ## GitHub Actions Secrets
 

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -4,17 +4,19 @@ One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup
 
 ## Architecture
 
-- **Server**: DigitalOcean x86 droplet (Ubuntu 24.04, $6/mo basic)
+- **Server**: DigitalOcean x86 droplet (Ubuntu 24.04, $12/mo — 2 vCPU, 2 GB RAM, 50 GB SSD) with automated weekly backups ($2.40/mo)
+- **DNS**: Hurricane Electric free DNS (`ns1.he.net` through `ns5.he.net`)
 - **Stack**: Same docker-compose prod profile as production
 - **Image**: Pulled from `ghcr.io/freelawproject/litigant-portal:latest` (built by CI)
 - **HTTPS**: Caddy auto-provisions via Let's Encrypt
 - **Database**: Postgres (pgvector) on the same server via docker-compose
+- **Deploy user**: `deploy` (non-root with sudo rights) — CI/CD uses a dedicated SSH key
 
 ## Provision the Server
 
 1. Create a DigitalOcean droplet:
    - Image: Ubuntu 24.04 LTS
-   - Plan: Basic $6/mo (1 vCPU, 1 GB RAM, 25 GB SSD)
+   - Plan: Basic $12/mo (2 vCPU, 2 GB RAM, 50 GB SSD)
    - Region: NYC or closest to demo audience
    - Add your SSH key during creation
 
@@ -93,10 +95,10 @@ Point an A record for `qa.litigantportal.com` at the VPS IP address.
 
 Add these to the repo at Settings → Secrets and variables → Actions:
 
-| Secret | Value |
-|--------|-------|
-| `QA_HOST` | VPS IP address |
-| `QA_USER` | `deploy` |
+| Secret       | Value                              |
+| ------------ | ---------------------------------- |
+| `QA_HOST`    | VPS IP address                     |
+| `QA_USER`    | `deploy`                           |
 | `QA_SSH_KEY` | Contents of the deploy private key |
 
 Generate the deploy key:

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -1,0 +1,153 @@
+# QA Environment Setup
+
+One-time setup for the QA/staging server at `qa.litigant-portal.com`. After setup, deploys are automatic — merge to main triggers a new Docker image build and deploy via GitHub Actions.
+
+## Architecture
+
+- **Server**: DigitalOcean x86 droplet (Ubuntu 24.04, $6/mo basic)
+- **Stack**: Same docker-compose prod profile as production
+- **Image**: Pulled from `ghcr.io/freelawproject/litigant-portal:latest` (built by CI)
+- **HTTPS**: Caddy auto-provisions via Let's Encrypt
+- **Database**: Postgres (pgvector) on the same server via docker-compose
+
+## Provision the Server
+
+1. Create a DigitalOcean droplet:
+   - Image: Ubuntu 24.04 LTS
+   - Plan: Basic $6/mo (1 vCPU, 1 GB RAM, 25 GB SSD)
+   - Region: NYC or closest to demo audience
+   - Add your SSH key during creation
+
+2. Configure the firewall (DigitalOcean Cloud Firewall or `ufw`):
+   - Allow: 22 (SSH), 80 (HTTP), 443 (HTTPS)
+   - Block everything else
+
+## Initial Server Setup
+
+```bash
+ssh root@<VPS_IP>
+
+# Create deploy user
+adduser deploy
+usermod -aG sudo deploy
+mkdir -p /home/deploy/.ssh
+cp ~/.ssh/authorized_keys /home/deploy/.ssh/
+chown -R deploy:deploy /home/deploy/.ssh
+chmod 700 /home/deploy/.ssh
+
+# Clone repo
+git clone https://github.com/freelawproject/litigant-portal.git /opt/litigant-portal
+chown -R deploy:deploy /opt/litigant-portal
+
+# Switch to deploy user
+su - deploy
+```
+
+## Install Docker
+
+```bash
+cd /opt/litigant-portal
+./scripts/init-server.sh
+# Log out and back in (or `newgrp docker`) for group membership
+```
+
+## Configure Environment
+
+```bash
+cd /opt/litigant-portal
+
+# Non-secret config
+cat > .env << 'EOF'
+DOMAIN=qa.litigant-portal.com
+ALLOWED_HOSTS=qa.litigant-portal.com
+CHAT_ENABLED=true
+CHAT_MODEL=openai/gpt-4o-mini
+EOF
+
+# Secrets (never committed)
+mkdir -p secrets
+chmod 700 secrets
+python3 -c 'import secrets; print(secrets.token_urlsafe(50))' > secrets/django_secret_key.txt
+echo "choose-a-strong-db-password" > secrets/db_password.txt
+echo "sk-your-openai-api-key" > secrets/openai_api_key.txt
+chmod 600 secrets/*.txt
+```
+
+## First Deploy
+
+```bash
+# Pull the pre-built image from GHCR
+docker compose pull django-prod
+
+# Start the full prod stack
+docker compose --profile prod up -d
+```
+
+Caddy will auto-provision a Let's Encrypt certificate once DNS resolves.
+
+## DNS
+
+Point an A record for `qa.litigant-portal.com` at the VPS IP address.
+
+## GitHub Actions Secrets
+
+Add these to the repo at Settings → Secrets and variables → Actions:
+
+| Secret | Value |
+|--------|-------|
+| `QA_HOST` | VPS IP address |
+| `QA_USER` | `deploy` |
+| `QA_SSH_KEY` | Contents of the deploy private key |
+
+Generate the deploy key:
+
+```bash
+# On your local machine
+ssh-keygen -t ed25519 -C "lp-qa-deploy" -f ~/.ssh/lp_qa_deploy
+ssh-copy-id -i ~/.ssh/lp_qa_deploy.pub deploy@<VPS_IP>
+
+# Add the private key contents to GitHub as QA_SSH_KEY
+cat ~/.ssh/lp_qa_deploy
+```
+
+## GHCR Package Visibility
+
+After the first merge to main pushes an image, set the package to public:
+
+1. Go to https://github.com/orgs/freelawproject/packages/container/litigant-portal/settings
+2. Change visibility to **Public**
+
+This allows the QA VPS to pull without authentication.
+
+## Common Operations
+
+```bash
+# View logs
+docker compose --profile prod logs -f
+
+# Django shell
+docker compose --profile prod exec django-prod python manage.py shell
+
+# Restart
+docker compose --profile prod restart
+
+# Manual pull + deploy (same as what CI does)
+cd /opt/litigant-portal
+docker compose pull django-prod
+docker compose --profile prod up -d --no-build
+
+# Rollback to a specific SHA
+docker pull ghcr.io/freelawproject/litigant-portal:sha-abc1234
+docker compose --profile prod up -d --no-build
+```
+
+## How Deploys Work
+
+1. Developer merges PR to `main`
+2. GitHub Actions `cd.yml` workflow triggers:
+   - Builds Docker image
+   - Pushes to GHCR with `latest` + SHA tags
+   - SSHs to QA VPS
+   - Runs `docker compose pull django-prod && docker compose --profile prod up -d --no-build`
+3. The `web-prod` entrypoint runs `migrate` + `collectstatic` + starts Gunicorn
+4. Caddy proxies traffic with HTTPS


### PR DESCRIPTION
Add automated CI/CD pipeline for QA/staging at qa.litigantportal.com.
DigitalOcean VPS running docker-compose prod profile with Caddy auto-HTTPS.

- GitHub Actions CD workflow: Docker build validation on PRs, build + push
  to GHCR + SSH deploy on merge to main
- Health endpoint exempted from SSL redirect for Docker health checks
- `make docker-rebuild` target for manual deploys
- Full VPS setup runbook in docs/QA-DEPLOY.md

Part of #293 (ops steps tracked in #295)

Test plan: QA server is live at https://qa.litigantportal.com — verified
health check, HTTPS, and full page load.