### PR TITLE
fix(ui): allow 2-line topic card descriptions

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -285,7 +285,7 @@
 
   .topic-card-description {
     @apply text-sm text-greyscale-500 mt-0.5 m-0;
-    @apply line-clamp-1;
+    @apply line-clamp-2;
   }
 
   .topic-card-arrow {


### PR DESCRIPTION
Topic card helper text was clipped to a single line by `line-clamp-1`, truncating descriptions like "Landlord disputes, eviction defense, tenant rights" mid-phrase. Relax to `line-clamp-2` so the full short description fits without letting a runaway string blow out the grid.

Closes #297

Test plan:
- [x] Home page — all 6 topic card descriptions render fully, no ellipsis
- [x] Row heights stay consistent (grid auto-equalizes)