### PR TITLE
fix(ui): hide user email in header, show generic logged-in state

### DIFF
--- a/portal/tests.py
+++ b/portal/tests.py
@@ -168,10 +168,10 @@ class UserMenuAuthenticatedTests(TestCase):
         )
         self.client.login(username="testuser", password="testpass123")
 
-    def test_header_shows_user_email(self):
-        """Header should display user's email when logged in."""
+    def test_header_does_not_expose_user_email(self):
+        """Header must not render the user's email (PII privacy — #273, #304)."""
         response = self.client.get("/")
-        self.assertContains(response, "test@example.com")
+        self.assertNotContains(response, "test@example.com")
 
     def test_header_shows_sign_out_link(self):
         """Header should show 'Sign out' option when logged in."""

--- a/templates/cotton/molecules/user_menu.html
+++ b/templates/cotton/molecules/user_menu.html
@@ -6,7 +6,7 @@
   <div x-data="userMenu" class="relative {{ class }}" {{ attrs }}>
     <c-atoms.button type="button" variant="ghost" class="!px-3 !py-2 text-sm font-medium" x-on:click="toggle" x-bind:aria-expanded="open" aria-haspopup="true">
     <c-atoms.icon name="user-circle" class="w-6 h-6 text-greyscale-500" />
-    <span class="hidden sm:inline max-w-[140px] truncate">{{ user.email }}</span>
+    <span class="hidden sm:inline">{% trans "You are logged in" %}</span>
     <c-atoms.icon name="chevron-down" style="solid" class="w-4 h-4 text-greyscale-400" />
     </c-atoms.button>
     {# Dropdown menu #}

--- a/templates/cotton/organisms/header.html
+++ b/templates/cotton/organisms/header.html
@@ -110,7 +110,7 @@
       {# Account Section (mobile) #}
       <div class="p-4 border-t border-greyscale-200 sm:hidden">
         {% if user.is_authenticated %}
-          <div class="mb-2 px-1 py-1 text-sm text-greyscale-600 truncate">{{ user.email }}</div>
+          <div class="mb-2 px-1 py-1 text-sm text-greyscale-600">{% trans "You are logged in" %}</div>
           <c-atoms.nav-link icon="arrow-right-start-on-rectangle" href="{% url 'account_logout' %}" icon_bg="bg-greyscale-100" icon_color="text-greyscale-600">{% trans "Sign out" %}</c-atoms.nav-link>
         {% else %}
           <c-atoms.nav-link icon="arrow-right-end-on-rectangle" href="{% url 'account_login' %}" icon_bg="bg-primary-50" icon_color="text-primary-600">{% trans "Sign in" %}</c-atoms.nav-link>


### PR DESCRIPTION
Replace user.email in the header user menu with a translated "You are logged in" label so PII isn't exposed in public spaces (library, court kiosk). The dropdown still has Profile + Sign out, so users can still reach their account. Dropped max-w/truncate since the string is now fixed-length.

This is an interim fix on top of the demo email/password auth — production-grade auth (SSO, etc.) is tracked in #304.

Closes #273
Part of #304

Test plan:
- [ ] Logged in: header shows "You are logged in" (no email) on ≥sm, icon only on mobile
- [ ] Dropdown still opens with Profile + Sign out
- [ ] Logged out: "Sign in" link renders as before