### PR TITLE
fix(ui): enlarge sign-in logo and use logo molecule

### DIFF
--- a/templates/cotton/organisms/auth_layout.html
+++ b/templates/cotton/organisms/auth_layout.html
@@ -1,17 +1,9 @@
-{% load static i18n %}
-
 <c-vars />
 <div class="min-h-dvh flex flex-col items-center justify-center px-4 py-8 bg-greyscale-50 {{ class }}" {{ attrs }}>
   <div class="w-full max-w-md">
     {# Logo #}
     <div class="text-center mb-8">
-      {% trans "Return to home" as return_label %}
-      {% trans "Litigant Portal" as site_name %}
-      <a href="{% url 'portal:home' %}" aria-label="{{ return_label }}">
-        <img src="{% static 'images/logo.svg' %}"
-             alt="{{ site_name }}"
-             class="h-10 mx-auto">
-      </a>
+      <c-molecules.logo size="lg" show_image />
     </div>
     {# Auth Card #}
     <div class="bg-white rounded-xl border border-greyscale-200 p-6 sm:p-8 shadow-sm">


### PR DESCRIPTION
Sign-in screen logo was 40px (hand-rolled `<img>`) — too small for the institutional-trust moment per Jessica's QA feedback. Swap to `<c-molecules.logo size="lg" />` which uses the designated "prominent" variant (60px) and consolidates link semantics/aria-label/hover state into the existing atomic component.

Closes #270

Follow-up: Jessica's second ask (carry court name through all auth pages for institutional trust) is structural — filed as #306.

Test plan:
- [ ] Visit /accounts/login/ — logo renders at 60px, centered, links to home
- [ ] Keyboard: tab to logo shows focus ring; screen reader announces "Litigant Portal - Home"
- [ ] Same verification on /accounts/signup/ and /accounts/password/reset/ (auth_layout is shared)