### PR TITLE
docs: correct local dev URL to http://localhost (no port)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ make docker-shell           # Shell into container
 make docker-down            # Stop containers
 ```
 
+**Dev URL:** `http://localhost` (or `http://portal.localhost`). Caddy runs on port 80 — **not** `:8000`. The `:8000` you'll see in `docker-compose.yml:101` is the container-internal gunicorn port, behind Caddy.
+
 ### Testing & Linting
 
 ```sh

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -19,7 +19,7 @@
 - **Completed:** Docker-first development
   - Removed `dev.sh` in favor of `make docker-dev`
   - PostgreSQL for local development
-  - `portal.localhost:8000` for dev URLs (1Password friendly)
+  - `portal.localhost` for dev URLs (1Password friendly)
 
 - **Completed:** Form components
   - New molecule: `form_field` (label + input + help/error display)

--- a/docs/COMPONENT_LIBRARY.md
+++ b/docs/COMPONENT_LIBRARY.md
@@ -66,7 +66,7 @@ This approach was chosen over Storybook for simplicity and to stay Django-native
 
 ### URL
 
-- Development: http://portal.localhost:8000/style-guide/
+- Development: http://portal.localhost/style-guide/
 - Template: `templates/pages/style_guide.html`
 - View: `portal/views.py::style_guide()`
 
@@ -318,7 +318,7 @@ tailwindcss -i src/css/main.css -o static/css/main.built.css --minify
 **Note:** We use Tailwind v4 with CSS-based configuration. Theme tokens are defined
 in `@theme { }` blocks within `static/css/main.css` - no `tailwind.config.js` needed.
 
-Visit http://portal.localhost:8000/style-guide/ to view component library.
+Visit http://portal.localhost/style-guide/ to view component library.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 ```bash
 cp .env.example .env        # Add your GROQ_API_KEY
 make docker-dev             # Start dev environment
-# Visit: http://portal.localhost:8000/style-guide/
+# Visit: http://portal.localhost/style-guide/
 ```
 
 **Other Commands:**
@@ -36,12 +36,12 @@ make test                   # Run tests
 
 ## URLs (Development)
 
-| URL                                       | Purpose                   |
-| ----------------------------------------- | ------------------------- |
-| http://portal.localhost:8000/             | Dashboard (hero + topics) |
-| http://portal.localhost:8000/chat/        | AI chat interface         |
-| http://portal.localhost:8000/style-guide/ | Component library / guide |
-| http://portal.localhost:8000/admin/       | Django admin              |
+| URL                                  | Purpose                   |
+| ------------------------------------ | ------------------------- |
+| http://portal.localhost/             | Dashboard (hero + topics) |
+| http://portal.localhost/chat/        | AI chat interface         |
+| http://portal.localhost/style-guide/ | Component library / guide |
+| http://portal.localhost/admin/       | Django admin              |
 
 ---
 


### PR DESCRIPTION
## Summary

- Drop stale `:8000` references in `docs/` — Caddy has run the dev stack on port 80 for a while, URLs are `http://localhost` / `http://portal.localhost`
- Add a short **Dev URL** note to `CLAUDE.md` so agents/devs coming fresh to the repo don't default to `:8000`

Closes #308

## Test plan

- [ ] `grep -rn ":8000" docs/ CLAUDE.md` returns no hits (the `docker-compose.yml:101` occurrence is intentional — internal gunicorn port behind Caddy)
- [ ] After merge, auto-deploy runs; no user-facing impact (docs only)