### PR TITLE
docs: add Sandra happy path narrative for ND adult name change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Chat model is configurable via `CHAT_MODEL` env var (LiteLLM format, e.g. `opena
 
 ## Commands
 
-**`make lint` and `make test`** — sandbox restrictions prevent Claude from running them. Always ask the user to run these manually. Never attempt to run them yourself.
+**`make lint`, `make test`, `make pre-commit`** — sandbox restrictions prevent Claude from running them. Always ask the user to run these manually. Never attempt to run them yourself.
 
 ### Local Development (Docker)
 
@@ -99,9 +99,10 @@ Run all hooks manually: `pre-commit run --all-files`
 Always run before commits (especially after rebases or batch edits):
 
 ```bash
-make lint    # Format + lint all code
-make test    # Run test suite
+make pre-commit   # lint → test, short-circuits if lint fails/fixes anything
 ```
+
+Equivalent to `make lint && make test`. If lint auto-fixes files, the target stops before tests — re-stage the changes and re-run. The name mirrors the `pre-commit` hook tool intentionally — same concept, different invocation surface.
 
 ### Template Formatting (Manual Conventions)
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ shell: ## Open Django shell
 lint: ## Lint and format all code (via pre-commit)
 	pre-commit run --all-files
 
+pre-commit: ## Lint then test — stops if lint fails/fixes anything
+	$(MAKE) lint && $(MAKE) test
+
 fmt-check: ## Check template formatting (dry run, no writes)
 	npx prettier --plugin prettier-plugin-django-cotton --parser django-html --check "templates/**/*.html"
 

--- a/docs/happy-path-sandra.md
+++ b/docs/happy-path-sandra.md
@@ -1,0 +1,252 @@
+# Sandra's Happy Path — Litigant Portal Narrative
+
+## Purpose
+
+A concrete, end-to-end story of Sandra's ideal experience in the Litigant Portal (LP). She arrives knowing what she needs, LP guides her from first load through post-order records cascade. This is the **standard track** for North Dakota adult name change — ships as the primary demo for ND. Alex's waiver track ([#312](https://github.com/freelawproject/litigant-portal/issues/312)) branches from here.
+
+Sandra's user story: [#311](https://github.com/freelawproject/litigant-portal/issues/311).
+
+---
+
+## The Story
+
+### First Load
+
+Sandra is at her desk in Bismarck on a weeknight. She's applying for a new passport in her birth name, Sandra Eriksen, and just learned her divorce decree doesn't include the name change — she needs to petition separately. She searched for how to do it, landed confusingly between divorce-decree and standalone paths, and eventually clicked through to the Litigant Portal from the Burleigh County District Court's self-help page.
+
+The portal opens with a clear header: **North Dakota Courts — Adult Name Change**. No triage screen, no "what's going on?" — the topic is already set because she arrived via the court's deep link.
+
+**LP:** "I'll help you get your name legally changed in North Dakota. To figure out the right path, I need to know a few things."
+
+---
+
+### Catching the Misunderstanding
+
+**Sandra:** "How do I change my name back after a divorce in North Dakota?"
+
+**LP:** "Quick first question: is this part of an active divorce case, or are you filing a new petition now that your divorce is finalized?"
+
+**Sandra:** "My divorce was finalized seven months ago. I didn't include a name change in it."
+
+**LP:** "Got it. In that case, you'll file a standalone name change petition — separate from your divorce case. It's its own civil filing in the district court. I'll walk you through it."
+
+_Sandra exhales. She had been worried she'd have to reopen the divorce._
+
+---
+
+### The Track Fork
+
+**LP:** "What are you changing? Your first name, middle name, last name, or some combination?"
+
+**Sandra:** "Just my last name — back to my birth name, Eriksen."
+
+**LP:** "Restoring a last name. In North Dakota, last-name changes require publishing notice in a county newspaper and a 30-day waiting period before a judge can consider your petition. There's a publication waiver available when someone is changing only their first or middle name — but it doesn't apply here, because you're changing your last name. I want to be upfront about that so you know why the timeline looks the way it does."
+
+**Sandra:** "That makes sense."
+
+---
+
+### The Full Picture
+
+**LP:** "Here's the full process end-to-end:
+
+- You'll file **5 forms** at the Burleigh County District Court: Notice of Petition for Name Change, Petition, Declaration, Confidential Information Form, and the proposed Order.
+- **Filing fee: $160.**
+- You'll publish the Notice in a Burleigh County newspaper.
+- Wait **30 days** from the publication date.
+- The judge reviews the petition. An in-person hearing isn't presumptively required but the judge can schedule one.
+- If the judge grants it, you'll receive the Order plus certified copies.
+- Then you'll update your records — Social Security, DMV, passport, and so on.
+- **Budget 6 to 8 weeks minimum** from filing to Order in hand.
+
+Since your passport is what started all this, I'll make sure the sequencing after your Order is right: SSA first, then DMV, then passport. We'll get there."
+
+_The sidebar populates, with a blocker pinned at the top:_
+
+- ⚠️ **Call Burleigh County Clerk of Court about background-check timing**
+- Prepare 5 forms
+- Pay $160 filing fee
+- Publish Notice in Burleigh County newspaper
+- Wait 30 days from publication
+- Possible hearing
+- Receive Order + certified copies
+- Update your records
+
+---
+
+### Surfacing the Facts
+
+**LP:** "A few things worth knowing up front:
+
+- **Fee waivers** exist for low-income filers; here's the ND criteria if you want to see it. Based on what I know, your situation likely doesn't qualify — I just want you to have the information.
+- You'll confirm **US citizenship or permanent residency** as part of the Petition.
+- **Background check timing varies by judge.** Some require it before you file; others order it after. That's why the call to the clerk is step one — we don't want you waiting on a background check you could have started weeks earlier."
+
+_Sandra appreciates the plainness. No one has been this direct with her about the process._
+
+---
+
+### The Clerk Call
+
+**LP:** "Ready to make that call? I can capture notes live while you're on the line if that helps, or you can paste your notes in after — whichever works for you."
+
+**Sandra:** "I'll type as I go."
+
+_LP opens a notes input. Sandra calls the Burleigh County Clerk of Court, asks: "Does the judge require a criminal history background check before I file, or after?"_
+
+**Clerk:** "After. Judge orders it once the petition is filed."
+
+_Sandra types that in. LP updates the sidebar: the blocker is resolved; a new item appears — "Complete court-ordered background check (after filing)."_
+
+---
+
+### Form Preparation
+
+**LP:** "I have most of what I need from our conversation. A few confirmations before I assemble the forms..."
+
+_LP prompts for: current legal name, requested name, date of birth, residential address, length of ND residency, and a brief reason for the change._
+
+**Sandra:** writes "Personal preference — restoring my birth name after divorce."
+
+_LP assembles the 5 forms as a single PDF packet. Opens in a new tab. Sandra scrolls through._
+
+**LP:** "A few ND-specific things to know as you review:
+
+- **Leave the case number blank** — the clerk assigns it when you file.
+- **Do not sign the proposed Order** — only the judge signs that one.
+- Your **Confidential Information Form** contains your date of birth and is sealed under ND Rules of Court; it isn't in the public file.
+
+Everything look right?"
+
+_Sandra reviews. Names, addresses, dates — all correct. She downloads the packet._
+
+---
+
+### Publication
+
+**LP:** "Next: publishing the Notice. You'll send it to a qualifying newspaper in Burleigh County. They handle the legal publication, send you proof when it runs, and that starts the 30-day clock.
+
+Qualifying papers in Burleigh County include the Bismarck Tribune. Contact them for pricing and submission instructions — costs vary by paper and notice length.
+
+Here's the Notice text, pre-filled with your details — copy and paste it into an email to the paper:
+
+> _[pre-filled Notice of Petition for Name Change — petitioner, current name, requested name, case caption placeholder, court info]_
+
+Once they confirm the publication date, tell me and I'll update your deadlines."
+
+_Sandra emails the paper. Two days later, they reply with a publication date. She tells LP. The sidebar hydrates: earliest judge review window opens 30 days after that date. Every downstream date shifts accordingly._
+
+---
+
+### Filing
+
+**LP:** "Once your Notice is in the paper, you'll file the full packet at the Burleigh County District Court Clerk's office. Here's what to bring and what to expect:"
+
+**Court Visit Plan — Sandra Eriksen, Burleigh County Name Change**
+
+- **Where:** Burleigh County Courthouse, Bismarck ND — Clerk of District Court
+- **What to bring:** the signed packet (5 forms), $160 filing fee, photo ID
+- **Payment:** check, money order, or cash accepted at the window; confirm card acceptance with the clerk
+- **What happens:** the clerk stamps your packet, assigns a case number, and files it with the court. The judge will order a background check. Once that comes back and 30 days have passed since publication, the judge reviews your petition.
+- If an in-person hearing is scheduled, you'll receive notice with the date and time.
+
+---
+
+### The Wait
+
+**Sandra files.** She gets her case number. The background check is ordered. Publication has already run. The sidebar now shows three real dates: publication date, earliest judge review, and the next LP reminder.
+
+Thirty days pass. LP fires a reminder in her email: _"Your publication window is complete. If you haven't heard from the court, it's a good time to check in with the clerk for an update on the judge's review."_
+
+A week later, the clerk's office emails: the Order is signed. No hearing was scheduled.
+
+---
+
+### The Order
+
+**LP:** "Your Order is granted. When you go back to the clerk to pick it up, request **at least 3 certified copies** — you'll need them for the records cascade. One thing that catches people: each certified copy needs to have the **Confidential Information Form attached** when you present it to ND Vital Records; without it, they'll reject the update. The clerk handles the attachment when you request certified copies."
+
+_Sandra picks up the copies. She now has proof, on paper, that she is legally Sandra Eriksen._
+
+---
+
+### Post-Order Cascade
+
+**LP:** "Here's the sequence for updating your records. Standard ND ordering — later agencies verify against SSA, so SSA has to go first:"
+
+**Sandra's Records Cascade**
+
+1. **Social Security Administration** — bring a certified copy; SSA updates your record. _[link + what to bring]_
+2. **North Dakota DMV** — once SSA is updated, get your driver's license reissued in your new name. _[link + what to bring]_
+3. **Passport application** — with your new license and a certified copy of the Order, submit your passport application. _[State Department link]_
+4. **Financial accounts** — banks, credit cards, retirement accounts.
+5. **Employer records** — HR, payroll, health insurance enrollment.
+6. **Health insurance** — policy holder name update.
+7. **Home title** — update the deed at the Burleigh County Recorder with a certified copy of the Order.
+8. **Voter registration** — update with the ND Secretary of State.
+
+**LP:** "A few things adjacent to a name change that you may want to look into on your own — not part of the court process, just information:
+
+- A name change may prompt re-execution of your will, power of attorney, and other estate planning instruments. ND Legal Self Help Center has resources."
+
+_LP presents these as facts with links, not as recommendations._
+
+---
+
+### Done
+
+Eight weeks after Sandra started, she has her passport application in, her license reissued, and the cascade mostly done. The LP session is dormant but not gone — the magic link in her email keeps her case accessible if she needs to revisit anything (updating her will, handling her home title, or coming back for another legal matter).
+
+She never created an account. She never had a lawyer. She needed a map — and a tool that knew the map, held her end goal in context throughout, and caught the things she would have missed.
+
+---
+
+## Key LP Touchpoints
+
+| Moment                  | What LP Does                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| First load              | Topic + jurisdiction pre-set via court deep link; no triage friction              |
+| Misunderstanding catch  | Corrects the divorce-decree assumption gently, redirects to standalone petition   |
+| Track fork              | Asks "what are you changing?" (not why); surfaces waiver as a fact when relevant  |
+| Full-picture narration  | End-to-end process up front so Sandra can decide before committing                |
+| Blocker pinning         | Clerk-call blocker stays at top of sidebar until resolved                         |
+| Proactive facts         | Fee waiver, citizenship, background-check timing surfaced as information          |
+| Live note capture       | Offers to capture during the clerk call — no re-entry                             |
+| Form assembly           | Pre-filled PDF packet opens in a new tab for review + download                    |
+| Publication support     | Qualifying papers named; pre-filled Notice text ready to paste                    |
+| Deadline hydration      | Dates are placeholders until real events confirm them, then recompute live        |
+| Certified-copy guidance | Reminds about Confidential Info Form attachment — a known ND Vital Records gotcha |
+| Post-order cascade      | Standard ND sequence; scope-adjacent items surfaced as facts, not recommendations |
+| End-state persistence   | Magic link keeps her case accessible indefinitely; no account required            |
+
+---
+
+## What This Story Is Not
+
+- Not legal advice — LP provides information and helps Sandra understand her options
+- Not auth-gated — account creation never gates the flow; magic link is for state persistence and reminders, not a sign-up wall
+- Not a guarantee of outcome — LP helps Sandra be as prepared as possible but the judge decides
+- Not a replacement for the court self-help center — LP flags handoff points where a person may help more than the tool
+
+---
+
+## Variations to Branch From Here
+
+1. **Alex's waiver track** ([#312](https://github.com/freelawproject/litigant-portal/issues/312)) — first/middle-name-only changes trigger the publication waiver path; 4 forms instead of 5; no 30-day wait; privacy and public-record transparency become first-order concerns
+2. **Other ND counties** — Burleigh specifics swap for Cass, Grand Forks, or Ward; court address, clerk phone, and qualifying papers vary; flow logic identical
+3. **Other states / courts** — topic layer (Adult Name Change) stays; court layer swaps; most ND-specific procedural details (5 forms, $160, 30-day publication) become per-state parameters
+4. **Hybrid path** — no AI; Sandra navigates topic pages, fills forms manually, LP becomes a structured reference
+5. **In-progress resume** — Sandra pauses mid-flow (e.g., waiting on clerk callback) and returns via magic link days later; state and deadlines resume exactly where she left off
+6. **Post-resolution re-entry** — Sandra comes back months later for a separate matter (e.g., updating her will); her case history is available, LP picks up her new need without losing her record
+
+---
+
+## References
+
+- [Sandra user story (#311)](https://github.com/freelawproject/litigant-portal/issues/311) — source of truth for persona facts
+- [Alex user story (#312)](https://github.com/freelawproject/litigant-portal/issues/312) — waiver-track phase-2 stress test
+- [ND Adult Name Change planning log](./nd-name-change-planning-log.md) — architecture decisions, patterns, and open questions
+- [Jane's happy path](./happy-path-jane.md) — template base for comparison
+- [Legal flow overview](./overview-mapped-legal-flow.md) — 9-stage generic flow
+- [AI Tone Guide](./ai-tone-guide.md) — how LP communicates
+- ND Courts Name Change: https://www.ndcourts.gov/legal-self-help/name-change-adult


### PR DESCRIPTION
## Summary

- New `docs/happy-path-sandra.md` — end-to-end narrative of Sandra's ideal LP experience for ND adult name change (standard track, post-divorce, passport-motivated).
- Parallel structure to `happy-path-jane.md` so reviewers can A/B compare the DuPage eviction and ND name-change flows.
- Pairs with the planning log (#319, merged): planning log captures decisions + rationale, this doc shows the decisions playing out in a concrete user story.
- **Piggyback:** small tooling commit adding `make pre-commit` — chains `lint → test` with sub-make recipes so each step gets its own `MAKECMDGOALS` (the test recipe forwards positional args to pytest, which broke the simpler prereq-list form). Included here since it's a 2-file, 7-line change and the doc PR is already the lightest thing in flight.

## Test plan

- [x] Doc-only — no code paths changed
- [x] All cross-references resolve (`nd-name-change-planning-log.md`, `happy-path-jane.md`, `overview-mapped-legal-flow.md`, `ai-tone-guide.md`)
- [x] Issue refs valid (#311, #312)
- [x] `make pre-commit` locally verified — lint clean, tests pass

Part of #311