### PR TITLE
feat(routing): deep-link entry at /t/{court}/{topic}

### DIFF
--- a/chat/services/chat_service.py
+++ b/chat/services/chat_service.py
@@ -30,15 +30,25 @@ class ChatService:
         session_id: str | UUID | None = None,
         agent_name: str | None = None,
         topic: str | None = None,
+        court: str | None = None,
     ):
         self.request = request
         agent_class = agent_registry[agent_name or settings.DEFAULT_CHAT_AGENT]
         agent_kwargs = {}
         if topic:
             agent_kwargs["topic"] = topic
+            # Jurisdiction default (for session storage + backward-compat
+            # composition on resume). Replaced when #179 carries jurisdiction
+            # through the request.
             jurisdiction = self._DEFAULT_JURISDICTION_FOR_TOPIC.get(topic)
             if jurisdiction:
                 agent_kwargs["jurisdiction"] = jurisdiction
+        if court:
+            # Explicit court (from deep-link) wins over the jurisdiction
+            # default in build_system_prompt (explicit ``court`` > mapped
+            # from ``jurisdiction``). Session still stores jurisdiction for
+            # resume-time composition.
+            agent_kwargs["court"] = court
         # Phase is derived from session state inside from_session_id for
         # existing sessions; new sessions default to "triage" there.
         self.agent = agent_class.from_session_id(

--- a/chat/tests/test_chat_session_topic.py
+++ b/chat/tests/test_chat_session_topic.py
@@ -188,3 +188,33 @@ class ChatSessionTopicServiceTests(TestCase):
 
         self.assertIn("ADULT NAME CHANGE", prompt)
         self.assertIn("NORTH DAKOTA", prompt)
+
+    def test_explicit_court_kwarg_composes_court_layer(self):
+        """ChatService accepts an explicit court kwarg (#327 deep-link path)."""
+        from chat.services.chat_service import ChatService
+
+        request = self._make_request()
+        chat = ChatService(request, topic="adult_name_change", court="nd")
+
+        prompt = chat.agent.messages[0]["content"]
+        self.assertIn("ADULT NAME CHANGE", prompt)
+        self.assertIn("NORTH DAKOTA", prompt)
+
+        session = chat.agent.session
+        session.refresh_from_db()
+        self.assertEqual(session.topic, "adult_name_change")
+        # Explicit court flows to jurisdiction storage via backward-compat alias.
+        self.assertEqual(session.jurisdiction, "nd")
+
+    def test_explicit_court_wins_over_topic_default(self):
+        """court kwarg overrides _DEFAULT_JURISDICTION_FOR_TOPIC mapping."""
+        from chat.services.chat_service import ChatService
+
+        request = self._make_request()
+        # eviction's default court is dupage_il; pass court=nd to override.
+        chat = ChatService(request, topic="eviction", court="nd")
+
+        prompt = chat.agent.messages[0]["content"]
+        self.assertIn("EVICTION", prompt)
+        self.assertIn("NORTH DAKOTA", prompt)
+        self.assertNotIn("DUPAGE COUNTY", prompt)

--- a/chat/views.py
+++ b/chat/views.py
@@ -54,6 +54,7 @@ def stream(request: HttpRequest):
     )
     agent_name = request.POST.get("agent_name") or None
     topic = request.POST.get("topic", "").strip() or None
+    court = request.POST.get("court", "").strip() or None
 
     if not message:
         return JsonResponse({"error": _("Message is required")}, status=400)
@@ -70,6 +71,7 @@ def stream(request: HttpRequest):
             session_id=session_id,
             agent_name=agent_name,
             topic=topic,
+            court=court,
         )
         request.session["chat_session_id"] = str(chat.agent.session.id)
         return chat.stream(message)

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -471,6 +471,65 @@ class ChatPageTopicTests(TestCase):
 
 
 # =============================================================================
+# Deep-link Entry Tests (#327)
+# =============================================================================
+
+
+@pytest.mark.postgres
+class DeepLinkTests(TestCase):
+    """Tests for /t/{court}/{topic}/ deep-link entry."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_valid_court_and_topic_redirects_to_chat(self):
+        """Valid pair redirects to /chat/ with both params set."""
+        response = self.client.get("/t/nd/adult_name_change/")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("topic=adult_name_change", response.url)
+        self.assertIn("court=nd", response.url)
+
+    def test_unknown_court_returns_404(self):
+        response = self.client.get("/t/xx/adult_name_change/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_unknown_topic_returns_404(self):
+        response = self.client.get("/t/nd/not_a_topic/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_deep_link_il_eviction(self):
+        """Second registered pair (DuPage/IL + eviction) also works."""
+        response = self.client.get("/t/dupage_il/eviction/")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("topic=eviction", response.url)
+        self.assertIn("court=dupage_il", response.url)
+
+
+@pytest.mark.postgres
+class ChatPageCourtTests(TestCase):
+    """Tests for court parameter handling on /chat/ (#327)."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_valid_court_passes_context(self):
+        response = self.client.get("/chat/?topic=adult_name_change&court=nd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["court_slug"], "nd")
+
+    def test_missing_court_context_is_empty(self):
+        response = self.client.get("/chat/?topic=eviction")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["court_slug"], "")
+
+    def test_unknown_court_context_is_empty(self):
+        """Unknown court on /chat/ silently drops (view is permissive; deep-link is the gatekeeper)."""
+        response = self.client.get("/chat/?topic=eviction&court=made_up")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["court_slug"], "")
+
+
+# =============================================================================
 # Context Processor Tests
 # =============================================================================
 

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path("privacy/", views.privacy, name="privacy"),
     path("accessibility/", views.accessibility, name="accessibility"),
     path("topics/<slug:slug>/", views.topic_detail, name="topic_detail"),
+    path("t/<slug:court>/<slug:topic>/", views.deep_link, name="deep_link"),
     path("chat/", views.chat_page, name="chat"),
     path("chat/action-plan/", action_plan, name="action_plan"),
     path("health/", views.health, name="health"),

--- a/portal/views.py
+++ b/portal/views.py
@@ -1,8 +1,9 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponse
-from django.shortcuts import render
-from django.urls import reverse_lazy
+from django.shortcuts import redirect, render
+from django.urls import reverse, reverse_lazy
+from django.utils.http import urlencode
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, UpdateView
@@ -187,6 +188,8 @@ def topic_detail(request, slug):
 
 def chat_page(request):
     """Chat page - AI-powered legal assistance chat interface."""
+    from chat.prompts import _COURT_PROMPTS, _load_court_prompts
+
     slug = request.GET.get("topic", "").strip()
     topic = TOPICS.get(slug) if slug else None
     topic_context = ""
@@ -195,6 +198,13 @@ def chat_page(request):
         for section in topic["context_sections"]:
             lines.append(f"{section['heading']}: {section['body']}")
         topic_context = "\n".join(lines)
+
+    court_slug = request.GET.get("court", "").strip().lower()
+    if court_slug:
+        _load_court_prompts()
+        if court_slug not in _COURT_PROMPTS:
+            court_slug = ""
+
     return render(
         request,
         "pages/chat.html",
@@ -202,8 +212,35 @@ def chat_page(request):
             "topic": topic,
             "topic_slug": slug if topic else "",
             "topic_context": topic_context,
+            "court_slug": court_slug,
         },
     )
+
+
+def deep_link(request, court, topic):
+    """Deep-link entry: /t/{court}/{topic}/ → chat with both pre-set.
+
+    Validates the pair against the prompt registries. Unknown court or
+    topic returns 404. On success, 302 to /chat/?topic=X&court=Y so the
+    existing chat page handles the heavy lifting.
+    """
+    from chat.prompts import (
+        _COURT_PROMPTS,
+        _TOPIC_PROMPTS,
+        _load_court_prompts,
+        _load_topic_prompts,
+    )
+
+    _load_topic_prompts()
+    _load_court_prompts()
+
+    if topic.lower() not in _TOPIC_PROMPTS:
+        raise Http404(f"Topic '{topic}' not registered")
+    if court.lower() not in _COURT_PROMPTS:
+        raise Http404(f"Court '{court}' not registered")
+
+    query = urlencode({"topic": topic.lower(), "court": court.lower()})
+    return redirect(f"{reverse('portal:chat')}?{query}")
 
 
 def test_agent(request, agent_name):

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -184,6 +184,7 @@ function createChat() {
         if (this.sessionId) formData.append('session_id', this.sessionId)
         if (this.agentName) formData.append('agent_name', this.agentName)
         if (this.topicSlug) formData.append('topic', this.topicSlug)
+        if (this.courtSlug) formData.append('court', this.courtSlug)
 
         const response = await fetch('/api/chat/stream/', {
           method: 'POST',
@@ -421,6 +422,7 @@ function createHomePage() {
 
     // --- Topic state ---
     topicSlug: '',
+    courtSlug: '',
     topicContext: '',
     _topicContextSent: false,
 
@@ -662,6 +664,7 @@ function createHomePage() {
       // Read config from data-* attributes
       this.agentName = this.$el.dataset.agentName || ''
       this.topicSlug = this.$el.dataset.topicSlug || ''
+      this.courtSlug = this.$el.dataset.courtSlug || ''
       const topicContextEl = document.getElementById('topic-context-data')
       this.topicContext = topicContextEl
         ? JSON.parse(topicContextEl.textContent)

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -24,6 +24,7 @@
   <div x-data="homePage"
        data-agent-name="{{ agent_name|default:'' }}"
        data-topic-slug="{{ topic_slug|default:'' }}"
+       data-court-slug="{{ court_slug|default:'' }}"
        class="flex-1 flex flex-row min-h-0">
     {# Hidden file input for PDF upload #}
     <input type="file"


### PR DESCRIPTION
## Summary

Court-partner deep-link surface. ``/t/nd/adult_name_change/`` validates the pair against the prompt registries, 404s on unknown court or topic, and 302s to ``/chat/?topic=X&court=Y`` so the existing chat page handles the render. Court now flows end-to-end:

```
URL /t/{court}/{topic}/
  → deep_link view (validate, 302)
  → /chat/?topic=X&court=Y
  → chat_page view (validate, render)
  → data-court-slug="..." in DOM
  → Alpine reads + POSTs court alongside topic
  → chat/views.py POST handler
  → ChatService(court=...)
  → build_system_prompt(..., court=...)
```

Third user-facing piece of the #310 ND demo stack. Builds on #332 (slug alignment) and #333 (topic grid). First external entry point the ND court can actually embed.

## Changes

- ``portal/urls.py`` — new ``t/<slug:court>/<slug:topic>/`` pattern
- ``portal/views.py`` — new ``deep_link`` view; ``chat_page`` reads ``?court`` and validates against ``_COURT_PROMPTS``
- ``chat/services/chat_service.py`` — accepts explicit ``court`` kwarg; session still stores jurisdiction (2-letter) via the topic default for backward-compat resume
- ``chat/views.py`` — POST handler reads ``court`` and forwards to ``ChatService``
- ``templates/pages/chat.html`` — ``data-court-slug`` passthrough
- ``static/js/chat.js`` — Alpine reads ``courtSlug`` from dataset, POSTs it alongside ``topic``
- ``portal/tests.py`` — 3 deep-link route tests + 3 chat-page court-param tests
- ``chat/tests/test_chat_session_topic.py`` — 2 ChatService composition tests (court kwarg, court-wins-over-default)

## Test plan

- [x] ``make pre-commit`` locally (lint + tests)
- [x] ``/t/nd/adult_name_change/`` 302s with both params
- [x] ``/t/dupage_il/eviction/`` 302s with both params
- [x] ``/t/xx/adult_name_change/`` 404s (unknown court)
- [x] ``/t/nd/not_a_topic/`` 404s (unknown topic)
- [x] Explicit ``court`` wins over the topic default (e.g. ``eviction`` + ``court=nd`` → composes eviction + ND, not eviction + DuPage)
- [x] Post-merge QA smoke: hit ``qa.litigantportal.com/t/nd/adult_name_change/`` from an incognito tab; verify redirect + composed prompt on first message

## Design notes

- Deep-link validates against prompt registries (``_COURT_PROMPTS``, ``_TOPIC_PROMPTS``). Unknown → 404 per planning-log "no silent drops" discipline.
- The ``chat_page`` view stays permissive: unknown ``court`` on ``/chat/`` just empties the context. Deep-link is the gatekeeper; direct ``?court=`` entry is for developer convenience.
- Explicit ``court`` precedence is already the ``build_system_prompt`` behavior (explicit > mapped-from-jurisdiction). The service just needs to pass it through.

## Known follow-up

- **Session resume for non-standard court slugs** — ``ChatSession.jurisdiction`` stores a 2-letter state code. If a user resumes a deep-link session started with ``court=dupage_il``, the session replays with jurisdiction=``il`` and the ``_JURISDICTION_TO_COURT["il"]="dupage_il"`` mapping reconstructs the court. Works today because each state maps to one court. When multiple courts per state exist (e.g., DuPage vs. Cook), we'll need a ``ChatSession.court`` column (separate migration).

Closes #327
Part of #310