### PR TITLE
feat(branding): court name slot in chat sub-header

### DIFF
--- a/chat/prompts/__init__.py
+++ b/chat/prompts/__init__.py
@@ -26,6 +26,7 @@ from chat.prompts.base import BASE_PROMPT
 _PHASE_PROMPTS: dict[str, str] = {}
 _TOPIC_PROMPTS: dict[str, str] = {}
 _COURT_PROMPTS: dict[str, str] = {}
+_COURT_NAMES: dict[str, str] = {}
 
 # Backward-compat: old callers passed jurisdiction (two-letter state code).
 # Map known states to their default court. Additional mappings land here as
@@ -73,6 +74,29 @@ def _load_court_prompts() -> None:
 
     _COURT_PROMPTS["dupage_il"] = dupage_il
     _COURT_PROMPTS["nd"] = nd
+
+
+def _load_court_names() -> None:
+    """Lazy-load court display names into the registry."""
+    if _COURT_NAMES:
+        return
+    from chat.prompts.courts.dupage_il import COURT_NAME as dupage_il_name
+    from chat.prompts.courts.nd import COURT_NAME as nd_name
+
+    _COURT_NAMES["dupage_il"] = dupage_il_name
+    _COURT_NAMES["nd"] = nd_name
+
+
+def get_court_name(court: str | None) -> str:
+    """Return the human-readable display name for a court slug.
+
+    Empty string for unknown or missing slugs — callers should treat empty
+    as "no court branding" and omit the UI slot entirely.
+    """
+    if not court:
+        return ""
+    _load_court_names()
+    return _COURT_NAMES.get(court.lower(), "")
 
 
 def build_system_prompt(

--- a/chat/prompts/courts/dupage_il.py
+++ b/chat/prompts/courts/dupage_il.py
@@ -4,6 +4,8 @@ Jurisdictional content that fills in the Topic layer's abstract framing with
 Illinois statutes, DuPage County logistics, and local Illinois programs.
 """
 
+COURT_NAME = "DuPage County Circuit Court"
+
 PROMPT = """\
 ILLINOIS — DUPAGE COUNTY (18TH JUDICIAL CIRCUIT)
 You are assisting someone whose matter is in Illinois, specifically DuPage \

--- a/chat/prompts/courts/nd.py
+++ b/chat/prompts/courts/nd.py
@@ -5,6 +5,8 @@ Topic layer's abstract framing with ND statutes, specific forms, fees,
 timelines, and procedural details.
 """
 
+COURT_NAME = "North Dakota Courts"
+
 PROMPT = """\
 NORTH DAKOTA
 You are assisting someone whose matter is in North Dakota district court. \

--- a/chat/tests/test_prompts.py
+++ b/chat/tests/test_prompts.py
@@ -6,6 +6,7 @@ from chat.prompts import (
     _VALID_PHASES,
     BASE_PROMPT,
     build_system_prompt,
+    get_court_name,
     phase_for_session,
 )
 
@@ -142,3 +143,25 @@ class PhaseForSessionTests(TestCase):
             resolution = {"status": "granted"}
 
         self.assertEqual(phase_for_session(FakeSession()), "resolve")
+
+
+class CourtNameTests(TestCase):
+    """Tests for get_court_name display-name lookup (#328)."""
+
+    def test_known_court_nd(self):
+        self.assertEqual(get_court_name("nd"), "North Dakota Courts")
+
+    def test_known_court_dupage_il(self):
+        self.assertEqual(
+            get_court_name("dupage_il"), "DuPage County Circuit Court"
+        )
+
+    def test_empty_court_returns_empty(self):
+        self.assertEqual(get_court_name(""), "")
+        self.assertEqual(get_court_name(None), "")
+
+    def test_unknown_court_returns_empty(self):
+        self.assertEqual(get_court_name("not_a_court"), "")
+
+    def test_case_insensitive_lookup(self):
+        self.assertEqual(get_court_name("ND"), "North Dakota Courts")

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -528,6 +528,28 @@ class ChatPageCourtTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["court_slug"], "")
 
+    def test_valid_court_passes_display_name(self):
+        """Chat page with valid court should expose its display name in context."""
+        response = self.client.get("/chat/?topic=adult_name_change&court=nd")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["court_name"], "North Dakota Courts")
+
+    def test_missing_court_display_name_is_empty(self):
+        response = self.client.get("/chat/?topic=eviction")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["court_name"], "")
+
+    def test_court_name_rendered_in_subheader(self):
+        """Template renders the court-branding eyebrow when court_name is set."""
+        response = self.client.get("/chat/?topic=adult_name_change&court=nd")
+        self.assertContains(response, "North Dakota Courts")
+
+    def test_court_name_absent_when_no_court(self):
+        """Template does not render the eyebrow when no court is set."""
+        response = self.client.get("/chat/?topic=eviction")
+        self.assertNotContains(response, "North Dakota Courts")
+        self.assertNotContains(response, "DuPage County Circuit Court")
+
 
 # =============================================================================
 # Context Processor Tests

--- a/portal/views.py
+++ b/portal/views.py
@@ -188,7 +188,11 @@ def topic_detail(request, slug):
 
 def chat_page(request):
     """Chat page - AI-powered legal assistance chat interface."""
-    from chat.prompts import _COURT_PROMPTS, _load_court_prompts
+    from chat.prompts import (
+        _COURT_PROMPTS,
+        _load_court_prompts,
+        get_court_name,
+    )
 
     slug = request.GET.get("topic", "").strip()
     topic = TOPICS.get(slug) if slug else None
@@ -213,6 +217,7 @@ def chat_page(request):
             "topic_slug": slug if topic else "",
             "topic_context": topic_context,
             "court_slug": court_slug,
+            "court_name": get_court_name(court_slug),
         },
     )
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -370,6 +370,10 @@
     @apply text-sm text-greyscale-600 mt-0.5 m-0;
   }
 
+  .court-branding {
+    @apply text-xs font-semibold tracking-wide uppercase text-greyscale-500 m-0 mb-0.5;
+  }
+
   .topic-prompts {
     @apply flex flex-col gap-2 mt-6;
   }

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -330,6 +330,9 @@
                 <c-atoms.icon name="{{ topic.icon }}" class="w-6 h-6" />
               </div>
               <div class="flex-1 min-w-0">
+                {% if court_name %}
+                  <p class="court-branding">{{ court_name }}</p>
+                {% endif %}
                 <h1 class="topic-entry-title">{{ topic.title }}</h1>
                 <p class="topic-entry-subtitle">{{ topic.subtitle }}</p>
               </div>


### PR DESCRIPTION
## Summary

Displays the active court's name as a small eyebrow above the topic title in the chat sub-header — so ``/t/nd/adult_name_change/`` shows ``NORTH DAKOTA COURTS`` above ``Adult Name Change``. Institutional trust: the user knows whose self-service surface they're on.

Fourth user-facing piece of the #310 ND demo stack. Builds on #332 (slugs), #333 (grid), #334 (deep-link).

## Where the name comes from

Each court prompt module exports a ``COURT_NAME`` constant co-located with its ``PROMPT``:

```python
# chat/prompts/courts/nd.py
COURT_NAME = "North Dakota Courts"
PROMPT = """..."""
```

New ``get_court_name(court)`` helper in ``chat.prompts`` does a lazy lookup — same pattern as ``_COURT_PROMPTS``. Unknown / empty slug returns ``""`` so callers can treat empty as "no branding" and omit the UI slot entirely.

## Layout stability

Eyebrow only renders when ``court_name`` is set. Topic-only sessions (grid click, no court) look identical to before. No empty slot, no reflow.

- ``.court-branding`` utility in ``src/css/main.css``: uppercase, small, muted — reads as "context label," not content
- Eyebrow sits inside the existing ``topic-entry-header`` flow so it aligns with the topic title, not with the icon column

## Changes

- ``chat/prompts/courts/{nd,dupage_il}.py`` — add ``COURT_NAME`` constant
- ``chat/prompts/__init__.py`` — new ``_COURT_NAMES`` registry + ``_load_court_names()`` + ``get_court_name()`` helper
- ``portal/views.py`` — ``chat_page`` resolves ``court_name`` and passes to template context
- ``templates/pages/chat.html`` — eyebrow line above topic title, conditional on ``court_name``
- ``src/css/main.css`` — new ``.court-branding`` class token
- Tests: 5 on ``get_court_name`` (known, empty, unknown, case-insensitive), 4 on the view/template (context carries name, eyebrow rendered when set, absent when no court)

## Test plan

- [x] ``make pre-commit`` — lint + tests green
- [x] Topic-only session unchanged (no eyebrow, no layout shift)
- [x] Deep-link ``/t/nd/adult_name_change/`` renders the eyebrow
- [x] Deep-link ``/t/dupage_il/eviction/`` renders ``DuPage County Circuit Court`` eyebrow
- [x] Post-merge QA smoke: visit deep link on QA, confirm visual hierarchy (small muted eyebrow, bold topic title below, subtitle below that)

## Out of scope / follow-ups

- **Per-county branding** (planning log pattern: "Burleigh County District Court" at finer grain). Needs a second lookup key (court + county) and county-level routing. Not demo-critical.
- **Court logo / seal** instead of / alongside the name. Branding-visual follow-up when courts send us assets.
- **Court name elsewhere** (site header next to logo, footer, email templates). Intentionally scoped to the chat page where court context is bound.

Closes #328
Part of #310