### PR TITLE
feat(sidebar): pin urgent-priority blockers with warning affordance

### DIFF
--- a/chat/tests/test_models.py
+++ b/chat/tests/test_models.py
@@ -289,3 +289,54 @@ class ActionItemToDictTests(TestCase):
 
         self.assertIn("completed", result)
         self.assertIs(result["completed"], True)
+
+    def test_to_dict_includes_priority(self):
+        """to_dict() must include the priority field (#329 sidebar pin)."""
+        urgent = ActionItemModel.objects.create(
+            case=self.case, title="Call clerk", priority="urgent"
+        )
+        normal = ActionItemModel.objects.create(
+            case=self.case, title="Gather docs", priority="normal"
+        )
+
+        self.assertEqual(urgent.to_dict()["priority"], "urgent")
+        self.assertEqual(normal.to_dict()["priority"], "normal")
+
+
+class ActionItemOrderingTests(TestCase):
+    """Tests for ActionItemModel default ordering (#329 sidebar pin).
+
+    Urgent items must come before normal items so blockers pin to the
+    top of the sidebar. Within a priority bucket, items sort by title.
+    """
+
+    def setUp(self):
+        self.case = CaseInfo.objects.create(data={})
+
+    def test_urgent_items_come_before_normal(self):
+        ActionItemModel.objects.create(
+            case=self.case, title="Gather documents", priority="normal"
+        )
+        ActionItemModel.objects.create(
+            case=self.case, title="Call clerk", priority="urgent"
+        )
+        ActionItemModel.objects.create(
+            case=self.case, title="Review lease", priority="normal"
+        )
+
+        titles = [item.title for item in self.case.action_items.all()]
+
+        self.assertEqual(titles[0], "Call clerk")
+        self.assertEqual(titles[1:], ["Gather documents", "Review lease"])
+
+    def test_within_priority_sorted_by_title(self):
+        ActionItemModel.objects.create(
+            case=self.case, title="Zebra task", priority="urgent"
+        )
+        ActionItemModel.objects.create(
+            case=self.case, title="Alpha task", priority="urgent"
+        )
+
+        titles = [item.title for item in self.case.action_items.all()]
+
+        self.assertEqual(titles, ["Alpha task", "Zebra task"])

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -70,6 +70,18 @@ class ChatPageTests(TestCase):
         response = self.client.get("/chat/")
         self.assertContains(response, "chat-subheader")
 
+    def test_chat_page_renders_urgent_blocker_affordance(self):
+        """Chat page template must include the urgent blocker warning icon (#329).
+
+        The icon is Alpine-rendered conditionally on ``item.isUrgentOpen``,
+        so the raw template markup is what we assert here — if this
+        exclamation-triangle block is removed, the urgent pin affordance
+        regresses silently.
+        """
+        response = self.client.get("/chat/")
+        self.assertContains(response, "isUrgentOpen")
+        self.assertContains(response, "exclamation-triangle")
+
 
 # =============================================================================
 # Auth Template Tests

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -563,6 +563,10 @@ function createHomePage() {
         isUrgent: item.priority === 'urgent',
         isCompleted: !!item.completed,
         isNotCompleted: !item.completed,
+        // Composed flags for CSP-safe template conditionals — needed
+        // because x-if can't evaluate compound expressions (&&, !).
+        isUrgentOpen: item.priority === 'urgent' && !item.completed,
+        isNormalOpen: item.priority !== 'urgent' && !item.completed,
         dimClass: item.completed ? 'opacity-50' : '',
         bgClass: item.completed
           ? 'bg-greyscale-50 border border-greyscale-200'

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -243,7 +243,13 @@
                   <template x-if="item.isCompleted">
                     <c-atoms.icon name="check-circle" style="solid" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
                   </template>
-                  <template x-if="item.isNotCompleted">
+                  <template x-if="item.isUrgentOpen">
+                    <span class="flex-shrink-0 mt-0.5">
+                      <c-atoms.icon name="exclamation-triangle" style="solid" class="w-4 h-4 text-red-500" />
+                      <span class="sr-only">{% trans "Urgent" %}</span>
+                    </span>
+                  </template>
+                  <template x-if="item.isNormalOpen">
                     <div class="w-4 h-4 rounded-full border-2 flex-shrink-0 mt-0.5"
                          x-bind:class="item.borderClass"></div>
                   </template>


### PR DESCRIPTION
## Summary

Adds the missing visual + a11y affordance for urgent action items in the sidebar: a warning-triangle icon (heroicon ``exclamation-triangle``) with an ``sr-only`` "Urgent" label, replacing the empty-circle indicator for not-completed urgent items. Completes the "Blockers ≠ traps" pattern from the planning log — urgent items now read as blockers at a glance, not just "red not-done items."

Fifth user-facing piece of the #310 ND demo stack. Builds on #332 (slugs), #333 (grid), #334 (deep-link), #336 (court branding).

## What was already there

Investigation surfaced that most of the machinery was in place from #288 and earlier:

- ``ActionItemModel.Meta.ordering = ["-priority", "title"]`` already sorts urgent first (works because "urgent" > "normal" alphabetically descending)
- ``to_dict()`` already includes ``priority`` in the JSON payload
- ``chat.js`` actionItems getter already computes ``isUrgent`` plus priority-aware color classes (``bg-red-50``, ``border-red-400``, ``text-red-800``, ``text-red-600``)

The gap was purely the warning icon + sr-only label. This PR fills it, plus adds regression guards for the bits that would silently break the affordance if touched.

## Changes

- ``static/js/chat.js`` — new composed flags ``isUrgentOpen`` and ``isNormalOpen`` on each action item. CSP build can't evaluate ``&&`` / ``!`` in templates, so the split has to be pre-computed here
- ``templates/pages/chat.html`` — split the existing ``isNotCompleted`` template block into ``isUrgentOpen`` (warning triangle + visually-hidden "Urgent" label) and ``isNormalOpen`` (existing empty circle)
- ``chat/tests/test_models.py`` — ``to_dict`` priority coverage + ordering regression guard (urgent first, within-priority alphabetical by title)
- ``portal/tests.py`` — template-level assertContains for ``isUrgentOpen`` + ``exclamation-triangle`` markers. Alpine renders client-side, so the test guards that the template markup itself doesn't regress

## Test plan

- [x] ``make pre-commit`` — lint + tests green
- [x] Seed case with mixed priorities via shell → visual check in browser: urgent items pinned at top with warning triangle; normal items below with empty circle
- [x] Toggle an urgent item to completed → red treatment + warning triangle collapse cleanly to the completed-style with green check
- [ ] Post-merge QA smoke: deep link into ``/t/nd/adult_name_change/``, cause the AI to emit an urgent action item, verify the sidebar affordance

## Interaction with completed state

When an urgent item is marked complete, the existing completed-style (``bg-greyscale-50``, greyscale strike-through, green check-circle) takes over automatically — the warning triangle disappears because ``isUrgentOpen`` requires not-completed. No jarring reflow, no lingering red treatment. Matches the planning-log "pin shape stays; empty sort bucket collapses cleanly" intent.

## Known follow-ups

- **Completion-aware sort** — currently a completed urgent item still ranks above normal open items (model sort doesn't consider completion). If the demo surfaces it as confusing, add a tertiary sort key ``completed ASC`` to push completed items to the bottom regardless of priority. Not in this PR.
- **Empty-urgent-bucket state** — when all urgents resolve, the sidebar section flows naturally (no empty header, no placeholder). If product wants an explicit "no active blockers" callout, that's its own UX decision.

Closes #329
Part of #310