### PR TITLE
docs(claude): document sprint cadence and naming convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,15 @@ Building a complete eviction flow from discovery to resolution for court partner
 - [User Flows Matrix](docs/user-flows.md) - 3×2 matrix (Full AI / Hybrid / Basic × Anon / Auth)
 - [Retro Notes](docs/itc-demo-retro.md) - Lessons learned from ITC demo (Jan 2026)
 
+## Sprint Cadence & Naming
+
+- Sprints are named after **musical artists**, alphabetical (A → B → C → …).
+- During the sprint-web-team retro, the team votes for the artist who will name the next sprint.
+- Current and previous sprints can be referred to by **letter** OR by the **artist** that won the vote (e.g. "Sprint B" or "Beyoncé").
+- Future sprints (not yet voted on) display by letter only, often with a matching generic emoji — e.g. `B 🐝`, `C 💻`.
+
+Sprint board (`#61`) has letter-coded columns for past, current, and (when planning rolls) future sprints, alongside standard hygiene columns (Ancestors, To Do, In Progress, Buffer Zone, Blocked, In Review, Done, General Backlog, Someday). Brand-new untriaged work goes to **General Backlog** until grooming places it in a sprint column. Don't move issues that are already on the board without direction — placement is intentional.
+
 ## Environment Philosophy
 
 Keep configuration **simple and consistent** across dev, CI/CD, and QA. Docker everywhere.


### PR DESCRIPTION
## Summary

- Adds a `## Sprint Cadence & Naming` section to repo `CLAUDE.md`, placed between Current Focus and Environment Philosophy.
- Documents the band-naming convention (alphabetical, voted at retro by sprint-web-team, letter ↔ artist interchangeable for current/past, letter-only with generic emoji for future).
- Documents board #61 column meaning: letter-coded columns are sprint columns, **not** staging buckets. Brand-new untriaged work goes to **General Backlog** until grooming places it in a sprint column. "Don't move issues already on the board without direction — placement is intentional."
- One-file diff (`CLAUDE.md`, +9 lines).

## Why

Sprint cadence + naming was tribal knowledge. Without this in `CLAUDE.md`, Claude Code (and new contributors) misread `B 🐝` / `C 💻` as staging columns and place new work in the wrong place. Fixing the doc fixes future drift.

## Test plan

- [ ] Render `CLAUDE.md` on GitHub — new section formatted correctly, sits between Current Focus and Environment Philosophy.
- [ ] No surprise diff outside the new section.

Closes #351