### PR TITLE
ci(cd): harden QA deploy with SHA pins, health check, and concurrency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: false
@@ -33,33 +33,38 @@ jobs:
     name: Build, push, deploy to QA
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Serialize main-branch deploys so back-to-back merges don't race the SSH
+    # step. cancel-in-progress=false queues subsequent commits in order.
+    concurrency:
+      group: qa-deploy
+      cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ghcr.io/freelawproject/litigant-portal
           tags: |
             type=raw,value=latest
             type=sha,format=short
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Deploy to QA
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.QA_HOST }}
           username: ${{ secrets.QA_USER }}
@@ -68,3 +73,18 @@ jobs:
             cd /opt/litigant-portal
             docker compose pull django-prod
             docker compose --profile prod up -d --no-build
+
+      - name: Verify deploy
+        # Poll /health/ until 200 or timeout. Fails the workflow if the new
+        # image crash-loops or the container never serves — otherwise GitHub
+        # Actions reports the deploy as successful even when the site is down.
+        run: |
+          for i in {1..30}; do
+            if curl -fsS https://qa.litigantportal.com/health/ > /dev/null; then
+              echo "deploy healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "deploy failed health check"
+          exit 1


### PR DESCRIPTION
## Summary

Three follow-ups from PR #296 review, bundled because they all touch `cd.yml` in the same workflow:

- **SHA pins** (#299) — Pin every third-party action to a full commit SHA with version comment. Tag-move or compromise of an unpinned action would otherwise execute arbitrary code with `QA_SSH_KEY` + `GITHUB_TOKEN`.
- **Health check** (#300) — New `Verify deploy` step polls `/health/` (already at `portal/views.py:169`) for up to 60s after the SSH deploy. Fails the workflow if the new image crash-loops.
- **Concurrency** (#301) — `concurrency: qa-deploy` on the `build-and-deploy` job. Back-to-back main merges queue instead of racing the SSH step. Scoped to the deploy job so PR validation stays parallel.

## Test plan

- [ ] PR triggers the `docker-build` validation job (catches any YAML / pinning errors)
- [ ] On merge: deploy fires, health check polls `qa.litigantportal.com/health/`, succeeds within 60s
- [ ] (Negative) If a follow-up break causes the QA container to crash-loop, the workflow surfaces the failure (previously silent)

Closes #299
Closes #300
Closes #301