### PR TITLE
feat(prompts): topic.json schema with startup validation

### DIFF
--- a/chat/checks.py
+++ b/chat/checks.py
@@ -8,6 +8,9 @@ Currently checks:
 - Every ``chat/prompts/courts/<slug>/court.json`` parses and conforms to
   ``chat/prompts/courts/_schema.json``. Catches typos, missing required
   fields, or schema drift introduced when adding a new partner court.
+- Every ``chat/prompts/topics/<slug>/topic.json`` parses and conforms to
+  ``chat/prompts/topics/_schema.json``. Same shape as the court check;
+  enforces the topic.json sibling that reconciles parallel topic registries.
 """
 
 import json
@@ -18,6 +21,9 @@ from django.core.checks import Error, Tags, register
 
 _COURTS_DIR = Path(__file__).resolve().parent / "prompts" / "courts"
 _SCHEMA_PATH = _COURTS_DIR / "_schema.json"
+
+_TOPICS_DIR = Path(__file__).resolve().parent / "prompts" / "topics"
+_TOPIC_SCHEMA_PATH = _TOPICS_DIR / "_schema.json"
 
 
 @register(Tags.compatibility)
@@ -70,6 +76,62 @@ def check_court_json_schema(app_configs, **kwargs):
                     f"{meta_path}: {err.message} (at {location})",
                     obj=str(meta_path),
                     id="chat.E004",
+                )
+            )
+
+    return errors
+
+
+@register(Tags.compatibility)
+def check_topic_json_schema(app_configs, **kwargs):
+    """Validate every topic.json under chat/prompts/topics/ against the schema."""
+    errors: list[Error] = []
+
+    if not _TOPIC_SCHEMA_PATH.is_file():
+        return [
+            Error(
+                f"Topic schema missing at {_TOPIC_SCHEMA_PATH}",
+                hint="Restore chat/prompts/topics/_schema.json.",
+                id="chat.E005",
+            )
+        ]
+
+    try:
+        schema = json.loads(_TOPIC_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [
+            Error(
+                f"Topic schema at {_TOPIC_SCHEMA_PATH} is invalid JSON: {exc}",
+                id="chat.E006",
+            )
+        ]
+
+    validator = jsonschema.Draft202012Validator(schema)
+
+    for path in sorted(_TOPICS_DIR.iterdir()):
+        if not path.is_dir():
+            continue
+        meta_path = path / "topic.json"
+        if not meta_path.is_file():
+            continue
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(
+                Error(
+                    f"{meta_path}: invalid JSON ({exc})",
+                    obj=str(meta_path),
+                    id="chat.E007",
+                )
+            )
+            continue
+        for err in validator.iter_errors(meta):
+            location = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            errors.append(
+                Error(
+                    f"{meta_path}: {err.message} (at {location})",
+                    obj=str(meta_path),
+                    id="chat.E008",
                 )
             )
 

--- a/chat/prompts/__init__.py
+++ b/chat/prompts/__init__.py
@@ -62,6 +62,7 @@ _PHASE_PROMPTS: dict[str, str] = {}
 _TOPIC_PROMPTS: dict[str, str] = {}
 _COURT_PROMPTS: dict[str, str] = {}
 _COURT_META: dict[str, dict] = {}
+_TOPIC_META: dict[str, dict] = {}
 
 # Backward-compat: old callers passed jurisdiction (two-letter state code).
 # Map known states to their default court. Additional mappings land here as
@@ -217,6 +218,28 @@ def get_court_name(court: str | None) -> str:
         if meta is not None:
             _COURT_META[safe] = meta
     return _COURT_META.get(safe, {}).get("name", "")
+
+
+def get_topic_name(topic: str | None) -> str:
+    """Return the English display name for a topic slug from topic.json.
+
+    Pulls from ``topics/<slug>/topic.json:name`` — the structural source of
+    truth for topic identity. Returns empty string for unknown or missing
+    slugs.
+
+    Note: ``portal/views.py:TOPICS["<slug>"]["title"]`` still holds the
+    translatable display title used by current rendering paths. This helper
+    is the read-site that grounds ``topic.json`` in the codebase; broader
+    consumption follows the i18n-for-JSON consolidation in #377.
+    """
+    safe = _safe_slug(topic)
+    if safe is None:
+        return ""
+    if safe not in _TOPIC_META:
+        meta = _read_topic_meta(safe)
+        if meta is not None:
+            _TOPIC_META[safe] = meta
+    return _TOPIC_META.get(safe, {}).get("name", "")
 
 
 def build_system_prompt(

--- a/chat/prompts/__init__.py
+++ b/chat/prompts/__init__.py
@@ -27,8 +27,8 @@ Each Court and Topic lives in its own directory beneath this module:
           prompt.md     # corpus content
       topics/
         <slug>/
+          topic.json    # identity: name, icon (more fields land with #363)
           prompt.md     # corpus content
-          (topic.json lands with #363 — card display data)
 
 Markdown lets non-engineer contributors edit corpus content via PR. The
 per-court directory matches the eventual wiki tree (#355) so when AI-team
@@ -110,6 +110,23 @@ def _read_court_meta(slug: str) -> dict | None:
         return None
 
 
+def _read_topic_meta(slug: str) -> dict | None:
+    """Read `topics/<slug>/topic.json`. Returns None if missing or unparseable.
+
+    Mirrors `_read_court_meta`: parse errors log a warning rather than
+    crashing the request — the schema check at startup (chat.E007/E008) is
+    the loud signal; this is a graceful runtime fallback.
+    """
+    path = _PROMPTS_DIR / "topics" / slug / "topic.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.warning("Failed to parse topic metadata at %s: %s", path, exc)
+        return None
+
+
 def is_known_topic(slug: str | None) -> bool:
     """True iff a topic prompt is registered for the slug."""
     safe = _safe_slug(slug)
@@ -144,6 +161,31 @@ def iter_courts() -> list[tuple[str, dict]]:
         if not (path / "prompt.md").is_file():
             continue
         meta = _read_court_meta(path.name) or {}
+        out.append((path.name, meta))
+    return out
+
+
+def iter_topics() -> list[tuple[str, dict]]:
+    """Return ``(slug, metadata)`` for every registered topic.
+
+    A topic is registered when ``topics/<slug>/prompt.md`` exists. Metadata
+    comes from ``topics/<slug>/topic.json`` and is validated against
+    ``topics/_schema.json`` at app startup (see ``chat.checks``). Topics
+    without a ``topic.json`` yield an empty dict.
+
+    The schema is intentionally minimal in v1; translatable display copy
+    (subtitle, description, prompts, context_sections) still lives in
+    ``portal/views.py:TOPICS`` so makemessages can extract gettext_lazy
+    strings. See #355 follow-up for the full consolidation plan.
+    """
+    topics_dir = _PROMPTS_DIR / "topics"
+    out: list[tuple[str, dict]] = []
+    for path in sorted(topics_dir.iterdir()):
+        if not path.is_dir():
+            continue
+        if not (path / "prompt.md").is_file():
+            continue
+        meta = _read_topic_meta(path.name) or {}
         out.append((path.name, meta))
     return out
 

--- a/chat/prompts/topics/__init__.py
+++ b/chat/prompts/topics/__init__.py
@@ -8,8 +8,13 @@ lives at `chat.prompts.build_system_prompt`. Topic prompts are reusable
 across courts: when a second jurisdiction adopts the same topic, the Topic
 prompt stays; only the Court prompt changes.
 
-A `<slug>/topic.json` for card display data (title, subtitle, prompts,
-context_sections currently in `portal/views.py:TOPICS`) lands with #363.
+`<slug>/topic.json` carries structural identity for the topic — display
+name and icon today (validated at app startup via `chat.checks`). The
+schema is intentionally minimal in v1; translatable copy (subtitle,
+description, prompts, context_sections) stays in `portal/views.py:TOPICS`
+where `makemessages` can extract `gettext_lazy` strings. Full consolidation
+of TOPICS into topic.json is tracked as a follow-up to #372 once the
+i18n-for-JSON pattern is decided.
 
 When RAG over topic corpus lands, the Topic prompt shrinks to framing
 only; factual content is retrieved dynamically.

--- a/chat/prompts/topics/_schema.json
+++ b/chat/prompts/topics/_schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://litigantportal.com/schemas/topic.json",
+  "title": "Topic",
+  "description": "Structural identity for a legal topic. Lives at chat/prompts/topics/<slug>/topic.json alongside the corpus prompt.md. Schema is intentionally minimal in v1 — translatable display copy (subtitle, description, prompts, context_sections) stays in portal/views.py:TOPICS where Django's i18n pipeline can extract strings via makemessages. Additional structured fields will be driven by partner-court need (court-content overrides #363) and any decision on the JSON-i18n boundary, not preemptive design.",
+  "type": "object",
+  "required": ["name", "icon"],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Display name for the topic (English source). Translatable copy mirroring this currently lives as gettext_lazy strings in portal/views.py:TOPICS until the i18n-for-JSON pattern is decided."
+    },
+    "icon": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "Heroicon identifier rendered on the topic card (e.g. \"home\", \"identification\")."
+    }
+  }
+}

--- a/chat/prompts/topics/adult_name_change/topic.json
+++ b/chat/prompts/topics/adult_name_change/topic.json
@@ -1,0 +1,4 @@
+{
+  "name": "Adult Name Change",
+  "icon": "identification"
+}

--- a/chat/prompts/topics/eviction/topic.json
+++ b/chat/prompts/topics/eviction/topic.json
@@ -1,0 +1,4 @@
+{
+  "name": "Housing & Eviction",
+  "icon": "home"
+}

--- a/chat/tests/test_topic_schema.py
+++ b/chat/tests/test_topic_schema.py
@@ -1,0 +1,171 @@
+"""Tests for the topic.json schema, iter_topics() helper, and the Django
+system check that enforces the schema at app startup (#372)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import jsonschema
+from django.test import TestCase
+
+from chat import checks as chat_checks
+from chat.checks import check_topic_json_schema
+from chat.prompts import _PROMPTS_DIR, iter_topics
+
+TOPICS_DIR = _PROMPTS_DIR / "topics"
+SCHEMA_PATH = TOPICS_DIR / "_schema.json"
+
+
+class TopicSchemaTests(TestCase):
+    """The schema itself, and that every registered topic conforms."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+        cls.validator = jsonschema.Draft202012Validator(cls.schema)
+
+    def test_schema_is_valid_2020_12(self):
+        jsonschema.Draft202012Validator.check_schema(self.schema)
+
+    def test_every_registered_topic_conforms(self):
+        for slug, meta in iter_topics():
+            errors = list(self.validator.iter_errors(meta))
+            self.assertEqual(
+                errors,
+                [],
+                msg=f"{slug}/topic.json failed schema: {[e.message for e in errors]}",
+            )
+
+    def test_required_fields_enforced(self):
+        with self.assertRaises(jsonschema.ValidationError):
+            self.validator.validate({"name": "Eviction"})  # missing icon
+        with self.assertRaises(jsonschema.ValidationError):
+            self.validator.validate({"icon": "home"})  # missing name
+
+    def test_icon_pattern_enforced(self):
+        for bad_icon in ("Home", "home_icon", "home/icon", "home icon", ""):
+            with self.assertRaises(jsonschema.ValidationError):
+                self.validator.validate({"name": "Test", "icon": bad_icon})
+        # Sanity: a well-formed icon passes.
+        self.validator.validate({"name": "Test", "icon": "identification"})
+
+    def test_additional_properties_rejected(self):
+        # additionalProperties: false catches typos and unscoped fields.
+        bad = {"name": "Test", "icon": "home", "badge": "new"}
+        with self.assertRaises(jsonschema.ValidationError):
+            self.validator.validate(bad)
+
+    def test_name_min_length_enforced(self):
+        with self.assertRaises(jsonschema.ValidationError):
+            self.validator.validate({"name": "", "icon": "home"})
+
+
+class IterTopicsTests(TestCase):
+    """Tests for the iter_topics() public helper."""
+
+    def test_returns_known_topics(self):
+        topics = dict(iter_topics())
+        self.assertIn("eviction", topics)
+        self.assertIn("adult_name_change", topics)
+
+    def test_metadata_includes_required_fields(self):
+        for slug, meta in iter_topics():
+            self.assertIn("name", meta, msg=f"{slug} missing name")
+            self.assertIn("icon", meta, msg=f"{slug} missing icon")
+
+    def test_sorted_by_slug(self):
+        slugs = [slug for slug, _ in iter_topics()]
+        self.assertEqual(slugs, sorted(slugs))
+
+
+class TopicJsonCheckTests(TestCase):
+    """Tests for the Django system check that validates topic.json files."""
+
+    def test_check_passes_for_current_state(self):
+        errors = check_topic_json_schema(app_configs=None)
+        self.assertEqual(
+            errors,
+            [],
+            msg=f"Topic schema check failed: {[e.msg for e in errors]}",
+        )
+
+
+class TopicJsonCheckErrorPathTests(TestCase):
+    """Exercise the check function's error-emission paths against fixture
+    dirs. Complements TopicJsonCheckTests, which only proves the green path
+    against the real chat/prompts/topics/ tree."""
+
+    def _run_check_with_fixture(self, topic_json_text: str) -> list:
+        """Set up a temp topics dir with one fake topic whose topic.json
+        contains the given raw text, then run the check against it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            (tmpdir_path / "_schema.json").write_text(
+                SCHEMA_PATH.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            topic_dir = tmpdir_path / "fake-topic"
+            topic_dir.mkdir()
+            (topic_dir / "prompt.md").write_text("placeholder corpus\n")
+            (topic_dir / "topic.json").write_text(
+                topic_json_text, encoding="utf-8"
+            )
+            with (
+                mock.patch.object(chat_checks, "_TOPICS_DIR", tmpdir_path),
+                mock.patch.object(
+                    chat_checks,
+                    "_TOPIC_SCHEMA_PATH",
+                    tmpdir_path / "_schema.json",
+                ),
+            ):
+                return check_topic_json_schema(app_configs=None)
+
+    def test_invalid_json_emits_e007(self):
+        errors = self._run_check_with_fixture("not valid json {")
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "chat.E007")
+        self.assertIn("invalid JSON", errors[0].msg)
+
+    def test_schema_violation_emits_e008(self):
+        # Missing the required icon field.
+        errors = self._run_check_with_fixture(
+            json.dumps({"name": "Fake Topic"})
+        )
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "chat.E008")
+        self.assertIn("icon", errors[0].msg)
+
+    def test_missing_schema_emits_e005(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            with (
+                mock.patch.object(chat_checks, "_TOPICS_DIR", tmpdir_path),
+                mock.patch.object(
+                    chat_checks,
+                    "_TOPIC_SCHEMA_PATH",
+                    tmpdir_path / "missing.json",
+                ),
+            ):
+                errors = check_topic_json_schema(app_configs=None)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "chat.E005")
+
+    def test_invalid_schema_json_emits_e006(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            (tmpdir_path / "_schema.json").write_text(
+                "not valid json {", encoding="utf-8"
+            )
+            with (
+                mock.patch.object(chat_checks, "_TOPICS_DIR", tmpdir_path),
+                mock.patch.object(
+                    chat_checks,
+                    "_TOPIC_SCHEMA_PATH",
+                    tmpdir_path / "_schema.json",
+                ),
+            ):
+                errors = check_topic_json_schema(app_configs=None)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, "chat.E006")

--- a/chat/tests/test_topic_schema.py
+++ b/chat/tests/test_topic_schema.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 
 from chat import checks as chat_checks
 from chat.checks import check_topic_json_schema
-from chat.prompts import _PROMPTS_DIR, iter_topics
+from chat.prompts import _PROMPTS_DIR, get_topic_name, iter_topics
 
 TOPICS_DIR = _PROMPTS_DIR / "topics"
 SCHEMA_PATH = TOPICS_DIR / "_schema.json"
@@ -78,6 +78,28 @@ class IterTopicsTests(TestCase):
     def test_sorted_by_slug(self):
         slugs = [slug for slug, _ in iter_topics()]
         self.assertEqual(slugs, sorted(slugs))
+
+
+class TopicNameTests(TestCase):
+    """Tests for get_topic_name display-name lookup from topic.json."""
+
+    def test_known_topic_eviction(self):
+        self.assertEqual(get_topic_name("eviction"), "Housing & Eviction")
+
+    def test_known_topic_adult_name_change(self):
+        self.assertEqual(
+            get_topic_name("adult_name_change"), "Adult Name Change"
+        )
+
+    def test_empty_topic_returns_empty(self):
+        self.assertEqual(get_topic_name(""), "")
+        self.assertEqual(get_topic_name(None), "")
+
+    def test_unknown_topic_returns_empty(self):
+        self.assertEqual(get_topic_name("not_a_topic"), "")
+
+    def test_case_insensitive_lookup(self):
+        self.assertEqual(get_topic_name("EVICTION"), "Housing & Eviction")
 
 
 class TopicJsonCheckTests(TestCase):


### PR DESCRIPTION
Mirrors the court.json pattern (PR #374) for topics. Each topic dir gets a minimal topic.json carrying display name and icon, validated at app startup so drift fails the deploy rather than degrading silently.

The schema is intentionally minimal in v1 — translatable copy (subtitle, description, prompts, context_sections) stays in `portal/views.py:TOPICS` where makemessages can extract gettext_lazy strings. Full TOPICS consolidation depends on an i18n-for-JSON decision; tracked as #377.

Closes #372. Sub of #355.

## Test plan

- [ ] `make test` — full suite including `chat/tests/test_topic_schema.py`
- [ ] `manage.py check` runs clean against current eviction + adult_name_change topic.json files
- [ ] Mutation check: temporarily drop `icon` from one topic.json — startup check fails with chat.E008