### PR TITLE
ci(cd): trigger QA deploy on push to qa branch instead of main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - qa
 
 permissions:
   contents: read
@@ -27,13 +27,13 @@ jobs:
           push: false
 
   # ---------------------------------------------------------------------------
-  # Main: build, push to GHCR, deploy to QA
+  # qa: build, push to GHCR, deploy to QA
   # ---------------------------------------------------------------------------
   build-and-deploy:
     name: Build, push, deploy to QA
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # Serialize main-branch deploys so back-to-back merges don't race the SSH
+    if: github.event_name == 'push' && github.ref == 'refs/heads/qa'
+    # Serialize qa-branch deploys so back-to-back merges don't race the SSH
     # step. cancel-in-progress=false queues subsequent commits in order.
     concurrency:
       group: qa-deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Keep configuration **simple and consistent** across dev, CI/CD, and QA. Docker e
 | QA/Staging  | OpenAI        | docker-compose prod profile + secrets/     |
 | Production  | OpenAI        | docker-compose.yml + `.env` + secrets/     |
 
-**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to main via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
+**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to `qa` via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
 
 **Local dev setup:**
 
@@ -468,7 +468,7 @@ curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js" -o 
 
 ### QA/Staging
 
-QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to main via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
+QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to `qa` via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
 
 Manual deploy on the QA server: `make docker-rebuild`
 

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -1,6 +1,6 @@
 # QA Environment Setup
 
-One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to main triggers a new Docker image build and deploy via GitHub Actions.
+One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to `qa` triggers a new Docker image build and deploy via GitHub Actions.
 
 ## Architecture
 
@@ -114,7 +114,7 @@ cat ~/.ssh/lp_qa_deploy
 
 ## GHCR Package Visibility
 
-After the first merge to main pushes an image, set the package to public:
+After the first merge to `qa` pushes an image, set the package to public:
 
 1. Go to https://github.com/orgs/freelawproject/packages/container/litigant-portal/settings
 2. Change visibility to **Public**
@@ -145,7 +145,7 @@ docker compose --profile prod up -d --no-build
 
 ## How Deploys Work
 
-1. Developer merges PR to `main`
+1. Developer merges PR to `qa`
 2. GitHub Actions `cd.yml` workflow triggers:
    - Builds Docker image
    - Pushes to GHCR with `latest` + SHA tags


### PR DESCRIPTION
## Summary

Move the QA auto-deploy trigger from `main` to `qa` so QA stops deploying on every `main` merge. Updates the workflow trigger and ref guard in `cd.yml`, plus aligns `docs/QA-DEPLOY.md` and the QA-related sections of `CLAUDE.md` with the new branch model. PR validation (`pull_request:`) is unaffected.

Closes #383

## Test plan

- [ ] Merge PR to `main`
- [ ] Fast-forward `qa` from `main`, push `qa`
- [ ] Confirm `cd.yml` `build-and-deploy` job runs on the `qa` push (not on `main` merge)
- [ ] Confirm `https://qa.litigantportal.com/health/` returns 200 after deploy
- [ ] Sanity-check next `main` merge does NOT trigger `build-and-deploy`