### PR TITLE
feat(header): production-clean header + dev/QA hamburger menu

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 import os
+from datetime import datetime
 from pathlib import Path
 
 from config.secrets import read_secret
@@ -25,6 +26,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 # Defaults to True for development; set DEBUG=false in production
 DEBUG = os.environ.get("DEBUG", "true").lower() not in ("false", "0")
+
+# Deployment environment label. Distinguishes QA from prod (both run DEBUG=false).
+# Used by template context processor to gate non-prod-only UI (build-time chip).
+DEPLOYMENT_ENV = os.environ.get("DEPLOYMENT_ENV", "dev")
+
+# Captured at module import — approximates container/process start time. Shown
+# in the dev/QA header so testers can disambiguate deploys by the minute.
+APP_BUILD_TIME = datetime.now().strftime("%Y/%m/%d %H:%M")
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
@@ -104,6 +113,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "portal.context_processors.toast_messages",
+                "portal.context_processors.app_meta",
             ],
             "builtins": [
                 "django_cotton.templatetags.cotton",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     command: web-dev
     environment:
       - DEBUG=true
+      - DEPLOYMENT_ENV=dev
       - SECRET_KEY=dev
       - POSTGRES_HOST=postgres-dev
       - POSTGRES_PASSWORD=postgres
@@ -87,6 +88,7 @@ services:
     command: web-prod
     environment:
       - DEBUG=false
+      - DEPLOYMENT_ENV=${DEPLOYMENT_ENV:-prod}
       - SECRET_KEY_FILE=/run/secrets/django_secret_key
       - POSTGRES_HOST=postgres-prod
       - POSTGRES_PASSWORD_FILE=/run/secrets/db_password

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -62,6 +62,7 @@ cd /opt/litigant-portal
 cat > .env << 'EOF'
 DOMAIN=qa.litigantportal.com
 ALLOWED_HOSTS=qa.litigantportal.com
+DEPLOYMENT_ENV=qa
 CHAT_ENABLED=true
 CHAT_MODEL=openai/gpt-4o-mini
 EOF

--- a/portal/context_processors.py
+++ b/portal/context_processors.py
@@ -1,4 +1,13 @@
+from django.conf import settings
 from django.contrib.messages import get_messages
+
+
+def app_meta(request):
+    """App-level metadata available in every template."""
+    return {
+        "deployment_env": settings.DEPLOYMENT_ENV,
+        "app_build_time": settings.APP_BUILD_TIME,
+    }
 
 
 def toast_messages(request):

--- a/portal/tests.py
+++ b/portal/tests.py
@@ -10,7 +10,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.management import call_command
 from django.test import Client, RequestFactory, SimpleTestCase, TestCase
 
-from portal.context_processors import toast_messages
+from portal.context_processors import app_meta, toast_messages
 
 User = get_user_model()
 
@@ -675,3 +675,25 @@ class ToastMessagesTests(TestCase):
         result = toast_messages(request)
 
         self.assertEqual(result["toast_messages"][0]["variant"], "warning")
+
+
+class AppMetaTests(SimpleTestCase):
+    """Tests for app_meta context processor."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_exposes_deployment_env_and_build_time(self):
+        from django.conf import settings
+
+        result = app_meta(self.factory.get("/"))
+
+        self.assertEqual(result["deployment_env"], settings.DEPLOYMENT_ENV)
+        self.assertEqual(result["app_build_time"], settings.APP_BUILD_TIME)
+
+    def test_app_build_time_matches_yyyy_mm_dd_hh_mm(self):
+        result = app_meta(self.factory.get("/"))
+
+        self.assertRegex(
+            result["app_build_time"], r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}$"
+        )

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -306,10 +306,6 @@
     @apply max-w-content mx-auto;
   }
 
-  .mobile-header-menu-btn {
-    @apply p-2 -mr-2; /* Extend touch target */
-  }
-
   /* Hero Section */
   .hero {
     @apply px-4 py-8 md:py-12 bg-greyscale-50;

--- a/static/js/components.js
+++ b/static/js/components.js
@@ -31,40 +31,17 @@ document.addEventListener('alpine:init', () => {
   }))
 
   // ===========================================================================
-  // Activity timeline (header slide-out panel)
+  // Dev menu (header dropdown — visible in dev + QA only)
   // ===========================================================================
 
-  Alpine.data('activityTimeline', () => ({
-    menuOpen: false,
-    isLoading: false,
-    timeline: [],
-
-    async openMenu() {
-      this.menuOpen = true
-      this.isLoading = true
-      try {
-        const response = await fetch('/api/chat/case/')
-        if (response.ok) {
-          const data = await response.json()
-          this.timeline = (data.timeline || []).map((e) => ({
-            id: e.id,
-            type: e.event_type,
-            timestamp: e.created_at,
-            title: e.title,
-            content: e.content,
-            metadata: e.metadata,
-          }))
-        }
-      } catch (e) {
-        console.error('Failed to load timeline:', e)
-      } finally {
-        this.isLoading = false
-      }
+  Alpine.data('devMenu', () => ({
+    open: false,
+    toggle() {
+      this.open = !this.open
     },
-    closeMenu() {
-      this.menuOpen = false
+    close() {
+      this.open = false
     },
-
     async resetDemo() {
       const csrfToken =
         document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
@@ -81,57 +58,6 @@ document.addEventListener('alpine:init', () => {
         console.error('Failed to reset demo:', e)
       }
       location.reload()
-    },
-
-    get isLoadingTimeline() {
-      return this.isLoading
-    },
-    get notLoadingTimeline() {
-      return !this.isLoading
-    },
-    get hasTimeline() {
-      return !this.isLoading && this.timeline.length > 0
-    },
-    get noTimeline() {
-      return !this.isLoading && this.timeline.length === 0
-    },
-
-    get reversedTimeline() {
-      return this.timeline
-        .slice()
-        .reverse()
-        .map((event) => ({
-          ...event,
-          borderClass:
-            {
-              upload: 'border-primary-300 bg-primary-50/50',
-              summary: 'border-blue-300 bg-blue-50/50',
-              change: 'border-greyscale-300 bg-greyscale-50',
-            }[event.type] || 'border-greyscale-300 bg-greyscale-50',
-          formattedDate: new Date(event.timestamp).toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            hour: 'numeric',
-            minute: '2-digit',
-          }),
-          isUpload: event.type === 'upload',
-          isSummary: event.type === 'summary',
-          isChange: event.type === 'change',
-        }))
-    },
-  }))
-
-  // ===========================================================================
-  // Timeline event card (nested inside activity timeline)
-  // ===========================================================================
-
-  Alpine.data('timelineEvent', () => ({
-    expanded: false,
-    toggle() {
-      this.expanded = !this.expanded
-    },
-    get clampClass() {
-      return this.expanded ? '' : 'line-clamp-2'
     },
   }))
 

--- a/templates/cotton/organisms/header.html
+++ b/templates/cotton/organisms/header.html
@@ -5,11 +5,18 @@
         class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
         {{ attrs }}>
   <div class="mobile-header-inner">
-    <a href="{% url 'portal:home' %}" aria-label="{% trans "Home" %}">
-      <img src="{% static 'images/logo_powered.svg' %}"
-           alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
-           class="h-12">
-    </a>
+    <div class="flex items-end gap-2">
+      <a href="{% url 'portal:home' %}" aria-label="{% trans "Home" %}">
+        <img src="{% static 'images/logo_powered.svg' %}"
+             alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
+             class="h-12">
+      </a>
+      {% if deployment_env != "prod" %}
+        <span class="text-xs font-medium text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
+          {{ app_build_time }}
+        </span>
+      {% endif %}
+    </div>
     <div class="flex items-center gap-1 sm:gap-2">
       {% if debug %}
         <c-atoms.link href="{% url 'portal:style_guide' %}" variant="unstyled" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-greyscale-600 transition-colors">
@@ -20,10 +27,6 @@
         </c-atoms.button>
       {% endif %}
       <c-molecules.user-menu class="hidden sm:flex" />
-      {% trans "Open activity timeline" as timeline_label %}
-      <c-atoms.button type="button" variant="ghost" aria_label="{{ timeline_label }}" class="mobile-header-menu-btn" x-bind:aria-expanded="menuOpen" x-on:click="openMenu">
-      <c-atoms.icon name="bars-3" class="w-6 h-6" />
-      </c-atoms.button>
     </div>
   </div>
   {# Menu Overlay #}

--- a/templates/cotton/organisms/header.html
+++ b/templates/cotton/organisms/header.html
@@ -1,124 +1,53 @@
 {% load static i18n %}
 
 <c-vars sticky="" />
-<header x-data="activityTimeline"
-        class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
+<header class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
         {{ attrs }}>
   <div class="mobile-header-inner">
-    <div class="flex items-end gap-2">
-      <a href="{% url 'portal:home' %}" aria-label="{% trans "Home" %}">
-        <img src="{% static 'images/logo_powered.svg' %}"
-             alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
-             class="h-12">
-      </a>
-      {% if deployment_env != "prod" %}
-        <span class="text-xs font-medium text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
-          {{ app_build_time }}
-        </span>
-      {% endif %}
-    </div>
+    <a href="{% url 'portal:home' %}" aria-label="{% trans "Home" %}">
+      <img src="{% static 'images/logo_powered.svg' %}"
+           alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
+           class="h-12">
+    </a>
     <div class="flex items-center gap-1 sm:gap-2">
-      {% if debug %}
-        <c-atoms.link href="{% url 'portal:style_guide' %}" variant="unstyled" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-greyscale-600 transition-colors">
-        Style Guide
-        </c-atoms.link>
-        <c-atoms.button type="button" variant="ghost" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-red-500 !p-0" x-on:click="resetDemo">
-        Reset Demo
-        </c-atoms.button>
-      {% endif %}
       <c-molecules.user-menu class="hidden sm:flex" />
+      {% if deployment_env != "prod" %}
+        {% trans "Dev tools" as dev_tools_label %}
+        <div x-data="devMenu" class="relative">
+          <c-atoms.button type="button" variant="ghost" aria_label="{{ dev_tools_label }}" class="!p-2" x-on:click="toggle" x-bind:aria-expanded="open" aria-haspopup="true">
+          <c-atoms.icon name="bars-3" class="w-6 h-6" />
+          </c-atoms.button>
+          <div x-show="open"
+               x-cloak
+               x-on:click.outside="close"
+               x-on:keydown.escape.window="close"
+               x-transition:enter="transition ease-out duration-100"
+               x-transition:enter-start="opacity-0 scale-95"
+               x-transition:enter-end="opacity-100 scale-100"
+               x-transition:leave="transition ease-in duration-75"
+               x-transition:leave-start="opacity-100 scale-100"
+               x-transition:leave-end="opacity-0 scale-95"
+               class="absolute right-0 mt-2 w-max bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
+               role="menu"
+               aria-orientation="vertical">
+            <button type="button" x-on:click="resetDemo" class="flex items-center gap-2 w-full px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Reset Demo" %}
+            </button>
+            <a href="{% url 'portal:style_guide' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="swatch" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Style Guide" %}
+            </a>
+            <a href="https://github.com/freelawproject/litigant-portal/issues/new" target="_blank" rel="noopener" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="chat-bubble-left-ellipsis" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Feedback" %}
+            </a>
+            <div class="border-t border-greyscale-200 mt-1 px-4 py-2 text-xs text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
+              {{ app_build_time }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
-  </div>
-  {# Menu Overlay #}
-  <div x-show="menuOpen"
-       x-cloak
-       class="fixed inset-0 z-50"
-       x-on:keydown.escape.window="closeMenu">
-    {# Backdrop #}
-    <div class="absolute inset-0 bg-black/50"
-         x-on:click="closeMenu"
-         x-show="menuOpen"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0"
-         x-transition:enter-end="opacity-100"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="opacity-100"
-         x-transition:leave-end="opacity-0"></div>
-    {# Menu Panel #}
-    <nav class="absolute right-0 top-0 h-full w-80 bg-white shadow-xl overflow-y-auto"
-         x-show="menuOpen"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="translate-x-full"
-         x-transition:enter-end="translate-x-0"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="translate-x-0"
-         x-transition:leave-end="translate-x-full"
-         role="dialog"
-         aria-modal="true"
-         aria-label="{% trans "Activity timeline" %}">
-      <div class="flex items-center justify-between p-4 border-b border-greyscale-200">
-        <span class="font-semibold text-greyscale-900">{% trans "Activity" %}</span>
-        {% trans "Close menu" as close_label %}
-        <c-atoms.button type="button" variant="ghost" aria_label="{{ close_label }}" class="p-2 -mr-2 text-greyscale-500 hover:text-greyscale-700" x-on:click="closeMenu">
-        <c-atoms.icon name="x-mark" class="w-6 h-6" />
-        </c-atoms.button>
-      </div>
-      {# Timeline - fetches from server when menu opens #}
-      <div class="p-4 space-y-3">
-        {# Loading state #}
-        <template x-if="isLoadingTimeline">
-          <div class="flex items-center justify-center py-8">
-            <c-atoms.icon name="arrow-path" class="w-6 h-6 text-greyscale-400 animate-spin" />
-          </div>
-        </template>
-        {# Empty state #}
-        <template x-if="noTimeline">
-          <div class="text-center py-8">
-            <c-atoms.icon name="clock" class="w-10 h-10 text-greyscale-300 mx-auto mb-3" />
-            <p class="text-sm text-greyscale-500">{% trans "No activity yet" %}</p>
-            <p class="text-xs text-greyscale-400 mt-1">{% trans "Upload documents and chat to see your history here" %}</p>
-          </div>
-        </template>
-        {# Timeline events #}
-        <template x-if="hasTimeline">
-          <div class="space-y-3">
-            <template x-for="event in reversedTimeline" :key="event.id">
-              <div class="p-3 border-l-2 cursor-pointer"
-                   x-data="timelineEvent"
-                   x-on:click="toggle"
-                   x-bind:class="event.borderClass">
-                <div class="flex items-center gap-2 mb-1">
-                  <template x-if="event.isUpload">
-                    <c-atoms.icon name="document-arrow-up" class="w-4 h-4 text-primary-500" />
-                  </template>
-                  <template x-if="event.isSummary">
-                    <c-atoms.icon name="chat-bubble-left-right" class="w-4 h-4 text-blue-500" />
-                  </template>
-                  <template x-if="event.isChange">
-                    <c-atoms.icon name="pencil-square" class="w-4 h-4 text-greyscale-500" />
-                  </template>
-                  <p class="text-xs text-greyscale-500" x-text="event.formattedDate"></p>
-                </div>
-                <p x-show="event.title"
-                   class="text-sm font-medium text-greyscale-800"
-                   x-text="event.title"></p>
-                <p class="text-sm text-greyscale-600 mt-0.5"
-                   x-bind:class="clampClass"
-                   x-text="event.content"></p>
-              </div>
-            </template>
-          </div>
-        </template>
-      </div>
-      {# Account Section (mobile) #}
-      <div class="p-4 border-t border-greyscale-200 sm:hidden">
-        {% if user.is_authenticated %}
-          <div class="mb-2 px-1 py-1 text-sm text-greyscale-600">{% trans "You are logged in" %}</div>
-          <c-atoms.nav-link icon="arrow-right-start-on-rectangle" href="{% url 'account_logout' %}" icon_bg="bg-greyscale-100" icon_color="text-greyscale-600">{% trans "Sign out" %}</c-atoms.nav-link>
-        {% else %}
-          <c-atoms.nav-link icon="arrow-right-end-on-rectangle" href="{% url 'account_login' %}" icon_bg="bg-primary-50" icon_color="text-primary-600">{% trans "Sign in" %}</c-atoms.nav-link>
-        {% endif %}
-      </div>
-    </nav>
   </div>
 </header>

--- a/templates/pages/style_guide.html
+++ b/templates/pages/style_guide.html
@@ -130,10 +130,6 @@
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Auth Status</a>
             </li>
             <li>
-              <a href="#chat-message"
-                 class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Chat Message</a>
-            </li>
-            <li>
               <a href="#timeline-event-card"
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Timeline Event Card</a>
             </li>
@@ -1152,29 +1148,6 @@
               <div class="flex flex-col md:flex-row">
                 <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>slot</code></span>
                 <span class="p-2.5">CTA area — button, link, or form</span>
-              </div>
-            </div>
-          </section>
-          <section id="chat-message" class="mb-12" aria-labelledby="chat-message-heading">
-            <h3 id="chat-message-heading" class="mb-4">Chat Message</h3>
-            <p class="text-greyscale-600 mb-6">Server-rendered chat message bubble with avatar. Used for static/initial message display.</p>
-            <div class="space-y-4 mb-6 max-w-lg">
-              <c-molecules.chat-message role="user" content="I just received an eviction notice. What should I do?" timestamp="2:30 PM" />
-              <c-molecules.chat-message role="assistant" content="I can help you understand your rights. First, what state are you in?" timestamp="2:31 PM" />
-            </div>
-            <h4 class="mt-8">Props</h4>
-            <div class="bg-greyscale-100 rounded-xl p-4 my-3">
-              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>role</code></span>
-                <span class="p-2.5">"user" | "assistant"</span>
-              </div>
-              <div class="flex flex-col md:flex-row border-b border-greyscale-200">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>content</code></span>
-                <span class="p-2.5">Message text (alternative to slot)</span>
-              </div>
-              <div class="flex flex-col md:flex-row">
-                <span class="p-2.5 md:w-48 md:min-w-48 font-medium"><code>timestamp</code></span>
-                <span class="p-2.5">Displayed time string</span>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary

Production-clean header for partners and SRLs; dev/QA tools tucked into a hamburger dropdown only visible when `deployment_env != "prod"`.

**Prod header:** `logo … sign-in`

**Dev/QA header:** `logo … sign-in <hamburger>` with dropdown:

- Reset Demo
- Style Guide
- Feedback (links to GH new-issue)
- — divider —
- Build-time stamp `yyyy/mm/dd hh:mm`

### Plumbing

- New `DEPLOYMENT_ENV` env var (`dev` default, `qa`, `prod`) so we can distinguish QA from prod — both run `DEBUG=false` so `DEBUG` alone wasn't enough. Wired through `docker-compose.yml` per profile, the QA `.env` example, and a new `app_meta` context processor.
- `APP_BUILD_TIME` captured at Django module import via `datetime.now().strftime("%Y/%m/%d %H:%M")` — approximates deploy time within seconds.
- `devMenu` Alpine.data mirrors the existing `userMenu` pattern (open/toggle/close + transitions).
- Orphaned activity-timeline overlay markup + `activityTimeline` / `timelineEvent` Alpine registrations removed — unreachable from the header anyway.

Closes #385

## Commits

- `aa40835` first pass: build-time chip next to logo, hamburger removed
- `c6fe2d0` final landing: hamburger restored as dev/QA dropdown, chip moved into menu

## Iteration notes

The design moved twice during this PR — see #385 for the longer-form story. Short version: started as "version label next to logo + remove hamburger," pivoted to "build-time stamp instead of semver" (more useful for QA disambiguation), then to "production-clean header with all dev/QA tools in a single hamburger dropdown" once we realized the inline `{% if debug %}` links weren't doing partners or SRLs any favors.

## Test plan

- [x] Merge triggers `cd.yml` `build-and-deploy` job (validates new `qa`-branch trigger from #383)
- [x] `https://qa.litigantportal.com/health/` returns 200 after deploy
- [x] Header on `qa.litigantportal.com`: logo, user menu, hamburger button
- [x] Hamburger opens dropdown with Reset Demo, Style Guide, Feedback, build-time stamp
- [x] Reset Demo clears chat state and reloads
- [x] Style Guide link goes to `/style-guide/`
- [x] Feedback link opens the GH new-issue page in a new tab
- [x] Build-time stamp matches roughly when the QA container started serving
- [x] No hamburger button when `DEPLOYMENT_ENV=prod`