### PR TITLE
Add manage cli

### DIFF
--- a/litigant_portal/main.py
+++ b/litigant_portal/main.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "litigant_portal.settings")
+
+application = get_wsgi_application()

--- a/litigant_portal/manage.py
+++ b/litigant_portal/manage.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "litigant_portal.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ test = [
     "tox-uv>=1.29.0",
 ]
 
+[project.scripts]
+manage = "litigant_portal.manage:main"
+
 [tool.setuptools.packages.find]
 include = [ "litigant_portal*" ]
 


### PR DESCRIPTION
Adds `manage.py` to package wired up to package settings. A `main.py` wsgi app entrypoint for gunicorn. And a `manage` helper command installed by pyproject