### PR TITLE
feat(infra): set up issue templates (bug, feature, task) + chooser co…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly
+title: 'fix: '
+labels: ['bug', 'qa-feedback']
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe what you saw and what you expected
+      placeholder: ex. Clicking "Save" did nothing; I expected the form to submit
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See ...
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where did this happen?
+      options:
+        - Production (litigantportal.com)
+        - QA (qa.litigantportal.com)
+        - Local dev
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: 'P0 = fire · P1 = this sprint · P2 = stretch · P3 = eventually'
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: accessibility
+    attributes:
+      label: Accessibility impact (tick if any apply)
+      options:
+        - label: Screen reader
+        - label: Keyboard-only navigation
+        - label: Mobile / small screens
+        - label: Color contrast / visual
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Screenshots, logs, anything else (optional)
+      description: Drag images directly into this box. Wrap log snippets in triple backticks.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: FLP wiki
+    url: https://wiki.free.law/
+    about: Practices, runbooks, decisions
+  - name: GitHub Discussions
+    url: https://github.com/freelawproject/courtlistener/discussions
+    about: Question or open-ended idea? Start a discussion in CourtListener.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,64 @@
+name: Feature
+description: New capability, enhancement, or change to existing behavior
+title: 'feat: '
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Who is affected and why does this matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should we do? Sketches, pseudo-code, or links to references all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope (optional)
+      description: What this issue is NOT trying to do — guards against scope creep.
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of done
+      description: Checklist of acceptance criteria
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: 'P0 = fire · P1 = this sprint · P2 = stretch · P3 = eventually'
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size estimate
+      description: 'XS ≈ 1–2 hr · S ≈ half day · M ≈ 1–2 days · L ≈ 3–4 days · XL → break into sub-issues first'
+      options:
+        - XS
+        - S
+        - M
+        - L
+        - XL
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/qa-round.md
+++ b/.github/ISSUE_TEMPLATE/qa-round.md
@@ -7,7 +7,7 @@ labels: question
 
 QA testing round for the current sprint/milestone.
 
-**QA environment:** https://litigant-portal.nates.ai
+**QA environment:** https://qa.litigantportal.com
 
 ## How to use this issue
 

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,53 @@
+name: Task
+description: Chore, refactor, docs, infra, tech debt, or other non-feature work
+title: 'chore: '
+labels: []
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs to change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: Motivation — bug-prone code, slow tests, drift, missing docs, etc.
+
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of done
+      value: |
+        - [ ]
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: 'P0 = fire · P1 = this sprint · P2 = stretch · P3 = eventually'
+      options:
+        - P0
+        - P1
+        - P2
+        - P3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size estimate
+      description: 'XS ≈ 1–2 hr · S ≈ half day · M ≈ 1–2 days · L ≈ 3–4 days · XL → break into sub-issues first'
+      options:
+        - XS
+        - S
+        - M
+        - L
+        - XL
+    validations:
+      required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,25 @@ Prettier adds `/>` to void HTML elements and self-closing components alike. Foll
 
 **9. Long `class` values.** Tailwind classes stay on one line inside the `class` attribute even when long — don't break a class string across lines. If the element also has many other attributes, the `class` attribute gets its own line in the multi-line format (rule 2), but the value itself stays unbroken.
 
+## Issue creation
+
+New issues use the templates in `.github/ISSUE_TEMPLATE/`. Blank issues are disabled in `config.yml`, so the web UI forces a template; the CLI must opt in explicitly.
+
+| Template         | Title prefix                     | Use for                                                                                      |
+| ---------------- | -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `bug-report.yml` | `fix: `                          | Something broken — includes environment + priority dropdowns + accessibility-impact checkbox |
+| `feature.yml`    | `feat: `                         | New capability or enhancement — out-of-scope + DoD + priority + size                         |
+| `task.yml`       | `chore: `                        | Refactor / docs / infra / tech debt — what + why + DoD + priority + size                     |
+| `qa-round.md`    | `QA: [Month Year] testing round` | Recurring sprint QA artifact (markdown, prose-heavy)                                         |
+
+When filing from the CLI, pass `--template` so dropdowns and required fields are honored:
+
+```bash
+gh issue create --template bug-report.yml
+gh issue create --template feature.yml
+gh issue create --template task.yml
+```
+
 ## Architecture
 
 ### Front-End Principles


### PR DESCRIPTION
…nfig

Adds GitHub Issue Forms (YAML) for bug-report, feature, and task workflows with FLP-specific dropdowns (P0-P3 priority, XS-XL size, accessibility-impact checkbox on bugs). config.yml disables blank issues and points to wiki + Discussions. Fixes stale QA URL in qa-round.md. CLAUDE.md documents the templates and CLI usage.

Closes #388. Part of #432.