### PR TITLE
feat(docker): update references to secrets dir in compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ static/assets/
 # Tailwind CLI binary
 tailwindcss
 
-# Tailwind CLI output (source is static/css/main.css)
+# Tailwind CLI output (source is litigant_portal/app/styles/main.css)
 litigant_portal/app/static/css/main.built.css
 
 # Django collectstatic output

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ install: ## Install Python dependencies (includes Tailwind CSS)
 	.venv/bin/pip install -e ".[dev]"
 
 css: ## Build Tailwind CSS (one-time)
-	tailwindcss -i litigant_portal/app/static/css/main.css -o litigant_portal/app/static/css/main.built.css
+	tailwindcss -i litigant_portal/app/styles/main.css -o litigant_portal/app/static/css/main.built.css
 
 css-watch: ## Watch Tailwind CSS for changes
-	tailwindcss -i src/css/main.css -o static/css/main.built.css --watch
+	tailwindcss -i litigant_portal/app/styles/main.css -o static/css/main.built.css --watch
 
 css-prod: ## Build production CSS (minified)
-	tailwindcss -i src/css/main.css -o static/css/main.built.css --minify
+	tailwindcss -i litigant_portal/app/styles/main.css -o static/css/main.built.css --minify
 
 migrate: ## Run Django migrations
 	source .venv/bin/activate && python manage.py migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@
 #   - Access at http://localhost (port 80 via Caddy)
 #
 # Production: docker compose --profile prod up
-#   - Requires: secrets/django_secret_key.txt, secrets/db_password.txt, secrets/openai_api_key.txt, DOMAIN in .env
+#   - Requires .env file with DOMAIN, ALLOWED_HOSTS, OPENAI_API_KEY, POSTGRES_PASSWORD, SECRET_KEY
 #   - Caddy auto-provisions HTTPS via Let's Encrypt
 
 services:
@@ -41,14 +41,12 @@ services:
     environment:
       - POSTGRES_DB=litigant_portal
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD_FILE=/run/secrets/db_password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s
       timeout: 3s
       retries: 5
-    secrets:
-      - db_password
     volumes:
       # See postgres-dev comment — keep volume name in sync with image tag.
       - postgres_data_prod_pg17:/var/lib/postgresql/data
@@ -92,26 +90,22 @@ services:
     command: web-prod
     environment:
       - DEBUG=false
-      - SECRET_KEY_FILE=/run/secrets/django_secret_key
+      - SECRET_KEY=${SECRET_KEY}
       - POSTGRES_HOST=postgres-prod
-      - POSTGRES_PASSWORD_FILE=/run/secrets/db_password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - ALLOWED_HOSTS=localhost,${ALLOWED_HOSTS:-localhost}
       - GUNICORN_WORKERS=${GUNICORN_WORKERS:-3}
       - GUNICORN_THREADS=${GUNICORN_THREADS:-2}
       # AI Chat configuration
       - CHAT_ENABLED=${CHAT_ENABLED:-true}
       - CHAT_MODEL=${CHAT_MODEL:-openai/gpt-4o-mini}
-      - OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/health/']
       interval: 5s
       timeout: 3s
       start_period: 30s
       retries: 3
-    secrets:
-      - django_secret_key
-      - db_password
-      - openai_api_key
     depends_on:
       postgres-prod:
         condition: service_healthy
@@ -147,17 +141,6 @@ services:
     depends_on:
       django-prod:
         condition: service_healthy
-
-# ---------------------------------------------------------------------------
-# Secrets (create these files locally, never commit them)
-# ---------------------------------------------------------------------------
-secrets:
-  django_secret_key:
-    file: ./secrets/django_secret_key.txt
-  db_password:
-    file: ./secrets/db_password.txt
-  openai_api_key:
-    file: ./secrets/openai_api_key.txt
 
 volumes:
   postgres_data_dev_pg17:

--- a/litigant_portal/app/styles/main.css
+++ b/litigant_portal/app/styles/main.css
@@ -1,7 +1,6 @@
 /**
  * Litigant Portal - Main Stylesheet (Tailwind v4)
  * Based on CourtListener's design system
- * Build: tailwindcss -i static/css/main.css -o static/css/main.built.css
  */
 
 @import 'tailwindcss';

--- a/litigant_portal/app/templates/pages/style_guide.html
+++ b/litigant_portal/app/templates/pages/style_guide.html
@@ -231,7 +231,7 @@
           <section id="colors" class="mb-12" aria-labelledby="colors-heading">
             <h3 id="colors-heading" class="mb-4">Colors</h3>
             <p class="text-greyscale-600 mb-6">
-              Color tokens defined in <code>static/css/main.css</code> via
+              Color tokens defined in <code>litigant_portal/app/styles/main.css</code> via
               Tailwind v4 <code>@theme</code>.
             </p>
             <div class="mb-8">


### PR DESCRIPTION
Fixes #447

Removes the pattern for loading secrets from files in favor of just using env vars.