### PR TITLE
feat(header): build-time chip + dev tools dropdown (replay)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
     command: web-dev
     environment:
       - DEBUG=true
+      - DEPLOYMENT_ENV=dev
       - SECRET_KEY=dev
       - POSTGRES_HOST=postgres-dev
       - POSTGRES_PASSWORD=postgres
@@ -90,6 +91,7 @@ services:
     command: web-prod
     environment:
       - DEBUG=false
+      - DEPLOYMENT_ENV=${DEPLOYMENT_ENV:-prod}
       - SECRET_KEY=${SECRET_KEY}
       - POSTGRES_HOST=postgres-prod
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -63,6 +63,7 @@ cat > .env << 'EOF'
 SECRET_KEY=choose-a-strong-secret-key
 DOMAIN=https://qa.litigantportal.com
 ALLOWED_HOSTS=qa.litigantportal.com
+DEPLOYMENT_ENV=qa
 CHAT_ENABLED=true
 CHAT_MODEL=openai/gpt-4o-mini
 POSTGRES_PASSWORD=choose-a-strong-db-password

--- a/litigant_portal/app/context_processors.py
+++ b/litigant_portal/app/context_processors.py
@@ -1,4 +1,13 @@
+from django.conf import settings
 from django.contrib.messages import get_messages
+
+
+def app_meta(request):
+    """App-level metadata available in every template."""
+    return {
+        "deployment_env": settings.DEPLOYMENT_ENV,
+        "app_build_time": settings.APP_BUILD_TIME,
+    }
 
 
 def toast_messages(request):

--- a/litigant_portal/app/src/main.css
+++ b/litigant_portal/app/src/main.css
@@ -305,10 +305,6 @@
     @apply max-w-content mx-auto;
   }
 
-  .mobile-header-menu-btn {
-    @apply p-2 -mr-2; /* Extend touch target */
-  }
-
   /* Hero Section */
   .hero {
     @apply px-4 py-8 md:py-12 bg-greyscale-50;

--- a/litigant_portal/app/static/js/components.js
+++ b/litigant_portal/app/static/js/components.js
@@ -31,40 +31,17 @@ document.addEventListener('alpine:init', () => {
   }))
 
   // ===========================================================================
-  // Activity timeline (header slide-out panel)
+  // Dev menu (header dropdown — visible in dev + QA only)
   // ===========================================================================
 
-  Alpine.data('activityTimeline', () => ({
-    menuOpen: false,
-    isLoading: false,
-    timeline: [],
-
-    async openMenu() {
-      this.menuOpen = true
-      this.isLoading = true
-      try {
-        const response = await fetch('/api/chat/case/')
-        if (response.ok) {
-          const data = await response.json()
-          this.timeline = (data.timeline || []).map((e) => ({
-            id: e.id,
-            type: e.event_type,
-            timestamp: e.created_at,
-            title: e.title,
-            content: e.content,
-            metadata: e.metadata,
-          }))
-        }
-      } catch (e) {
-        console.error('Failed to load timeline:', e)
-      } finally {
-        this.isLoading = false
-      }
+  Alpine.data('devMenu', () => ({
+    open: false,
+    toggle() {
+      this.open = !this.open
     },
-    closeMenu() {
-      this.menuOpen = false
+    close() {
+      this.open = false
     },
-
     async resetDemo() {
       const csrfToken =
         document.querySelector('[name=csrfmiddlewaretoken]')?.value ||
@@ -81,57 +58,6 @@ document.addEventListener('alpine:init', () => {
         console.error('Failed to reset demo:', e)
       }
       location.reload()
-    },
-
-    get isLoadingTimeline() {
-      return this.isLoading
-    },
-    get notLoadingTimeline() {
-      return !this.isLoading
-    },
-    get hasTimeline() {
-      return !this.isLoading && this.timeline.length > 0
-    },
-    get noTimeline() {
-      return !this.isLoading && this.timeline.length === 0
-    },
-
-    get reversedTimeline() {
-      return this.timeline
-        .slice()
-        .reverse()
-        .map((event) => ({
-          ...event,
-          borderClass:
-            {
-              upload: 'border-primary-300 bg-primary-50/50',
-              summary: 'border-blue-300 bg-blue-50/50',
-              change: 'border-greyscale-300 bg-greyscale-50',
-            }[event.type] || 'border-greyscale-300 bg-greyscale-50',
-          formattedDate: new Date(event.timestamp).toLocaleDateString('en-US', {
-            month: 'short',
-            day: 'numeric',
-            hour: 'numeric',
-            minute: '2-digit',
-          }),
-          isUpload: event.type === 'upload',
-          isSummary: event.type === 'summary',
-          isChange: event.type === 'change',
-        }))
-    },
-  }))
-
-  // ===========================================================================
-  // Timeline event card (nested inside activity timeline)
-  // ===========================================================================
-
-  Alpine.data('timelineEvent', () => ({
-    expanded: false,
-    toggle() {
-      this.expanded = !this.expanded
-    },
-    get clampClass() {
-      return this.expanded ? '' : 'line-clamp-2'
     },
   }))
 

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -5,11 +5,18 @@
         class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
         {{ attrs }}>
   <div class="mobile-header-inner">
-    <a href="{% url 'pages:home' %}" aria-label="{% trans "Home" %}">
-      <img src="{% static 'images/logo_powered.svg' %}"
-           alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
-           class="h-12">
-    </a>
+    <div class="flex items-end gap-2">
+      <a href="{% url 'pages:home' %}" aria-label="{% trans "Home" %}">
+        <img src="{% static 'images/logo_powered.svg' %}"
+             alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
+             class="h-12">
+      </a>
+      {% if deployment_env != "prod" %}
+        <span class="text-xs font-medium text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
+          {{ app_build_time }}
+        </span>
+      {% endif %}
+    </div>
     <div class="flex items-center gap-1 sm:gap-2">
       {% if debug %}
         <c-atoms.link href="{% url 'pages:style_guide' %}" variant="unstyled" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-greyscale-600 transition-colors">
@@ -20,10 +27,6 @@
         </c-atoms.button>
       {% endif %}
       <c-molecules.user-menu class="hidden sm:flex" />
-      {% trans "Open activity timeline" as timeline_label %}
-      <c-atoms.button type="button" variant="ghost" aria_label="{{ timeline_label }}" class="mobile-header-menu-btn" x-bind:aria-expanded="menuOpen" x-on:click="openMenu">
-      <c-atoms.icon name="bars-3" class="w-6 h-6" />
-      </c-atoms.button>
     </div>
   </div>
   {# Menu Overlay #}

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -1,124 +1,53 @@
 {% load static i18n %}
 
 <c-vars sticky="" />
-<header x-data="activityTimeline"
-        class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
+<header class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
         {{ attrs }}>
   <div class="mobile-header-inner">
-    <div class="flex items-end gap-2">
-      <a href="{% url 'pages:home' %}" aria-label="{% trans "Home" %}">
-        <img src="{% static 'images/logo_powered.svg' %}"
-             alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
-             class="h-12">
-      </a>
-      {% if deployment_env != "prod" %}
-        <span class="text-xs font-medium text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
-          {{ app_build_time }}
-        </span>
-      {% endif %}
-    </div>
+    <a href="{% url 'pages:home' %}" aria-label="{% trans "Home" %}">
+      <img src="{% static 'images/logo_powered.svg' %}"
+           alt="{% trans "Litigant Portal – Powered by Free Law Project" %}"
+           class="h-12">
+    </a>
     <div class="flex items-center gap-1 sm:gap-2">
-      {% if debug %}
-        <c-atoms.link href="{% url 'pages:style_guide' %}" variant="unstyled" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-greyscale-600 transition-colors">
-        Style Guide
-        </c-atoms.link>
-        <c-atoms.button type="button" variant="ghost" class="hidden sm:inline-flex text-xs font-medium text-greyscale-400 hover:text-red-500 !p-0" x-on:click="resetDemo">
-        Reset Demo
-        </c-atoms.button>
-      {% endif %}
       <c-molecules.user-menu class="hidden sm:flex" />
+      {% if deployment_env != "prod" %}
+        {% trans "Dev tools" as dev_tools_label %}
+        <div x-data="devMenu" class="relative">
+          <c-atoms.button type="button" variant="ghost" aria_label="{{ dev_tools_label }}" class="!p-2" x-on:click="toggle" x-bind:aria-expanded="open" aria-haspopup="true">
+          <c-atoms.icon name="bars-3" class="w-6 h-6" />
+          </c-atoms.button>
+          <div x-show="open"
+               x-cloak
+               x-on:click.outside="close"
+               x-on:keydown.escape.window="close"
+               x-transition:enter="transition ease-out duration-100"
+               x-transition:enter-start="opacity-0 scale-95"
+               x-transition:enter-end="opacity-100 scale-100"
+               x-transition:leave="transition ease-in duration-75"
+               x-transition:leave-start="opacity-100 scale-100"
+               x-transition:leave-end="opacity-0 scale-95"
+               class="absolute right-0 mt-2 w-max bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
+               role="menu"
+               aria-orientation="vertical">
+            <button type="button" x-on:click="resetDemo" class="flex items-center gap-2 w-full px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Reset Demo" %}
+            </button>
+            <a href="{% url 'pages:style_guide' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="swatch" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Style Guide" %}
+            </a>
+            <a href="https://github.com/freelawproject/litigant-portal/issues/new" target="_blank" rel="noopener" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="chat-bubble-left-ellipsis" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Feedback" %}
+            </a>
+            <div class="border-t border-greyscale-200 mt-1 px-4 py-2 text-xs text-greyscale-400 tabular-nums" aria-label="{% trans "Build time" %}">
+              {{ app_build_time }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
-  </div>
-  {# Menu Overlay #}
-  <div x-show="menuOpen"
-       x-cloak
-       class="fixed inset-0 z-50"
-       x-on:keydown.escape.window="closeMenu">
-    {# Backdrop #}
-    <div class="absolute inset-0 bg-black/50"
-         x-on:click="closeMenu"
-         x-show="menuOpen"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0"
-         x-transition:enter-end="opacity-100"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="opacity-100"
-         x-transition:leave-end="opacity-0"></div>
-    {# Menu Panel #}
-    <nav class="absolute right-0 top-0 h-full w-80 bg-white shadow-xl overflow-y-auto"
-         x-show="menuOpen"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="translate-x-full"
-         x-transition:enter-end="translate-x-0"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-start="translate-x-0"
-         x-transition:leave-end="translate-x-full"
-         role="dialog"
-         aria-modal="true"
-         aria-label="{% trans "Activity timeline" %}">
-      <div class="flex items-center justify-between p-4 border-b border-greyscale-200">
-        <span class="font-semibold text-greyscale-900">{% trans "Activity" %}</span>
-        {% trans "Close menu" as close_label %}
-        <c-atoms.button type="button" variant="ghost" aria_label="{{ close_label }}" class="p-2 -mr-2 text-greyscale-500 hover:text-greyscale-700" x-on:click="closeMenu">
-        <c-atoms.icon name="x-mark" class="w-6 h-6" />
-        </c-atoms.button>
-      </div>
-      {# Timeline - fetches from server when menu opens #}
-      <div class="p-4 space-y-3">
-        {# Loading state #}
-        <template x-if="isLoadingTimeline">
-          <div class="flex items-center justify-center py-8">
-            <c-atoms.icon name="arrow-path" class="w-6 h-6 text-greyscale-400 animate-spin" />
-          </div>
-        </template>
-        {# Empty state #}
-        <template x-if="noTimeline">
-          <div class="text-center py-8">
-            <c-atoms.icon name="clock" class="w-10 h-10 text-greyscale-300 mx-auto mb-3" />
-            <p class="text-sm text-greyscale-500">{% trans "No activity yet" %}</p>
-            <p class="text-xs text-greyscale-400 mt-1">{% trans "Upload documents and chat to see your history here" %}</p>
-          </div>
-        </template>
-        {# Timeline events #}
-        <template x-if="hasTimeline">
-          <div class="space-y-3">
-            <template x-for="event in reversedTimeline" :key="event.id">
-              <div class="p-3 border-l-2 cursor-pointer"
-                   x-data="timelineEvent"
-                   x-on:click="toggle"
-                   x-bind:class="event.borderClass">
-                <div class="flex items-center gap-2 mb-1">
-                  <template x-if="event.isUpload">
-                    <c-atoms.icon name="document-arrow-up" class="w-4 h-4 text-primary-500" />
-                  </template>
-                  <template x-if="event.isSummary">
-                    <c-atoms.icon name="chat-bubble-left-right" class="w-4 h-4 text-blue-500" />
-                  </template>
-                  <template x-if="event.isChange">
-                    <c-atoms.icon name="pencil-square" class="w-4 h-4 text-greyscale-500" />
-                  </template>
-                  <p class="text-xs text-greyscale-500" x-text="event.formattedDate"></p>
-                </div>
-                <p x-show="event.title"
-                   class="text-sm font-medium text-greyscale-800"
-                   x-text="event.title"></p>
-                <p class="text-sm text-greyscale-600 mt-0.5"
-                   x-bind:class="clampClass"
-                   x-text="event.content"></p>
-              </div>
-            </template>
-          </div>
-        </template>
-      </div>
-      {# Account Section (mobile) #}
-      <div class="p-4 border-t border-greyscale-200 sm:hidden">
-        {% if user.is_authenticated %}
-          <div class="mb-2 px-1 py-1 text-sm text-greyscale-600">{% trans "You are logged in" %}</div>
-          <c-atoms.nav-link icon="arrow-right-start-on-rectangle" href="{% url 'account_logout' %}" icon_bg="bg-greyscale-100" icon_color="text-greyscale-600">{% trans "Sign out" %}</c-atoms.nav-link>
-        {% else %}
-          <c-atoms.nav-link icon="arrow-right-end-on-rectangle" href="{% url 'account_login' %}" icon_bg="bg-primary-50" icon_color="text-primary-600">{% trans "Sign in" %}</c-atoms.nav-link>
-        {% endif %}
-      </div>
-    </nav>
   </div>
 </header>

--- a/litigant_portal/app/tests/test_context_processors.py
+++ b/litigant_portal/app/tests/test_context_processors.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.test import RequestFactory, SimpleTestCase
+
+from litigant_portal.app.context_processors import app_meta
+
+
+class AppMetaTests(SimpleTestCase):
+    """Tests for app_meta context processor."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_exposes_deployment_env_and_build_time(self):
+        result = app_meta(self.factory.get("/"))
+
+        self.assertEqual(result["deployment_env"], settings.DEPLOYMENT_ENV)
+        self.assertEqual(result["app_build_time"], settings.APP_BUILD_TIME)
+
+    def test_app_build_time_matches_yyyy_mm_dd_hh_mm(self):
+        result = app_meta(self.factory.get("/"))
+
+        self.assertRegex(
+            result["app_build_time"], r"^\d{4}/\d{2}/\d{2} \d{2}:\d{2}$"
+        )

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from pathlib import Path
 
 from django.core.management.utils import get_random_secret_key
@@ -6,6 +7,14 @@ from django.core.management.utils import get_random_secret_key
 BASE_DIR = Path(__file__).resolve().parent
 
 DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
+
+# Deployment environment label. Distinguishes QA from prod (both run DEBUG=false).
+# Used by template context processor to gate non-prod-only UI (build-time chip).
+DEPLOYMENT_ENV = os.environ.get("DEPLOYMENT_ENV", "dev")
+
+# Captured at module import — approximates container/process start time. Shown
+# in the dev/QA header so testers can disambiguate deploys by the minute.
+APP_BUILD_TIME = datetime.now().strftime("%Y/%m/%d %H:%M")
 
 SECRET_KEY = os.environ.get("SECRET_KEY") or get_random_secret_key()
 
@@ -62,6 +71,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 # "portal.context_processors.toast_messages",
+                "litigant_portal.app.context_processors.app_meta",
             ],
             "builtins": [
                 "django_cotton.templatetags.cotton",

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
 
 from django.core.management.utils import get_random_secret_key
+
+logger = logging.getLogger(__name__)
 
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -10,7 +13,14 @@ DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
 
 # Deployment environment label. Distinguishes QA from prod (both run DEBUG=false).
 # Used by template context processor to gate non-prod-only UI (build-time chip).
+# Invalid values are kept as-is (fail-closed: non-prod UI won't match and stays hidden).
 DEPLOYMENT_ENV = os.environ.get("DEPLOYMENT_ENV", "dev")
+if DEPLOYMENT_ENV not in {"dev", "qa", "prod"}:
+    logger.warning(
+        "DEPLOYMENT_ENV=%r is not one of {'dev', 'qa', 'prod'}; "
+        "non-prod UI gates may not behave as expected.",
+        DEPLOYMENT_ENV,
+    )
 
 # Captured at module import — approximates container/process start time. Shown
 # in the dev/QA header so testers can disambiguate deploys by the minute.


### PR DESCRIPTION
Replays qa \`aa40835\`, \`c6fe2d0\`, \`0017cc1\` (originally [PR #386](https://github.com/freelawproject/litigant-portal/pull/386) + direct-to-qa follow-up; closed #385) onto \`main\` after Nathan's V2 refactor.

- Build-time chip + \`DEPLOYMENT_ENV\` env var, gated to dev/QA via new \`app_meta\` context processor.
- Dev tools (Reset Demo / Style Guide / Feedback / build chip) moved from inline header into a hamburger dropdown.
- Validates \`DEPLOYMENT_ENV \in {dev, qa, prod}\` with a fail-closed warning on misconfig.

**Path-ports:** \`config/settings.py\` → \`litigant_portal/settings.py\`; \`portal/context_processors.py\` → \`litigant_portal/app/context_processors.py\`; \`portal/tests.py\` (AppMetaTests) → new \`litigant_portal/app/tests/test_context_processors.py\`; template / static / src paths under \`litigant_portal/app/\`; URL namespace \`portal:\` → \`pages:\`. The \`__contains__\` underscore-rename from \`0017cc1\` was dropped (the \`AllIPs\` helper doesn't exist on main).