### PR TITLE
ci(cd): trigger QA deploy on push to main instead of qa branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - qa
+      - main
 
 permissions:
   contents: read
@@ -28,14 +28,14 @@ jobs:
           push: false
 
   # ---------------------------------------------------------------------------
-  # qa: build, push to GHCR, deploy to QA
+  # main: build, push to GHCR, deploy to QA
   # ---------------------------------------------------------------------------
   build-and-deploy:
     name: Build, push, deploy to QA
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/qa'
-    # Serialize qa-branch deploys so back-to-back merges don't race the SSH
-    # step. cancel-in-progress=false queues subsequent commits in order.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Serialize deploys so back-to-back merges don't race the SSH step.
+    # cancel-in-progress=false queues subsequent commits in order.
     concurrency:
       group: qa-deploy
       cancel-in-progress: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Keep configuration **simple and consistent** across dev, CI/CD, and QA. Docker e
 | QA/Staging  | OpenAI        | docker-compose prod profile        |
 | Production  | OpenAI        | docker-compose.yml + `.env`        |
 
-**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to `qa` via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
+**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to `main` via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
 
 **Local dev setup:**
 
@@ -514,7 +514,7 @@ curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js" -o 
 
 ### QA/Staging
 
-QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to `qa` via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
+QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to `main` via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
 
 Manual deploy on the QA server: `make docker-rebuild`
 

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -1,6 +1,6 @@
 # QA Environment Setup
 
-One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to `qa` triggers a new Docker image build and deploy via GitHub Actions.
+One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to `main` triggers a new Docker image build and deploy via GitHub Actions.
 
 ## Architecture
 
@@ -108,7 +108,7 @@ cat ~/.ssh/lp_qa_deploy
 
 ## GHCR Package Visibility
 
-After the first merge to `qa` pushes an image, set the package to public:
+After the first merge to `main` pushes an image, set the package to public:
 
 1. Go to https://github.com/orgs/freelawproject/packages/container/litigant-portal/settings
 2. Change visibility to **Public**


### PR DESCRIPTION
Reverses \`fc4903c\`. Main is the integration target now; \`qa\` is a tombstone — without this, qa.litigantportal.com stops getting fresh images.

Edits: workflow trigger (\`push: qa\` → \`push: main\`), gating if-condition (\`refs/heads/qa\` → \`refs/heads/main\`), and the prose in CLAUDE.md + docs/QA-DEPLOY.md.

Closes #456