### PR TITLE
feat(topic-flow): downloadable .vcf from a Contact

### DIFF
--- a/litigant_portal/app/tests/test_topic_flow_artifacts.py
+++ b/litigant_portal/app/tests/test_topic_flow_artifacts.py
@@ -1,0 +1,118 @@
+"""Tests for Topic Flow artifact generation + the download view.
+
+The generator (`contact_to_vcard`) is pure and tested directly; the result is
+parsed back with vobject so assertions ride on field values, not on brittle
+serialized-text formatting. The view is exercised through the Django test
+client with the module-level registry monkeypatched onto a fixture corpus.
+"""
+
+from pathlib import Path
+
+import vobject
+from django.urls import reverse
+
+from litigant_portal.app.topic_flow.artifacts import contact_to_vcard
+from litigant_portal.app.topic_flow.registry import CorpusRegistry
+from litigant_portal.app.topic_flow.schema import Contact
+
+FIXTURE = Path(__file__).resolve().parents[2] / "content" / "_test_fixture.yml"
+FIXTURE_KEY = ("test-court", "test_topic", "petitioner")
+
+
+def _contact(**overrides):
+    base = {"id": "clerk", "name": "Test County Clerk"}
+    base.update(overrides)
+    return Contact(**base)
+
+
+# --- generator: field mapping --------------------------------------------
+
+
+def test_vcard_is_wellformed_with_name():
+    card = vobject.readOne(contact_to_vcard(_contact()))
+    assert card.fn.value == "Test County Clerk"
+
+
+def test_vcard_includes_every_present_field():
+    contact = _contact(
+        phone="701-555-0100",
+        email="clerk@example.gov",
+        url="https://example.gov/clerk",
+        address="100 Courthouse Square, Test City",
+        note="Call before filing.",
+    )
+    card = vobject.readOne(contact_to_vcard(contact))
+    assert card.tel.value == "701-555-0100"
+    assert card.email.value == "clerk@example.gov"
+    assert card.url.value == "https://example.gov/clerk"
+    assert card.adr.value.street == "100 Courthouse Square, Test City"
+    assert card.note.value == "Call before filing."
+
+
+def test_vcard_omits_absent_fields():
+    # Name only — no phone/email/url/address/note set.
+    card = vobject.readOne(contact_to_vcard(_contact()))
+    assert "tel" not in card.contents
+    assert "email" not in card.contents
+    assert "url" not in card.contents
+    assert "adr" not in card.contents
+    assert "note" not in card.contents
+
+
+def test_vcard_phone_without_email_emits_only_tel():
+    card = vobject.readOne(contact_to_vcard(_contact(phone="701-555-0100")))
+    assert card.tel.value == "701-555-0100"
+    assert "email" not in card.contents
+
+
+# --- download view --------------------------------------------------------
+
+
+def _patch_registry(monkeypatch, tmp_path):
+    """Point the view's registry at a fixture corpus (renamed so it indexes)."""
+    (tmp_path / "real.yml").write_text(
+        FIXTURE.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "litigant_portal.app.views.pages.registry",
+        CorpusRegistry(content_dir=tmp_path),
+    )
+
+
+def _vcard_url(contact_id="clerk", key=FIXTURE_KEY):
+    court, topic, role = key
+    return reverse(
+        "pages:contact_vcard",
+        kwargs={
+            "court": court,
+            "topic": topic,
+            "role": role,
+            "contact_id": contact_id,
+        },
+    )
+
+
+def test_view_returns_vcard_attachment(client, monkeypatch, tmp_path):
+    _patch_registry(monkeypatch, tmp_path)
+    response = client.get(_vcard_url())
+    assert response.status_code == 200
+    assert response["Content-Type"].startswith("text/vcard")
+    assert (
+        response["Content-Disposition"] == 'attachment; filename="clerk.vcf"'
+    )
+    card = vobject.readOne(response.content.decode())
+    assert card.tel.value == "701-555-0100"
+
+
+def test_view_404_for_unknown_corpus(client, monkeypatch, tmp_path):
+    _patch_registry(monkeypatch, tmp_path)
+    response = client.get(
+        _vcard_url(key=("no-court", "no_topic", "petitioner"))
+    )
+    assert response.status_code == 404
+
+
+def test_view_404_for_unknown_contact(client, monkeypatch, tmp_path):
+    _patch_registry(monkeypatch, tmp_path)
+    response = client.get(_vcard_url(contact_id="ghost"))
+    assert response.status_code == 404

--- a/litigant_portal/app/topic_flow/artifacts.py
+++ b/litigant_portal/app/topic_flow/artifacts.py
@@ -1,0 +1,39 @@
+"""Generate downloadable artifacts from corpus data.
+
+Currently: a vCard (``.vcf``) from a :class:`Contact` — a pure projection with
+no user input, no session, no host page. The future ``.ics`` generator
+(Deadline + a gathered date) needs the session-backed AnswerStore and lands
+separately.
+
+The view layer only orchestrates (look the entity up, set download headers);
+the bytes are produced here so the field mapping is unit-testable without
+Django, and ``vobject`` owns vCard escaping and line folding.
+"""
+
+import vobject
+
+from litigant_portal.app.topic_flow.schema import Contact
+
+
+def contact_to_vcard(contact: Contact) -> str:
+    """Serialize a Contact to a vCard 3.0 string.
+
+    Only the fields the Contact actually has are emitted — an absent field
+    means an absent line, never an empty one.
+    """
+    card = vobject.vCard()
+    card.add("fn").value = contact.name
+    # vCard 3.0 requires N alongside FN. These are office/person names with no
+    # given/family split, so the whole name goes in the family slot.
+    card.add("n").value = vobject.vcard.Name(family=contact.name)
+    if contact.phone:
+        card.add("tel").value = contact.phone
+    if contact.email:
+        card.add("email").value = contact.email
+    if contact.url:
+        card.add("url").value = contact.url
+    if contact.address:
+        card.add("adr").value = vobject.vcard.Address(street=contact.address)
+    if contact.note:
+        card.add("note").value = contact.note
+    return card.serialize()

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -13,6 +13,11 @@ app_patterns = [
     path("accessibility/", pages.accessibility, name="accessibility"),
     path("topics/<slug:slug>/", pages.topic_detail, name="topic_detail"),
     path("t/<slug:court>/<slug:topic>/", pages.deep_link, name="deep_link"),
+    path(
+        "t/<slug:court>/<slug:topic>/<slug:role>/contact/<slug:contact_id>.vcf",
+        pages.contact_vcard,
+        name="contact_vcard",
+    ),
     path("chat/", pages.chat_page, name="chat"),
     path("chat/action-plan/", endpoints.action_plan, name="action_plan"),
     path("health/", pages.health, name="health"),

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -11,6 +11,8 @@ from django.views.generic import DetailView, UpdateView
 from litigant_portal.agents import agent_registry
 from litigant_portal.app.forms import UserProfileForm
 from litigant_portal.app.models import UserProfile
+from litigant_portal.app.topic_flow.artifacts import contact_to_vcard
+from litigant_portal.app.topic_flow.registry import registry
 
 TOPICS = {
     "eviction": {
@@ -231,6 +233,30 @@ def deep_link(request, court, topic):
 
     query = urlencode({"topic": topic.lower(), "court": court.lower()})
     return redirect(f"{reverse('pages:chat')}?{query}")
+
+
+def contact_vcard(request, court, topic, role, contact_id):
+    """Download a corpus Contact as a .vcf the phone imports as a contact card.
+
+    Orchestration only: resolve the corpus and contact, 404 on either miss,
+    and hand the bytes off to ``contact_to_vcard``. ``text/vcard`` +
+    attachment disposition is what routes the file to the device's Contacts
+    app on download.
+    """
+    corpus = registry.get(court, topic, role)
+    if corpus is None:
+        raise Http404(f"No topic flow for {court}/{topic}/{role}")
+    contact = next((c for c in corpus.contacts if c.id == contact_id), None)
+    if contact is None:
+        raise Http404(f"Contact '{contact_id}' not found")
+
+    response = HttpResponse(
+        contact_to_vcard(contact), content_type="text/vcard"
+    )
+    response["Content-Disposition"] = (
+        f'attachment; filename="{contact_id}.vcf"'
+    )
+    return response
 
 
 def test_agent(request, agent_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pydantic>=2.0",
     # Topic Flow corpus loading (litigant_portal/app/topic_flow)
     "pyyaml>=6.0",
+    # Topic Flow .vcf handoff generation (Contact → vCard)
+    "vobject>=0.9.9",
     # Security minimums (transitive deps — Dependabot #13-#25)
     "aiohttp>=3.13.4",
     "cryptography>=46.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -976,6 +976,7 @@ dependencies = [
     { name = "pygments" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "vobject" },
     { name = "whitenoise", extra = ["brotli"] },
 ]
 
@@ -1023,6 +1024,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.8" },
     { name = "tox-uv", marker = "extra == 'dev'", specifier = ">=1.29.0" },
     { name = "tox-uv", marker = "extra == 'test'", specifier = ">=1.29.0" },
+    { name = "vobject", specifier = ">=0.9.9" },
     { name = "whitenoise", extras = ["brotli"], specifier = ">=6.0" },
 ]
 provides-extras = ["dev", "test"]
@@ -1662,12 +1664,33 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -2162,6 +2185,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "vobject"
+version = "0.9.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/8a/15c34b3d27c43fc81a467d0f66577afc5542326804c42f30557e31c3259e/vobject-0.9.9.tar.gz", hash = "sha256:ac44e5d7e2079d84c1d52c50a615b9bec4b1ba958608c4c7fe40cbf33247b38e", size = 1208905, upload-time = "2024-12-16T07:29:39.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/20/6bba813bbd498c28edbbcf8253a6398cf4266ecf7bfa6129835c0a2bfbb1/vobject-0.9.9-py2.py3-none-any.whl", hash = "sha256:0fbdb982065cf4d1843a5d5950c88510041c6de026bda49c3502721de1c6ac3d", size = 47526, upload-time = "2024-12-16T07:31:08.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
First concrete file-artifact handoff for Topic Flow: turn a corpus Contact into a downloadable `.vcf` the phone imports as a contact card. It's a pure projection — no user input, no session, no host page — so it lands fully tested now; `.ics` follows once AnswerStore exists.

- `topic_flow/artifacts.py` — `contact_to_vcard(contact)` → vCard 3.0 via vobject; only fields the Contact has are emitted (absent = no line)
- `contact_vcard` view — `text/vcard` + attachment disposition, 404 on unknown corpus/contact; orchestration only, generation lives in artifacts
- URL `t/<court>/<topic>/<role>/contact/<contact_id>.vcf`
- `vobject` dependency added + locked

Closes #473
Part of #441

Test plan:
- `make lint && make test` green
- Generator: field present/absent mapping, assertions on parsed vCard values
- View: 200 + content-type/disposition/body; 404 on unknown corpus and contact