### PR TITLE
feat(topic-flow): SectionRenderer registry + section render handlers

### DIFF
--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -1,0 +1,197 @@
+"""SectionRenderer tests — registry dispatch of corpus sections to render context.
+
+The renderer is a fat, pure function of ``(section, corpus, answers)`` → a
+``RenderedSection`` carrying a template path + flat, dumb context. It takes a
+plain ``answers`` dict (not an AnswerStore), so these tests need no session or
+DB. Handlers for ``ics`` / ``vcf`` are intentionally unregistered here — they
+land with their download-view items — so rendering one fails fast.
+"""
+
+import pytest
+
+from litigant_portal.app.topic_flow.renderer import (
+    RenderedSection,
+    render_section,
+)
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    FactGatherSection,
+    IcsOutput,
+    InfoSection,
+    Metadata,
+    PacketOutput,
+    Question,
+    SummaryOutput,
+)
+
+
+def _corpus(*sections):
+    return Corpus(
+        metadata=Metadata(court="c", topic="t", role="r", title="T"),
+        sections=list(sections),
+    )
+
+
+# --- info -------------------------------------------------------------------
+
+
+def test_info_renders_heading_and_body():
+    section = InfoSection(
+        kind="info", id="intro", heading="Your rights", body="Read this."
+    )
+    rendered = render_section(section, _corpus(section), {})
+    assert isinstance(rendered, RenderedSection)
+    assert rendered.anchor_id == "intro"
+    assert rendered.heading == "Your rights"
+    assert rendered.context["body"] == "Read this."
+
+
+# --- fact_gather ------------------------------------------------------------
+
+
+def _fg(questions, heading=None, id="facts"):
+    return FactGatherSection(
+        kind="fact_gather", id=id, heading=heading, questions=questions
+    )
+
+
+def test_fact_gather_prefills_answered_questions():
+    section = _fg(
+        [Question(id="pubdate", label="Publication date", type="date")]
+    )
+    rendered = render_section(
+        section, _corpus(section), {"pubdate": "2026-05-01"}
+    )
+    (q,) = rendered.context["questions"]
+    assert q["id"] == "pubdate"
+    assert q["label"] == "Publication date"
+    assert q["value"] == "2026-05-01"
+
+
+def test_fact_gather_unanswered_question_prefills_empty():
+    section = _fg(
+        [Question(id="pubdate", label="Publication date", type="date")]
+    )
+    rendered = render_section(section, _corpus(section), {})
+    (q,) = rendered.context["questions"]
+    assert q["value"] == ""
+
+
+def test_fact_gather_carries_choice_metadata():
+    section = _fg(
+        [
+            Question(
+                id="track",
+                label="Track",
+                type="choice",
+                choices=["standard", "waiver"],
+            )
+        ]
+    )
+    rendered = render_section(section, _corpus(section), {})
+    (q,) = rendered.context["questions"]
+    assert q["type"] == "choice"
+    assert q["choices"] == ["standard", "waiver"]
+
+
+def test_fact_gather_heading_optional():
+    section = _fg([Question(id="x", label="X")], heading=None)
+    rendered = render_section(section, _corpus(section), {})
+    assert rendered.heading == ""
+
+
+# --- summary ----------------------------------------------------------------
+
+
+def test_summary_pairs_answers_with_labels_in_corpus_order():
+    fg = _fg(
+        [
+            Question(id="name", label="Full name"),
+            Question(id="dob", label="Date of birth", type="date"),
+        ]
+    )
+    summary = SummaryOutput(
+        kind="output",
+        output_type="summary",
+        id="recap",
+        heading="Your answers",
+    )
+    corpus = _corpus(fg, summary)
+    # answers inserted out of corpus order — summary must follow corpus order.
+    rendered = render_section(
+        summary, corpus, {"dob": "1990-02-03", "name": "Sandra"}
+    )
+    assert rendered.context["items"] == [
+        {"label": "Full name", "value": "Sandra"},
+        {"label": "Date of birth", "value": "1990-02-03"},
+    ]
+
+
+def test_summary_omits_unanswered_questions():
+    fg = _fg(
+        [
+            Question(id="name", label="Full name"),
+            Question(id="dob", label="DOB"),
+        ]
+    )
+    summary = SummaryOutput(
+        kind="output", output_type="summary", id="recap", heading="Recap"
+    )
+    rendered = render_section(
+        summary, _corpus(fg, summary), {"name": "Sandra"}
+    )
+    assert rendered.context["items"] == [
+        {"label": "Full name", "value": "Sandra"}
+    ]
+
+
+# --- packet -----------------------------------------------------------------
+
+
+def test_packet_renders_form_list():
+    section = PacketOutput(
+        kind="output",
+        output_type="packet",
+        id="forms",
+        heading="Your packet",
+        forms=["Petition for Name Change", "Order"],
+    )
+    rendered = render_section(section, _corpus(section), {})
+    assert rendered.heading == "Your packet"
+    assert rendered.context["forms"] == ["Petition for Name Change", "Order"]
+
+
+# --- dispatch ---------------------------------------------------------------
+
+
+def test_each_kind_dispatches_to_a_distinct_template():
+    info = InfoSection(kind="info", id="i", heading="I", body="B")
+    fg = _fg([Question(id="q", label="Q")])
+    summ = SummaryOutput(
+        kind="output", output_type="summary", id="s", heading="S"
+    )
+    packet = PacketOutput(
+        kind="output", output_type="packet", id="p", heading="P", forms=["F"]
+    )
+    corpus = _corpus(info, fg, summ, packet)
+    templates = {
+        render_section(s, corpus, {}).template
+        for s in (info, fg, summ, packet)
+    }
+    assert len(templates) == 4  # four kinds → four distinct templates
+    assert all(t for t in templates)  # all non-empty
+
+
+# --- fail-fast on unregistered (ics/vcf land with their view items) ---------
+
+
+def test_unregistered_output_type_raises():
+    ics = IcsOutput(
+        kind="output",
+        output_type="ics",
+        id="cal",
+        heading="Deadlines",
+        deadline_ids=["respond"],
+    )
+    with pytest.raises(ValueError, match="ics"):
+        render_section(ics, _corpus(ics), {})

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -1,0 +1,125 @@
+"""Registry dispatch of corpus sections to render context.
+
+Turns each validated corpus ``Section`` into a ``RenderedSection`` — a template
+path plus a flat, fully-resolved context dict — so the page view stays
+orchestration-only and templates stay logic-free. All section-type dispatch
+(``kind``, and ``output_type`` for outputs) is confined to the registry here;
+nothing downstream branches on section type.
+
+The renderer is *fat* but *pure*: it takes the ``corpus`` and a plain
+``answers`` dict (e.g. from ``AnswerStore.all()``) and resolves everything the
+template needs — prefilled fields, answer labels, form lists. It imports no
+session/request machinery.
+
+Corpus validity is guaranteed upstream at load, so the renderer never
+re-validates data; an unhandled section type is a *code* gap (a union member
+with no registered handler) and fails fast. Handlers for ``ics`` and ``vcf``
+register with their download-view items; until then, rendering one raises.
+"""
+
+from dataclasses import dataclass
+
+from litigant_portal.app.topic_flow.schema import FactGatherSection
+
+
+@dataclass(frozen=True)
+class RenderedSection:
+    anchor_id: str
+    heading: str
+    template: str
+    context: dict
+
+
+# Dispatch key (``kind``, or ``output_type`` for outputs) -> handler.
+SECTION_RENDERERS = {}
+
+_TEMPLATE_DIR = "cotton/molecules"
+
+
+def renderer(key):
+    """Register a handler under its dispatch key. Used as a decorator."""
+
+    def register(fn):
+        SECTION_RENDERERS[key] = fn
+        return fn
+
+    return register
+
+
+def _dispatch_key(section):
+    # Output sections share kind="output" and discriminate on output_type;
+    # everything else dispatches on kind. The two value spaces don't collide.
+    return getattr(section, "output_type", None) or section.kind
+
+
+def render_section(section, corpus, answers):
+    """Render one section to a ``RenderedSection``, or raise if unhandled."""
+    key = _dispatch_key(section)
+    handler = SECTION_RENDERERS.get(key)
+    if handler is None:
+        raise ValueError(f"No SectionRenderer handler registered for {key!r}")
+    return handler(section, corpus, answers)
+
+
+@renderer("info")
+def _render_info(section, corpus, answers):
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_info.html",
+        context={"body": section.body},
+    )
+
+
+@renderer("fact_gather")
+def _render_fact_gather(section, corpus, answers):
+    questions = [
+        {
+            "id": q.id,
+            "label": q.label,
+            "type": q.type,
+            "required": q.required,
+            "choices": q.choices,
+            "help_text": q.help_text,
+            "value": answers.get(q.id, ""),
+        }
+        for q in section.questions
+    ]
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading or "",
+        template=f"{_TEMPLATE_DIR}/flow_section_fact_gather.html",
+        context={"questions": questions},
+    )
+
+
+def _answered_in_corpus_order(corpus, answers):
+    """Yield ``{label, value}`` for answered questions, in corpus order."""
+    for section in corpus.sections:
+        if isinstance(section, FactGatherSection):
+            for question in section.questions:
+                if question.id in answers:
+                    yield {
+                        "label": question.label,
+                        "value": answers[question.id],
+                    }
+
+
+@renderer("summary")
+def _render_summary(section, corpus, answers):
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_summary.html",
+        context={"items": list(_answered_in_corpus_order(corpus, answers))},
+    )
+
+
+@renderer("packet")
+def _render_packet(section, corpus, answers):
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_packet.html",
+        context={"forms": list(section.forms)},
+    )


### PR DESCRIPTION
Registry-based dispatch that turns each validated corpus `Section` into a `RenderedSection` (template path + flat, dumb context), keeping the view orchestration-only and templates logic-free. Fat but pure — takes the corpus and a plain `answers` dict, resolves prefill / answer-labels / form lists, imports no session machinery; fails fast on an unhandled section type. Handlers for `info`, `fact_gather`, `summary`, `packet`; `ics`/`vcf` register with their download-view items.

Closes #479

**Test plan:** 10 unit tests (DB-free → fast suite): each handler, prefill present/absent, choice metadata, optional heading, summary ordering + omission, distinct-template dispatch, and the fail-fast raise on `ics`. Verified RED→GREEN via `.tox/fast/bin/pytest` — green, and a prefill mutation (`answers`→`""`) kills exactly the prefill test.

Part of the Topic Flow engine (#389). The Cotton section templates this references land in Item 8; the page view that loops it lands in Item 4.