### PR TITLE
feat(topic-flow): entry view + 3-segment URL rendering corpus sections

### DIFF
--- a/litigant_portal/app/templates/pages/topic_flow.html
+++ b/litigant_portal/app/templates/pages/topic_flow.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block title %}
+  {{ corpus.metadata.title }} - {% trans "Litigant Portal" %}
+{% endblock title %}
+
+{% block content %}
+<div class="border-b border-greyscale-100 bg-primary-50 px-4 py-4">
+  <p class="text-sm text-greyscale-500">
+    {{ corpus.metadata.court }} · {{ corpus.metadata.topic }} · {{ corpus.metadata.role }}
+  </p>
+  <h1 class="mt-1 text-xl font-bold text-greyscale-900">{{ corpus.metadata.title }}</h1>
+</div>
+
+<div class="mx-auto max-w-3xl px-4 py-8">
+  {% trans "On this page" as toc_label %}
+  <nav aria-label="{{ toc_label }}" class="mb-8">
+    <ul class="space-y-1">
+      {% for section in rendered_sections %}
+      <li>
+        <c-atoms.link href="#{{ section.anchor_id }}">{{ section.heading }}</c-atoms.link>
+      </li>
+      {% endfor %}
+    </ul>
+  </nav>
+
+  {% for section in rendered_sections %}
+  <section id="{{ section.anchor_id }}" class="mb-8 scroll-mt-4">
+    <h2 class="text-lg font-semibold text-greyscale-900">{{ section.heading }}</h2>
+    {# Section body (fields, summary, packet) renders here in Item 8 via the per-kind flow_section_*.html templates. #}
+  </section>
+  {% endfor %}
+</div>
+{% endblock content %}

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -1,0 +1,141 @@
+"""Topic Flow entry-view tests — 3-segment URL → rendered corpus sections.
+
+The view resolves a corpus via the registry, renders every section through
+``render_section`` (SectionRenderer, #479), and hands an ordered
+``rendered_sections`` list to ``pages/topic_flow.html``. Item 4 is the strict
+split: the page emits a heading + anchor per section (TOC works, JS off);
+per-kind section *bodies* land with the section templates (Item 8).
+
+URL-resolution tests are DB-free (they run in the fast suite). The render/404
+tests drive the test client through template rendering, which touches the
+auth/session machinery, so they need a database — run via Docker ``make test``.
+"""
+
+import pytest
+from django.urls import resolve, reverse
+
+from litigant_portal.app.topic_flow.renderer import RenderedSection
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    FactGatherSection,
+    InfoSection,
+    Metadata,
+    PacketOutput,
+    Question,
+    SummaryOutput,
+)
+from litigant_portal.app.views import pages
+
+COURT, TOPIC, ROLE = "test-court", "test_topic", "petitioner"
+URL = f"/t/{COURT}/{TOPIC}/{ROLE}/"
+# Section ids, in corpus order — these become the rendered anchor_ids/TOC targets.
+SECTION_IDS = ["overview", "key_dates", "filing_packet", "recap"]
+
+
+def _corpus():
+    """An in-memory corpus of only the four *registered* section kinds.
+
+    The on-disk fixture also carries ics/vcf outputs, but those handlers aren't
+    registered yet (Items 7/9) and render_section raises on them — so the view
+    is exercised against a corpus it can fully render today.
+    """
+    return Corpus(
+        metadata=Metadata(
+            court=COURT, topic=TOPIC, role=ROLE, title="Test Flow"
+        ),
+        sections=[
+            InfoSection(
+                kind="info",
+                id="overview",
+                heading="What this covers",
+                body="Read this first.",
+            ),
+            FactGatherSection(
+                kind="fact_gather",
+                id="key_dates",
+                heading="Your dates",
+                questions=[
+                    Question(
+                        id="publication_date",
+                        label="Date your notice was published",
+                        type="date",
+                        required=True,
+                    )
+                ],
+            ),
+            PacketOutput(
+                kind="output",
+                output_type="packet",
+                id="filing_packet",
+                heading="Your filing packet",
+                forms=["Petition for Name Change"],
+            ),
+            SummaryOutput(
+                kind="output",
+                output_type="summary",
+                id="recap",
+                heading="Summary of what you entered",
+            ),
+        ],
+    )
+
+
+# --- URL resolution (DB-free) -----------------------------------------------
+
+
+def test_three_segment_url_resolves_to_topic_flow_view():
+    assert resolve(URL).view_name == "pages:topic_flow"
+
+
+def test_two_segment_url_still_resolves_to_legacy_deep_link():
+    # The 3-seg flow URL must not shadow the legacy 2-seg deep_link. `slug`
+    # never crosses a `/`, so they're distinct — assert it, don't assume it.
+    assert resolve(f"/t/{COURT}/{TOPIC}/").view_name == "pages:deep_link"
+
+
+def test_topic_flow_url_reverses_with_three_segments():
+    assert (
+        reverse(
+            "pages:topic_flow",
+            kwargs={"court": COURT, "topic": TOPIC, "role": ROLE},
+        )
+        == URL
+    )
+
+
+# --- GET render (needs DB) --------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_renders_topic_flow_page(client, monkeypatch):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.get(URL)
+    assert response.status_code == 200
+    assert "pages/topic_flow.html" in [t.name for t in response.templates]
+
+
+@pytest.mark.django_db
+def test_context_carries_rendered_sections_in_corpus_order(
+    client, monkeypatch
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    rendered = client.get(URL).context["rendered_sections"]
+    # One RenderedSection per corpus section, same order — the view's core job.
+    assert all(isinstance(r, RenderedSection) for r in rendered)
+    assert [r.anchor_id for r in rendered] == SECTION_IDS
+
+
+@pytest.mark.django_db
+def test_page_emits_an_anchor_target_per_section(client, monkeypatch):
+    # The TOC jumps to #anchor_id; assert the loop emits each target so anchor
+    # navigation works with JS off. (Functional ids, not cosmetic markup.)
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    for section_id in SECTION_IDS:
+        assert f'id="{section_id}"' in html
+
+
+@pytest.mark.django_db
+def test_unknown_flow_returns_404(client, monkeypatch):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: None)
+    assert client.get(URL).status_code == 404

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -13,6 +13,11 @@ app_patterns = [
     path("accessibility/", pages.accessibility, name="accessibility"),
     path("topics/<slug:slug>/", pages.topic_detail, name="topic_detail"),
     path("t/<slug:court>/<slug:topic>/", pages.deep_link, name="deep_link"),
+    path(
+        "t/<slug:court>/<slug:topic>/<slug:role>/",
+        pages.topic_flow,
+        name="topic_flow",
+    ),
     path("chat/", pages.chat_page, name="chat"),
     path("chat/action-plan/", endpoints.action_plan, name="action_plan"),
     path("health/", pages.health, name="health"),

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -11,6 +11,8 @@ from django.views.generic import DetailView, UpdateView
 from litigant_portal.agents import agent_registry
 from litigant_portal.app.forms import UserProfileForm
 from litigant_portal.app.models import UserProfile
+from litigant_portal.app.topic_flow.registry import registry
+from litigant_portal.app.topic_flow.renderer import render_section
 
 TOPICS = {
     "eviction": {
@@ -231,6 +233,28 @@ def deep_link(request, court, topic):
 
     query = urlencode({"topic": topic.lower(), "court": court.lower()})
     return redirect(f"{reverse('pages:chat')}?{query}")
+
+
+def topic_flow(request, court, topic, role):
+    """Topic Flow entry: /t/{court}/{topic}/{role}/ → rendered corpus sections.
+
+    Resolves the corpus from the registry (404 on miss) and renders each
+    section to a RenderedSection via SectionRenderer. The view stays thin —
+    all dispatch lives in renderer.py; the template only loops and displays.
+    Answers are empty here; fact_gather prefill + POST arrive with AnswerStore
+    wiring, and per-kind section bodies with the section templates.
+    """
+    corpus = registry.get(court, topic, role)
+    if corpus is None:
+        raise Http404(f"No Topic Flow for {court}/{topic}/{role}")
+    rendered_sections = [
+        render_section(section, corpus, {}) for section in corpus.sections
+    ]
+    return render(
+        request,
+        "pages/topic_flow.html",
+        {"corpus": corpus, "rendered_sections": rendered_sections},
+    )
 
 
 def test_agent(request, agent_name):


### PR DESCRIPTION
Adds the Topic Flow entry view + 3-segment URL `t/<court>/<topic>/<role>/`: resolves the corpus from the registry (404 on miss), renders each section through SectionRenderer, and emits an anchored `<section>` + TOC entry per `RenderedSection`. Strict split (Item 4 of the v1 build plan) — section *bodies* are placeholders until the per-kind templates (Item 8); the view stays thin, all dispatch lives in `renderer.py`.

Part of #389. Closes #483.

## Test plan
- **DB-free (fast suite), passing:** URL resolution — 3-seg → `topic_flow`, legacy 2-seg → `deep_link` (unshadowed), `reverse` round-trip.
- **DB-backed (`make test`, Docker):** GET 200 + `pages/topic_flow.html` used; `rendered_sections` is one `RenderedSection` per corpus section, in order; one anchor target per section (TOC works JS-off); unknown `(court, topic, role)` → 404.
- Django system check clean; `topic_flow.html` compiles; TOC links use `c-atoms.link`.

Out of scope (later items): per-kind section bodies (Item 8), fact_gather POST + AnswerStore wiring (Item 5), TOC drawer organism (Item 10).