### PR TITLE
feat(topic-flow): per-kind section body templates

### DIFF
--- a/litigant_portal/app/templates/cotton/atoms/input.html
+++ b/litigant_portal/app/templates/cotton/atoms/input.html
@@ -1,4 +1,4 @@
-<c-vars type="text" />
+<c-vars type="text" :required="False" />
 {# --- Base --- #}
 {% with base="w-full text-md font-normal py-3 px-4 rounded-lg border bg-white text-greyscale-900 placeholder:text-greyscale-400 transition-colors duration-200 focus:outline-none focus:ring-2 disabled:bg-greyscale-100 disabled:text-greyscale-500 disabled:cursor-not-allowed" %}
 {# --- States --- #}

--- a/litigant_portal/app/templates/cotton/atoms/select.html
+++ b/litigant_portal/app/templates/cotton/atoms/select.html
@@ -1,3 +1,4 @@
+<c-vars :required="False" />
 <div class="relative inline-block w-full {{ class }}">
   {# --- Base --- #}
   {% with base="w-full text-md font-normal py-3 pl-4 pr-10 rounded-lg bg-white text-greyscale-900 transition-colors duration-200 cursor-pointer appearance-none focus:outline-none focus:ring-2 disabled:bg-greyscale-100 disabled:text-greyscale-500 disabled:cursor-not-allowed border" %}

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
@@ -1,0 +1,36 @@
+{% load i18n %}
+
+{# fact_gather section body: a server-rendered form, one field per question. #}
+{# Values are prefilled server-side (ctx.questions[].value) — no x-model. The #}
+{# POST handler + deadline recompute land in Item 5; this renders the form. #}
+{% trans "Select…" as choice_placeholder %}
+<form method="post" class="space-y-4">
+  {% csrf_token %}
+  {% for q in ctx.questions %}
+  {% if q.type == "choice" %}
+  <c-molecules.form-field-select
+    label="{{ q.label }}"
+    name="{{ q.id }}"
+    id="{{ q.id }}"
+    help_text="{{ q.help_text|default:'' }}"
+    :required="q.required"
+  >
+    <option value="">{{ choice_placeholder }}</option>
+    {% for choice in q.choices %}
+    <option value="{{ choice }}" {% if choice == q.value %}selected{% endif %}>{{ choice }}</option>
+    {% endfor %}
+  </c-molecules.form-field-select>
+  {% else %}
+  <c-molecules.form-field
+    label="{{ q.label }}"
+    type="{{ q.type }}"
+    name="{{ q.id }}"
+    id="{{ q.id }}"
+    value="{{ q.value }}"
+    help_text="{{ q.help_text|default:'' }}"
+    :required="q.required"
+  />
+  {% endif %}
+  {% endfor %}
+  <c-atoms.button type="submit" variant="primary">{% trans "Save answers" %}</c-atoms.button>
+</form>

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_info.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_info.html
@@ -1,0 +1,3 @@
+{# Info section body. Renders authored corpus prose; `linebreaks` turns blank #}
+{# lines into paragraphs. Included by pages/topic_flow.html with ctx=section.context. #}
+<div class="space-y-3 text-greyscale-700">{{ ctx.body|linebreaks }}</div>

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
@@ -1,0 +1,6 @@
+{# Packet section body: the forms the corpus says this flow needs. #}
+<ul class="list-disc space-y-1 pl-5 text-greyscale-700">
+  {% for form in ctx.forms %}
+  <li>{{ form }}</li>
+  {% endfor %}
+</ul>

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_summary.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_summary.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+
+{# Summary section body: the answers gathered so far, in corpus order. Empty #}
+{# until fact_gather answers are wired in (Item 5), so it leads with an empty #}
+{# state — static layout, dynamic content. #}
+{% if ctx.items %}
+<dl class="space-y-3">
+  {% for item in ctx.items %}
+  <div>
+    <dt class="text-sm font-medium text-greyscale-500">{{ item.label }}</dt>
+    <dd class="text-greyscale-900">{{ item.value }}</dd>
+  </div>
+  {% endfor %}
+</dl>
+{% else %}
+<p class="text-sm text-greyscale-500">
+  {% trans "You haven't entered anything yet." %}
+</p>
+{% endif %}

--- a/litigant_portal/app/templates/cotton/molecules/form_field.html
+++ b/litigant_portal/app/templates/cotton/molecules/form_field.html
@@ -1,8 +1,8 @@
-<c-vars type="text" required="false" />
+<c-vars type="text" :required="False" />
 <div class="{{ class }}">
   <label for="{{ id }}"
          class="block text-sm font-medium text-greyscale-700 mb-1.5">{{ label }}</label>
-  <c-atoms.input type="{{ type }}" name="{{ name }}" id="{{ id }}" value="{{ value }}" placeholder="{{ placeholder }}" autocomplete="{{ autocomplete }}" required="{{ required }}" error="{{ errors|yesno:'true,' }}" />
+  <c-atoms.input type="{{ type }}" name="{{ name }}" id="{{ id }}" value="{{ value }}" placeholder="{{ placeholder }}" autocomplete="{{ autocomplete }}" :required="required" error="{{ errors|yesno:'true,' }}" />
   {% if help_text %}<p class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
   {% if errors %}<p class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
 </div>

--- a/litigant_portal/app/templates/cotton/molecules/form_field_select.html
+++ b/litigant_portal/app/templates/cotton/molecules/form_field_select.html
@@ -1,8 +1,8 @@
-<c-vars required="false" />
+<c-vars :required="False" />
 <div class="{{ class }}">
   <label for="{{ id }}"
          class="block text-sm font-medium text-greyscale-700 mb-1.5">{{ label }}</label>
-  <c-atoms.select name="{{ name }}" id="{{ id }}" required="{{ required }}" error="{{ errors|yesno:'true,' }}">{{ slot }}</c-atoms.select>
+  <c-atoms.select name="{{ name }}" id="{{ id }}" :required="required" error="{{ errors|yesno:'true,' }}">{{ slot }}</c-atoms.select>
   {% if help_text %}<p class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
   {% if errors %}<p class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
 </div>

--- a/litigant_portal/app/templates/pages/topic_flow.html
+++ b/litigant_portal/app/templates/pages/topic_flow.html
@@ -28,8 +28,10 @@
 
   {% for section in rendered_sections %}
   <section id="{{ section.anchor_id }}" class="mb-8 scroll-mt-4">
-    <h2 class="text-lg font-semibold text-greyscale-900">{{ section.heading }}</h2>
-    {# Section body (fields, summary, packet) renders here in Item 8 via the per-kind flow_section_*.html templates. #}
+    {% if section.heading %}
+    <h2 class="mb-3 text-lg font-semibold text-greyscale-900">{{ section.heading }}</h2>
+    {% endif %}
+    {% include section.template with ctx=section.context %}
   </section>
   {% endfor %}
 </div>

--- a/litigant_portal/app/templates/pages/topic_flow.html
+++ b/litigant_portal/app/templates/pages/topic_flow.html
@@ -19,9 +19,11 @@
   <nav aria-label="{{ toc_label }}" class="mb-8">
     <ul class="space-y-1">
       {% for section in rendered_sections %}
+      {% if section.heading %}
       <li>
         <c-atoms.link href="#{{ section.anchor_id }}">{{ section.heading }}</c-atoms.link>
       </li>
+      {% endif %}
       {% endfor %}
     </ul>
   </nav>

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -60,7 +60,13 @@ def _corpus():
                         label="Date your notice was published",
                         type="date",
                         required=True,
-                    )
+                    ),
+                    Question(
+                        id="filing_county",
+                        label="County where you'll file",
+                        type="choice",
+                        choices=["Cass", "Burleigh"],
+                    ),
                 ],
             ),
             PacketOutput(
@@ -139,3 +145,50 @@ def test_page_emits_an_anchor_target_per_section(client, monkeypatch):
 def test_unknown_flow_returns_404(client, monkeypatch):
     monkeypatch.setattr(pages.registry, "get", lambda *a: None)
     assert client.get(URL).status_code == 404
+
+
+# --- Section body rendering (Item 8, needs DB) ------------------------------
+# #483 emitted only the heading + anchor shell. These assert the per-kind body
+# templates now render through `{% include section.template with ctx=... %}` —
+# the functional payload (corpus content, form field names), not cosmetic markup.
+
+
+@pytest.mark.django_db
+def test_info_section_renders_its_body(client, monkeypatch):
+    # Proves the include wiring resolves and the info partial gets its context —
+    # the body the corpus supplied reaches the page, not just the heading.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert "Read this first." in html
+
+
+@pytest.mark.django_db
+def test_fact_gather_renders_post_form_with_a_field_per_question(
+    client, monkeypatch
+):
+    # The form must POST and carry a `name` per question — the contract the
+    # Item 5 POST handler reads. Without these names, answers can't persist.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert 'method="post"' in html
+    assert "csrfmiddlewaretoken" in html
+    assert 'name="publication_date"' in html
+    assert 'name="filing_county"' in html
+
+
+@pytest.mark.django_db
+def test_fact_gather_choice_question_renders_its_options(client, monkeypatch):
+    # A choice question must render its options, else the user can't answer it.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert "<option" in html
+    assert "Cass" in html
+    assert "Burleigh" in html
+
+
+@pytest.mark.django_db
+def test_packet_section_lists_each_form(client, monkeypatch):
+    # The packet partial must render every form name the corpus declares.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert "Petition for Name Change" in html

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -221,3 +221,35 @@ def test_fact_gather_marks_required_questions_and_leaves_optional_unmarked(
     html = client.get(URL).content.decode()
     assert re.search(r"\brequired\b", _field_tag(html, "publication_date"))
     assert not re.search(r"\brequired\b", _field_tag(html, "filing_county"))
+
+
+@pytest.mark.django_db
+def test_headingless_fact_gather_skipped_in_toc_but_body_still_renders(
+    client, monkeypatch
+):
+    # fact_gather is the one section whose heading is optional. A headingless
+    # one must not emit an empty (nameless) TOC link — guard the TOC entry, not
+    # the anchor/section, so its body still renders.
+    corpus = Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        sections=[
+            InfoSection(
+                kind="info",
+                id="overview",
+                heading="What this covers",
+                body="Read this first.",
+            ),
+            FactGatherSection(
+                kind="fact_gather",
+                id="key_dates",
+                questions=[
+                    Question(id="publication_date", label="When", type="date")
+                ],
+            ),
+        ],
+    )
+    monkeypatch.setattr(pages.registry, "get", lambda *a: corpus)
+    html = client.get(URL).content.decode()
+    assert 'href="#overview"' in html  # heading section -> TOC link
+    assert 'href="#key_dates"' not in html  # headingless -> no empty link
+    assert 'name="publication_date"' in html  # body still renders

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -11,6 +11,8 @@ tests drive the test client through template rendering, which touches the
 auth/session machinery, so they need a database — run via Docker ``make test``.
 """
 
+import re
+
 import pytest
 from django.urls import resolve, reverse
 
@@ -192,3 +194,30 @@ def test_packet_section_lists_each_form(client, monkeypatch):
     monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
     html = client.get(URL).content.decode()
     assert "Petition for Name Change" in html
+
+
+def _field_tag(html, name):
+    """The <input>/<select> element whose name == ``name``, whitespace flattened.
+
+    The atoms render one attribute per line, so flatten before matching so a
+    multi-line tag reads as one string.
+    """
+    flat = re.sub(r"\s+", " ", html)
+    match = re.search(
+        rf'<(?:input|select)\b[^>]*name="{re.escape(name)}"[^>]*>', flat
+    )
+    return match.group(0) if match else ""
+
+
+@pytest.mark.django_db
+def test_fact_gather_marks_required_questions_and_leaves_optional_unmarked(
+    client, monkeypatch
+):
+    # The HTML `required` attribute must track the corpus `required` flag:
+    # publication_date is required=True, filing_county defaults required=False.
+    # If an optional field renders required, the browser blocks the litigant on
+    # a question the author meant to be skippable — the bug this guards.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert re.search(r"\brequired\b", _field_tag(html, "publication_date"))
+    assert not re.search(r"\brequired\b", _field_tag(html, "filing_county"))


### PR DESCRIPTION
Fills the placeholder section bodies #483 left in the entry page with four dumb Cotton partials the SectionRenderer (#479) already dispatches to — info, fact_gather, summary, packet — so a corpus renders real content end-to-end. `topic_flow.html` now includes `section.template` with the renderer's flat context; fact_gather composes the form-field/select/button atoms into a real `<form method="post">` with server-side prefill and a name per question.

The POST handler + deadline recompute are the next brick (Item 5), so the form renders here but doesn't persist yet — the milestone delivers it working.

Closes #485

Test plan:
- `make lint` clean; `make test` green (Docker)
- 4 new `django_db` render tests: info body renders, fact_gather emits a `method="post"` form with a name per question + csrf, choice renders its options, packet lists each form
- existing URL-resolution + GET-render tests still pass