### PR TITLE
Add UserIdentity model

### DIFF
--- a/litigant_portal/agents/base.py
+++ b/litigant_portal/agents/base.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, TypedDict
 from uuid import UUID
 
 from django.conf import settings
-from django.http import HttpRequest
 from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 
 if TYPE_CHECKING:
-    from litigant_portal.app.models import ChatSession
+    from litigant_portal.app.models import ChatSession, UserIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -504,7 +503,7 @@ class Agent:
     @classmethod
     def from_session_id(
         cls,
-        request: HttpRequest,
+        identity: "UserIdentity",
         session_id: str | UUID | None = None,
         **kwargs: Any,
     ) -> "Agent":
@@ -512,10 +511,8 @@ class Agent:
 
         If no session ID is provided, a new session is created.
         """
-        from litigant_portal.app.models import ChatSession, UserIdentity
+        from litigant_portal.app.models import ChatSession
         from litigant_portal.app.models import Message as MessageModel
-
-        identity = UserIdentity.for_request(request)
 
         if not session_id:
             topic = kwargs.pop("topic", "")

--- a/litigant_portal/agents/base.py
+++ b/litigant_portal/agents/base.py
@@ -512,13 +512,10 @@ class Agent:
 
         If no session ID is provided, a new session is created.
         """
-        from litigant_portal.app.models import ChatSession
+        from litigant_portal.app.models import ChatSession, UserIdentity
         from litigant_portal.app.models import Message as MessageModel
 
-        if not request.session.session_key:
-            request.session.create()
-        user = request.user if request.user.is_authenticated else None
-        session_key = request.session.session_key if not user else ""
+        identity = UserIdentity.for_request(request)
 
         if not session_id:
             topic = kwargs.pop("topic", "")
@@ -526,8 +523,7 @@ class Agent:
             court = kwargs.pop("court", None)
             phase = kwargs.pop("phase", None)
             session = ChatSession.objects.create(
-                user=user,
-                session_key=session_key,
+                identity=identity,
                 topic=topic,
                 jurisdiction=jurisdiction,
             )
@@ -548,13 +544,8 @@ class Agent:
                 session = ChatSession.objects.get(id=session_id)
             except ChatSession.DoesNotExist:
                 raise ValueError(f"Session {session_id} not found")
-            # Verify ownership: check user for auth sessions, session_key for anonymous
-            if session.user:
-                if session.user != user:
-                    raise PermissionError("Unauthorized access to session")
-            else:
-                if session.session_key != session_key:
-                    raise PermissionError("Unauthorized access to session")
+            if session.identity_id != identity.pk:
+                raise PermissionError("Unauthorized access to session")
             messages = [
                 m.data for m in session.messages.order_by("created_at")
             ]

--- a/litigant_portal/agents/litigant_assistant.py
+++ b/litigant_portal/agents/litigant_assistant.py
@@ -227,13 +227,8 @@ class UpdateCaseFacts(Tool):
         # Persist: merge patch into existing CaseInfo for this session's owner
         if agent.session:
             session = agent.session
-            ownership = (
-                {"user": session.user}
-                if session.user
-                else {"session_key": session.session_key}
-            )
             case, _ = CaseInfo.objects.get_or_create(
-                status="active", **ownership
+                status="active", identity=session.identity
             )
             data = dict(case.data) if case.data else {}
 
@@ -325,13 +320,8 @@ class UpdateActionPlan(Tool):
         # Persist
         if agent.session:
             session = agent.session
-            ownership = (
-                {"user": session.user}
-                if session.user
-                else {"session_key": session.session_key}
-            )
             case, _ = CaseInfo.objects.get_or_create(
-                status="active", **ownership
+                status="active", identity=session.identity
             )
             data = dict(case.data) if case.data else {}
 

--- a/litigant_portal/app/admin.py
+++ b/litigant_portal/app/admin.py
@@ -7,6 +7,7 @@ from .models import (
     Deadline,
     Document,
     Message,
+    UserIdentity,
     UserProfile,
 )
 
@@ -15,6 +16,14 @@ from .models import (
 class UserProfileAdmin(admin.ModelAdmin):
     list_display = ["user", "name", "state", "county", "created_at"]
     search_fields = ["user__email", "name", "county"]
+
+
+@admin.register(UserIdentity)
+class UserIdentityAdmin(admin.ModelAdmin):
+    list_display = ["id", "user", "session_key", "created_at"]
+    list_filter = ["created_at"]
+    search_fields = ["user__email", "session_key"]
+    readonly_fields = ["id", "created_at"]
 
 
 class MessageInline(admin.TabularInline):
@@ -45,9 +54,9 @@ class MessageInline(admin.TabularInline):
 
 @admin.register(ChatSession)
 class ChatSessionAdmin(admin.ModelAdmin):
-    list_display = ["id", "user", "session_key", "created_at", "updated_at"]
+    list_display = ["id", "identity", "created_at", "updated_at"]
     list_filter = ["created_at"]
-    search_fields = ["id", "user__email", "session_key"]
+    search_fields = ["id", "identity__user__email", "identity__session_key"]
     readonly_fields = ["id", "created_at", "updated_at"]
     inlines = [MessageInline]
 
@@ -98,9 +107,9 @@ class ActionItemInline(admin.TabularInline):
 
 @admin.register(CaseInfo)
 class CaseInfoAdmin(admin.ModelAdmin):
-    list_display = ["id", "user", "session_key", "created_at"]
+    list_display = ["id", "identity", "created_at"]
     list_filter = ["created_at"]
-    search_fields = ["id", "user__email", "session_key"]
+    search_fields = ["id", "identity__user__email", "identity__session_key"]
     readonly_fields = ["id", "created_at", "updated_at"]
     inlines = [DeadlineInline, ActionItemInline]
 

--- a/litigant_portal/app/management/commands/cleanup_sessions.py
+++ b/litigant_portal/app/management/commands/cleanup_sessions.py
@@ -1,10 +1,10 @@
 """
-Management command to clean up old anonymous chat sessions.
+Management command to clean up old anonymous identities and their associated data.
 
 Usage:
     python manage.py cleanup_sessions           # Dry run (default)
     python manage.py cleanup_sessions --delete  # Actually delete
-    python manage.py cleanup_sessions --days=7  # Sessions older than 7 days
+    python manage.py cleanup_sessions --days=7  # Identities older than 7 days
 """
 
 from datetime import timedelta
@@ -12,23 +12,23 @@ from datetime import timedelta
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from litigant_portal.app.models import ChatSession
+from litigant_portal.app.models import UserIdentity
 
 
 class Command(BaseCommand):
-    help = "Clean up old anonymous chat sessions"
+    help = "Clean up old anonymous user identities (and their chat/case data)"
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--days",
             type=int,
             default=30,
-            help="Delete sessions older than this many days (default: 30)",
+            help="Delete identities older than this many days (default: 30)",
         )
         parser.add_argument(
             "--delete",
             action="store_true",
-            help="Actually delete sessions (default is dry run)",
+            help="Actually delete identities (default is dry run)",
         )
 
     def handle(self, *args, **options):
@@ -36,35 +36,34 @@ class Command(BaseCommand):
         delete = options["delete"]
         cutoff = timezone.now() - timedelta(days=days)
 
-        # Find anonymous sessions (no user) older than cutoff
-        old_sessions = ChatSession.objects.filter(
+        old_identities = UserIdentity.objects.filter(
             user__isnull=True,
-            updated_at__lt=cutoff,
+            created_at__lt=cutoff,
         )
 
-        count = old_sessions.count()
+        count = old_identities.count()
 
         if count == 0:
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"No anonymous sessions older than {days} days found."
+                    f"No anonymous identities older than {days} days found."
                 )
             )
             return
 
         if delete:
-            # Delete cascades to messages
-            deleted, details = old_sessions.delete()
+            deleted, details = old_identities.delete()
             self.stdout.write(
                 self.style.SUCCESS(f"Deleted {deleted} objects: {details}")
             )
         else:
-            # Dry run - show what would be deleted
-            message_count = sum(s.messages.count() for s in old_sessions)
+            chat_count = sum(i.chat_sessions.count() for i in old_identities)
+            case_count = sum(i.case_infos.count() for i in old_identities)
             self.stdout.write(
                 self.style.WARNING(
-                    f"DRY RUN: Would delete {count} anonymous sessions "
-                    f"({message_count} messages) older than {days} days.\n"
+                    f"DRY RUN: Would delete {count} anonymous identities "
+                    f"({chat_count} chat sessions, {case_count} cases) "
+                    f"older than {days} days.\n"
                     f"Run with --delete to actually remove them."
                 )
             )

--- a/litigant_portal/app/middleware.py
+++ b/litigant_portal/app/middleware.py
@@ -1,26 +1,45 @@
-"""Middleware for preserving anonymous session key across login."""
+from django.utils.functional import SimpleLazyObject
+
+from litigant_portal.app.models import UserIdentity
+from litigant_portal.app.services.identity import identity_ensure
 
 
 class AnonymousSessionKeyMiddleware:
-    """Save the anonymous session key so the login signal can migrate data.
-
-    Django's login() calls session.cycle_key(), which changes the session
-    key but preserves session data. By storing the key as session data,
-    the user_logged_in signal handler can find anonymous records to
-    migrate.
-    """
+    """Save the anonymous session key so the login signal can migrate data."""
 
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
+        session = request.session
         if (
-            hasattr(request, "session")
-            and hasattr(request, "user")
-            and not request.user.is_authenticated
-            and request.session.session_key
+            not request.user.is_authenticated
+            and session.session_key
+            and session.get("_anonymous_session_key") != session.session_key
         ):
-            request.session["_anonymous_session_key"] = (
-                request.session.session_key
-            )
+            session["_anonymous_session_key"] = session.session_key
+        return self.get_response(request)
+
+
+def resolve_identity(request) -> UserIdentity:
+    """Resolve the UserIdentity that owns this request's data, creating it if
+    needed."""
+    if request.user.is_authenticated:
+        return identity_ensure(user=request.user)
+    if not request.session.session_key:
+        request.session.create()
+    identity, _ = UserIdentity.objects.get_or_create(
+        user=None, session_key=request.session.session_key
+    )
+    return identity
+
+
+class IdentityMiddleware:
+    """Attach a lazy ``request.identity`` UserIdentity."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.identity = SimpleLazyObject(lambda: resolve_identity(request))
         return self.get_response(request)

--- a/litigant_portal/app/migrations/0002_useridentity.py
+++ b/litigant_portal/app/migrations/0002_useridentity.py
@@ -1,0 +1,155 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def create_identities_and_link(apps, schema_editor):
+    """Populate UserIdentity rows and set identity FK on all existing rows."""
+    UserIdentity = apps.get_model("app", "UserIdentity")
+    ChatSession = apps.get_model("app", "ChatSession")
+    CaseInfo = apps.get_model("app", "CaseInfo")
+
+    identity_cache: dict = {}
+
+    def get_identity(user_id, session_key):
+        if user_id:
+            key = ("user", user_id)
+            if key not in identity_cache:
+                identity, _ = UserIdentity.objects.get_or_create(user_id=user_id)
+                identity_cache[key] = identity
+        elif session_key:
+            key = ("session", session_key)
+            if key not in identity_cache:
+                identity, _ = UserIdentity.objects.get_or_create(
+                    user=None, session_key=session_key
+                )
+                identity_cache[key] = identity
+        else:
+            identity = UserIdentity.objects.create()
+            key = ("orphan", identity.pk)
+            identity_cache[key] = identity
+        return identity_cache[key]
+
+    for session in ChatSession.objects.all():
+        session.identity = get_identity(session.user_id, session.session_key)
+        session.save(update_fields=["identity"])
+
+    for case in CaseInfo.objects.all():
+        case.identity = get_identity(case.user_id, case.session_key)
+        case.save(update_fields=["identity"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. Create UserIdentity table
+        migrations.CreateModel(
+            name="UserIdentity",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "session_key",
+                    models.CharField(blank=True, db_index=True, max_length=40),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="identity",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "User Identity",
+                "verbose_name_plural": "User Identities",
+            },
+        ),
+        # 2. Add nullable identity FK to ChatSession
+        migrations.AddField(
+            model_name="chatsession",
+            name="identity",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="chat_sessions",
+                to="app.useridentity",
+            ),
+        ),
+        # 3. Add nullable identity FK to CaseInfo
+        migrations.AddField(
+            model_name="caseinfo",
+            name="identity",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="case_infos",
+                to="app.useridentity",
+            ),
+        ),
+        # 4. Populate UserIdentity rows and link existing records
+        migrations.RunPython(
+            create_identities_and_link,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        # 5. Make identity non-nullable on ChatSession
+        migrations.AlterField(
+            model_name="chatsession",
+            name="identity",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="chat_sessions",
+                to="app.useridentity",
+            ),
+        ),
+        # 6. Make identity non-nullable on CaseInfo
+        migrations.AlterField(
+            model_name="caseinfo",
+            name="identity",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="case_infos",
+                to="app.useridentity",
+            ),
+        ),
+        # 7. Remove old indexes from ChatSession
+        migrations.RemoveIndex(
+            model_name="chatsession",
+            name="app_chatses_user_id_13e404_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="chatsession",
+            name="app_chatses_session_cc7acd_idx",
+        ),
+        # 8. Remove old fields from ChatSession
+        migrations.RemoveField(model_name="chatsession", name="user"),
+        migrations.RemoveField(model_name="chatsession", name="session_key"),
+        # 9. Remove old indexes from CaseInfo
+        migrations.RemoveIndex(
+            model_name="caseinfo",
+            name="app_caseinf_user_id_2c1330_idx",
+        ),
+        migrations.RemoveIndex(
+            model_name="caseinfo",
+            name="app_caseinf_session_421804_idx",
+        ),
+        # 10. Remove old fields from CaseInfo
+        migrations.RemoveField(model_name="caseinfo", name="user"),
+        migrations.RemoveField(model_name="caseinfo", name="session_key"),
+    ]

--- a/litigant_portal/app/models/chat.py
+++ b/litigant_portal/app/models/chat.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.conf import settings
 from django.db import models
 from django_pydantic_field import SchemaField
 
@@ -11,15 +10,11 @@ class ChatSession(models.Model):
     """A chat conversation session."""
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        null=True,
-        blank=True,
-        on_delete=models.SET_NULL,
+    identity = models.ForeignKey(
+        "UserIdentity",
+        on_delete=models.CASCADE,
         related_name="chat_sessions",
     )
-    # For anonymous users, track by session key
-    session_key = models.CharField(max_length=40, blank=True, db_index=True)
     topic = models.CharField(max_length=50, blank=True)
     jurisdiction = models.CharField(max_length=10, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
@@ -27,14 +22,10 @@ class ChatSession(models.Model):
 
     class Meta:
         ordering = ["-updated_at"]
-        indexes = [
-            models.Index(fields=["user", "-created_at"]),
-            models.Index(fields=["session_key", "-created_at"]),
-        ]
 
     def __str__(self):
-        if self.user:
-            return f"Chat {self.id} - {self.user}"
+        if self.identity.user_id:
+            return f"Chat {self.id} - {self.identity.user}"
         return f"Chat {self.id} - Anonymous"
 
 
@@ -82,23 +73,19 @@ class Message(models.Model):
 class CaseInfo(models.Model):
     """Server-side storage for extracted case information.
 
-    Replaces browser localStorage for PII (names, case numbers, court
-    details). Same dual-ownership pattern as ChatSession: authenticated
-    users get user FK, anonymous users get session_key. Optional
-    chat_session FK tracks which conversation produced the data.
+    Linked to a UserIdentity (which may represent an authenticated user or
+    an anonymous session). When the user logs in, only the UserIdentity row
+    changes — this record and all its children follow automatically.
 
-    User FK uses CASCADE — PII is deleted when the user is deleted.
+    Cascade delete on identity: PII is removed when the identity is deleted.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        null=True,
-        blank=True,
+    identity = models.ForeignKey(
+        "UserIdentity",
         on_delete=models.CASCADE,
         related_name="case_infos",
     )
-    session_key = models.CharField(max_length=40, blank=True, db_index=True)
     chat_session = models.ForeignKey(
         ChatSession,
         null=True,
@@ -131,15 +118,11 @@ class CaseInfo(models.Model):
 
     class Meta:
         ordering = ["-updated_at"]
-        indexes = [
-            models.Index(fields=["user", "-created_at"]),
-            models.Index(fields=["session_key", "-created_at"]),
-        ]
 
     def __str__(self):
         case_type = self.data.get("case_type", "Unknown")
-        if self.user:
-            return f"Case {self.id} - {case_type} ({self.user})"
+        if self.identity.user_id:
+            return f"Case {self.id} - {case_type} ({self.identity.user})"
         return f"Case {self.id} - {case_type} (Anonymous)"
 
 

--- a/litigant_portal/app/models/user.py
+++ b/litigant_portal/app/models/user.py
@@ -3,6 +3,52 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 
+class UserIdentity(models.Model):
+    """Single identity row for either an authenticated user or an anonymous session.
+
+    Downstream models (ChatSession, CaseInfo) link here via FK so that at
+    login, updating this one row migrates all associated data automatically —
+    no per-model FK updates needed.
+    """
+
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="identity",
+    )
+    session_key = models.CharField(max_length=40, blank=True, db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = "User Identity"
+        verbose_name_plural = "User Identities"
+
+    def __str__(self):
+        if self.user_id:
+            return f"Identity({self.user})"
+        key = self.session_key[:8] if self.session_key else "..."
+        return f"Identity(anon:{key})"
+
+    @classmethod
+    def for_request(cls, request) -> "UserIdentity":
+        """Get or create the identity for the current request."""
+        if request.user.is_authenticated:
+            identity, _ = cls.objects.get_or_create(
+                user=request.user,
+                defaults={"session_key": ""},
+            )
+            return identity
+        if not request.session.session_key:
+            request.session.create()
+        identity, _ = cls.objects.get_or_create(
+            user=None,
+            session_key=request.session.session_key,
+        )
+        return identity
+
+
 class UserProfile(models.Model):
     """
     Extended profile data for authenticated users.

--- a/litigant_portal/app/models/user.py
+++ b/litigant_portal/app/models/user.py
@@ -31,23 +31,6 @@ class UserIdentity(models.Model):
         key = self.session_key[:8] if self.session_key else "..."
         return f"Identity(anon:{key})"
 
-    @classmethod
-    def for_request(cls, request) -> "UserIdentity":
-        """Get or create the identity for the current request."""
-        if request.user.is_authenticated:
-            identity, _ = cls.objects.get_or_create(
-                user=request.user,
-                defaults={"session_key": ""},
-            )
-            return identity
-        if not request.session.session_key:
-            request.session.create()
-        identity, _ = cls.objects.get_or_create(
-            user=None,
-            session_key=request.session.session_key,
-        )
-        return identity
-
 
 class UserProfile(models.Model):
     """

--- a/litigant_portal/app/services/chat_service.py
+++ b/litigant_portal/app/services/chat_service.py
@@ -52,7 +52,7 @@ class ChatService:
         # Phase is derived from session state inside from_session_id for
         # existing sessions; new sessions default to "triage" there.
         self.agent = agent_class.from_session_id(
-            request, session_id, **agent_kwargs
+            request.identity, session_id, **agent_kwargs
         )
 
     def stream(self, user_message: str) -> StreamingHttpResponse:

--- a/litigant_portal/app/services/identity.py
+++ b/litigant_portal/app/services/identity.py
@@ -1,0 +1,60 @@
+import logging
+
+from django.db import transaction
+
+from litigant_portal.app.models import UserIdentity
+
+logger = logging.getLogger(__name__)
+
+
+def identity_ensure(*, user) -> UserIdentity:
+    """Return the UserIdentity for an authenticated user, creating it if needed."""
+    identity, _ = UserIdentity.objects.get_or_create(
+        user=user, defaults={"session_key": ""}
+    )
+    return identity
+
+
+@transaction.atomic
+def identity_merge(
+    *, source_identity: UserIdentity, target_identity: UserIdentity
+) -> None:
+    """Fold ``source`` into ``target``, then delete ``source``.
+
+    All chat sessions migrate. For cases, an identity is assumed to hold at
+    most one active case: if ``target`` already has one, ``source``'s active
+    case is dropped as a duplicate. Every other case (resolved/archived)
+    migrates regardless. Runs in a single transaction.
+    """
+    chats = source_identity.chat_sessions.update(identity=target_identity)
+
+    dropped = 0
+    if target_identity.case_infos.filter(status="active").exists():
+        duplicates = source_identity.case_infos.filter(status="active")
+        dropped = duplicates.count()
+        duplicates.delete()
+    cases = source_identity.case_infos.update(identity=target_identity)
+
+    source_identity.delete()
+
+    logger.info(
+        "Merged anonymous identity into user %s: %d chat session(s), "
+        "%d case(s) migrated, %d duplicate active case(s) dropped",
+        target_identity.user_id,
+        chats,
+        cases,
+        dropped,
+    )
+
+
+def identity_merge_anonymous(*, user, session_key: str) -> None:
+    """On login, fold the anonymous identity for ``session_key`` into ``user``."""
+    anon_identity = UserIdentity.objects.filter(
+        session_key=session_key, user__isnull=True
+    ).first()
+    if anon_identity is None:
+        return
+    target_identity = identity_ensure(user=user)
+    identity_merge(
+        source_identity=anon_identity, target_identity=target_identity
+    )

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -1,56 +1,12 @@
-"""Signals for migrating anonymous data to authenticated users."""
-
-import logging
-
 from django.contrib.auth.signals import user_logged_in
 from django.dispatch import receiver
 
-from .models import CaseInfo, ChatSession
-
-logger = logging.getLogger(__name__)
+from .services.identity import identity_merge_anonymous
 
 
 @receiver(user_logged_in)
-def migrate_anonymous_data(request, user, **kwargs):
-    """Migrate ChatSession and CaseInfo from anonymous session to user.
-
-    When a user logs in, any data created during their anonymous session
-    (identified by session_key) gets transferred to their user account.
-    If the user already has a CaseInfo, the anonymous one is deleted to
-    avoid duplicates.
-    """
-    # login() calls session.cycle_key() before this signal fires,
-    # so session_key is the new one. The middleware saved the original
-    # anonymous key as session data (which survives cycle_key).
+def merge_anonymous_identity(request, user, **kwargs):
+    """On login, fold the anonymous UserIdentity into the user's identity."""
     session_key = request.session.pop("_anonymous_session_key", None)
-    if not session_key:
-        return
-
-    # Migrate chat sessions
-    anonymous_sessions = ChatSession.objects.filter(
-        session_key=session_key, user__isnull=True
-    )
-    migrated_chats = anonymous_sessions.update(user=user, session_key="")
-    if migrated_chats:
-        logger.info(
-            "Migrated %d chat session(s) for user %s", migrated_chats, user
-        )
-
-    # Migrate case info
-    anonymous_case = CaseInfo.objects.filter(
-        session_key=session_key, user__isnull=True
-    ).first()
-
-    if not anonymous_case:
-        return
-
-    existing_case = CaseInfo.objects.filter(user=user).first()
-    if existing_case:
-        # User already has case info — delete the anonymous one
-        anonymous_case.delete()
-        logger.info("Deleted duplicate anonymous CaseInfo for user %s", user)
-    else:
-        anonymous_case.user = user
-        anonymous_case.session_key = ""
-        anonymous_case.save(update_fields=["user", "session_key"])
-        logger.info("Migrated CaseInfo to user %s", user)
+    if session_key:
+        identity_merge_anonymous(user=user, session_key=session_key)

--- a/litigant_portal/app/tests/test_action_plan.py
+++ b/litigant_portal/app/tests/test_action_plan.py
@@ -3,7 +3,12 @@
 import pytest
 from django.test import Client, TestCase
 
-from litigant_portal.app.models import ActionItemModel, CaseInfo, Deadline
+from litigant_portal.app.models import (
+    ActionItemModel,
+    CaseInfo,
+    Deadline,
+    UserIdentity,
+)
 
 pytestmark = pytest.mark.postgres
 
@@ -33,8 +38,9 @@ class ActionPlanViewTests(TestCase):
         session.save()
         self.client.cookies["sessionid"] = session.session_key
 
+        identity = UserIdentity.objects.create(session_key=session.session_key)
         case = CaseInfo.objects.create(
-            session_key=session.session_key, data=SAMPLE_CASE_DATA
+            identity=identity, data=SAMPLE_CASE_DATA
         )
         Deadline.objects.create(
             case=case, label="Answer deadline", date="2026-03-15"

--- a/litigant_portal/app/tests/test_agents.py
+++ b/litigant_portal/app/tests/test_agents.py
@@ -24,6 +24,7 @@ from litigant_portal.app.models import (
     CaseInfo,
     ChatSession,
     Deadline,
+    UserIdentity,
 )
 
 User = get_user_model()
@@ -165,9 +166,15 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
         self.user = User.objects.create_user(
             username="jane", password="testpass"
         )
-        self.user_session = ChatSession.objects.create(user=self.user)
-        self.anon_session = ChatSession.objects.create(
+        self.user_identity = UserIdentity.objects.create(user=self.user)
+        self.anon_identity = UserIdentity.objects.create(
             session_key="anon-key-abc"
+        )
+        self.user_session = ChatSession.objects.create(
+            identity=self.user_identity
+        )
+        self.anon_session = ChatSession.objects.create(
+            identity=self.anon_identity
         )
 
     def _call(self, tool, session):
@@ -175,18 +182,25 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
 
     def test_creates_case_info_for_authenticated_user(self):
         """First call creates a CaseInfo owned by the user."""
-        self.assertEqual(CaseInfo.objects.filter(user=self.user).count(), 0)
+        self.assertEqual(
+            CaseInfo.objects.filter(identity__user=self.user).count(), 0
+        )
 
         self._call(UpdateCaseFacts(case_type="Eviction"), self.user_session)
 
-        self.assertEqual(CaseInfo.objects.filter(user=self.user).count(), 1)
-        case = CaseInfo.objects.get(user=self.user)
+        self.assertEqual(
+            CaseInfo.objects.filter(identity__user=self.user).count(), 1
+        )
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(case.data["case_type"], "Eviction")
 
     def test_creates_case_info_for_anonymous_session(self):
         """First call creates a CaseInfo keyed by session_key for anon users."""
         self.assertEqual(
-            CaseInfo.objects.filter(session_key="anon-key-abc").count(), 0
+            CaseInfo.objects.filter(
+                identity__session_key="anon-key-abc"
+            ).count(),
+            0,
         )
 
         self._call(
@@ -194,24 +208,29 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
         )
 
         self.assertEqual(
-            CaseInfo.objects.filter(session_key="anon-key-abc").count(), 1
+            CaseInfo.objects.filter(
+                identity__session_key="anon-key-abc"
+            ).count(),
+            1,
         )
-        case = CaseInfo.objects.get(session_key="anon-key-abc")
+        case = CaseInfo.objects.get(identity__session_key="anon-key-abc")
         self.assertEqual(case.data["case_type"], "Small Claims")
 
     def test_updates_existing_case_type(self):
         """Subsequent call updates the case_type in the existing CaseInfo."""
-        CaseInfo.objects.create(user=self.user, data={"case_type": "Unknown"})
+        CaseInfo.objects.create(
+            identity=self.user_identity, data={"case_type": "Unknown"}
+        )
 
         self._call(UpdateCaseFacts(case_type="Eviction"), self.user_session)
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(case.data["case_type"], "Eviction")
 
     def test_merges_court_info_preserves_existing_fields(self):
         """Merging partial court_info updates given fields without clearing others."""
         CaseInfo.objects.create(
-            user=self.user,
+            identity=self.user_identity,
             data={
                 "court_info": {
                     "court_name": "Circuit Court",
@@ -222,7 +241,7 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
 
         self._call(UpdateCaseFacts(court_county="DuPage"), self.user_session)
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(case.data["court_info"]["county"], "DuPage")
         # Existing field must not be overwritten
         self.assertEqual(
@@ -233,7 +252,7 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
     def test_merges_parties_preserves_existing_fields(self):
         """Merging partial parties updates given fields without clearing others."""
         CaseInfo.objects.create(
-            user=self.user,
+            identity=self.user_identity,
             data={
                 "parties": {
                     "opposing_party": "Acme Corp",
@@ -246,7 +265,7 @@ class UpdateCaseFactsDbPersistenceTests(TestCase):
             UpdateCaseFacts(opposing_address="100 Oak Ave"), self.user_session
         )
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(
             case.data["parties"]["opposing_address"], "100 Oak Ave"
         )
@@ -267,8 +286,9 @@ class UpdateCaseFactsDateDeduplicationTests(TestCase):
         self.user = User.objects.create_user(
             username="jane", password="testpass"
         )
-        self.session = ChatSession.objects.create(user=self.user)
-        self.case = CaseInfo.objects.create(user=self.user, data={})
+        self.identity = UserIdentity.objects.create(user=self.user)
+        self.session = ChatSession.objects.create(identity=self.identity)
+        self.case = CaseInfo.objects.create(identity=self.identity, data={})
         Deadline.objects.create(
             case=self.case,
             label="Hearing",
@@ -411,9 +431,15 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
         self.user = User.objects.create_user(
             username="jane", password="testpass"
         )
-        self.user_session = ChatSession.objects.create(user=self.user)
-        self.anon_session = ChatSession.objects.create(
+        self.user_identity = UserIdentity.objects.create(user=self.user)
+        self.anon_identity = UserIdentity.objects.create(
             session_key="anon-key-xyz"
+        )
+        self.user_session = ChatSession.objects.create(
+            identity=self.user_identity
+        )
+        self.anon_session = ChatSession.objects.create(
+            identity=self.anon_identity
         )
 
     def _call(self, tool, session):
@@ -428,7 +454,7 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
             self.user_session,
         )
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(case.action_items.count(), 1)
         self.assertEqual(case.action_items.first().title, "File an Appearance")
 
@@ -441,7 +467,7 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
             self.anon_session,
         )
 
-        case = CaseInfo.objects.get(session_key="anon-key-xyz")
+        case = CaseInfo.objects.get(identity__session_key="anon-key-xyz")
         self.assertEqual(case.action_items.count(), 1)
 
     def test_spotted_issues_stored_in_json(self):
@@ -453,7 +479,7 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
             self.user_session,
         )
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(len(case.data["spotted_issues"]), 1)
         self.assertEqual(
             case.data["spotted_issues"][0]["title"], "Habitability defense"
@@ -468,7 +494,7 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
             self.user_session,
         )
 
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertEqual(len(case.data["resources"]), 1)
 
     def test_action_items_not_in_json(self):
@@ -477,7 +503,7 @@ class UpdateActionPlanDbPersistenceTests(TestCase):
             UpdateActionPlan(new_action_items=[ActionItem(title="Test")]),
             self.user_session,
         )
-        case = CaseInfo.objects.get(user=self.user)
+        case = CaseInfo.objects.get(identity__user=self.user)
         self.assertNotIn("action_items", case.data)
 
     def test_no_session_skips_db_write(self):
@@ -498,8 +524,9 @@ class UpdateActionPlanDeduplicationTests(TestCase):
         self.user = User.objects.create_user(
             username="jane", password="testpass"
         )
-        self.session = ChatSession.objects.create(user=self.user)
-        self.case = CaseInfo.objects.create(user=self.user, data={})
+        self.identity = UserIdentity.objects.create(user=self.user)
+        self.session = ChatSession.objects.create(identity=self.identity)
+        self.case = CaseInfo.objects.create(identity=self.identity, data={})
         ActionItemModel.objects.create(
             case=self.case,
             title="File an Appearance",

--- a/litigant_portal/app/tests/test_chat_session_topic.py
+++ b/litigant_portal/app/tests/test_chat_session_topic.py
@@ -8,7 +8,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase
 
-from litigant_portal.app.models import ChatSession
+from litigant_portal.app.models import ChatSession, UserIdentity
 
 User = get_user_model()
 
@@ -17,25 +17,32 @@ User = get_user_model()
 class ChatSessionTopicFieldTests(TestCase):
     """Tests for topic and jurisdiction fields on ChatSession."""
 
+    def setUp(self):
+        self.identity = UserIdentity.objects.create()
+
     def test_topic_defaults_to_empty(self):
-        session = ChatSession.objects.create()
+        session = ChatSession.objects.create(identity=self.identity)
 
         self.assertEqual(session.topic, "")
 
     def test_jurisdiction_defaults_to_empty(self):
-        session = ChatSession.objects.create()
+        session = ChatSession.objects.create(identity=self.identity)
 
         self.assertEqual(session.jurisdiction, "")
 
     def test_topic_persists(self):
-        session = ChatSession.objects.create(topic="housing")
+        session = ChatSession.objects.create(
+            identity=self.identity, topic="housing"
+        )
 
         session.refresh_from_db()
 
         self.assertEqual(session.topic, "housing")
 
     def test_jurisdiction_persists(self):
-        session = ChatSession.objects.create(jurisdiction="il")
+        session = ChatSession.objects.create(
+            identity=self.identity, jurisdiction="il"
+        )
 
         session.refresh_from_db()
 
@@ -43,7 +50,7 @@ class ChatSessionTopicFieldTests(TestCase):
 
     def test_both_fields_persist_together(self):
         session = ChatSession.objects.create(
-            topic="housing", jurisdiction="il"
+            identity=self.identity, topic="housing", jurisdiction="il"
         )
 
         session.refresh_from_db()

--- a/litigant_portal/app/tests/test_chat_session_topic.py
+++ b/litigant_portal/app/tests/test_chat_session_topic.py
@@ -8,6 +8,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase
 
+from litigant_portal.app.middleware import IdentityMiddleware
 from litigant_portal.app.models import ChatSession, UserIdentity
 
 User = get_user_model()
@@ -74,6 +75,7 @@ class ChatSessionTopicServiceTests(TestCase):
         request.user = self.user
         request.session = self.client.session
         request.session.create()
+        IdentityMiddleware(lambda r: None)(request)
         return request
 
     def test_new_session_persists_topic(self):

--- a/litigant_portal/app/tests/test_identity_services.py
+++ b/litigant_portal/app/tests/test_identity_services.py
@@ -1,0 +1,122 @@
+"""Unit tests for the identity services.
+
+These exercise the core logic directly — no HTTP client, no login flow —
+which is the payoff of moving the merge out of the signal handler. The
+end-to-end signal path stays covered by test_signals.py.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from litigant_portal.app.models import CaseInfo, ChatSession, UserIdentity
+from litigant_portal.app.services.identity import (
+    identity_ensure,
+    identity_merge,
+    identity_merge_anonymous,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.postgres
+class IdentityEnsureTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="p")
+
+    def test_creates_identity_when_missing(self):
+        identity = identity_ensure(user=self.user)
+        self.assertEqual(identity.user, self.user)
+        self.assertEqual(identity.session_key, "")
+
+    def test_returns_existing_identity_without_duplicating(self):
+        existing = UserIdentity.objects.create(user=self.user)
+        self.assertEqual(identity_ensure(user=self.user), existing)
+        self.assertEqual(
+            UserIdentity.objects.filter(user=self.user).count(), 1
+        )
+
+
+@pytest.mark.postgres
+class IdentityMergeTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="p")
+        self.target = UserIdentity.objects.create(user=self.user)
+        self.anon = UserIdentity.objects.create(session_key="abc123")
+
+    def test_migrates_chat_sessions_and_deletes_source(self):
+        chat = ChatSession.objects.create(identity=self.anon)
+        identity_merge(source_identity=self.anon, target_identity=self.target)
+        chat.refresh_from_db()
+        self.assertEqual(chat.identity, self.target)
+        self.assertFalse(UserIdentity.objects.filter(pk=self.anon.pk).exists())
+
+    def test_migrates_anonymous_case_and_its_children(self):
+        case = CaseInfo.objects.create(
+            identity=self.anon, data={"case_type": "Eviction"}
+        )
+        case.timeline_events.create(event_type="upload", title="Receipt")
+        identity_merge(source_identity=self.anon, target_identity=self.target)
+        case.refresh_from_db()
+        self.assertEqual(case.identity, self.target)
+        # Children hang off the case, not the identity, so they follow it.
+        self.assertEqual(case.timeline_events.count(), 1)
+
+    def test_drops_duplicate_active_case_keeping_target(self):
+        CaseInfo.objects.create(
+            identity=self.target,
+            status="active",
+            data={"case_type": "Foreclosure"},
+        )
+        CaseInfo.objects.create(
+            identity=self.anon,
+            status="active",
+            data={"case_type": "Eviction"},
+        )
+        identity_merge(source_identity=self.anon, target_identity=self.target)
+        cases = CaseInfo.objects.all()
+        self.assertEqual(cases.count(), 1)
+        self.assertEqual(cases.first().data["case_type"], "Foreclosure")
+
+    def test_migrates_non_active_case_even_when_target_has_active(self):
+        # The case the old signal silently cascade-dropped.
+        CaseInfo.objects.create(
+            identity=self.target,
+            status="active",
+            data={"case_type": "Foreclosure"},
+        )
+        CaseInfo.objects.create(
+            identity=self.anon,
+            status="archived",
+            data={"case_type": "Eviction"},
+        )
+        identity_merge(source_identity=self.anon, target_identity=self.target)
+        archived = CaseInfo.objects.get(status="archived")
+        self.assertEqual(archived.identity, self.target)
+
+
+@pytest.mark.postgres
+class IdentityAbsorbAnonymousTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u", password="p")
+
+    def test_noop_when_no_anonymous_identity(self):
+        identity_merge_anonymous(user=self.user, session_key="missing")
+        self.assertFalse(UserIdentity.objects.filter(user=self.user).exists())
+
+    def test_absorbs_anonymous_data_into_user(self):
+        anon = UserIdentity.objects.create(session_key="abc123")
+        ChatSession.objects.create(identity=anon)
+        identity_merge_anonymous(user=self.user, session_key="abc123")
+        target = UserIdentity.objects.get(user=self.user)
+        self.assertEqual(target.chat_sessions.count(), 1)
+        self.assertFalse(UserIdentity.objects.filter(pk=anon.pk).exists())
+
+    def test_ignores_logged_in_identity_sharing_the_session_key(self):
+        # A user-owned identity must never be treated as anonymous, even if it
+        # somehow shares the session key — guards the user__isnull filter.
+        UserIdentity.objects.create(user=self.user, session_key="abc123")
+        identity_merge_anonymous(user=self.user, session_key="abc123")
+        self.assertEqual(
+            UserIdentity.objects.filter(user=self.user).count(), 1
+        )

--- a/litigant_portal/app/tests/test_middleware.py
+++ b/litigant_portal/app/tests/test_middleware.py
@@ -1,8 +1,13 @@
-"""Tests for AnonymousSessionKeyMiddleware."""
+"""Tests for app middleware."""
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+
+from litigant_portal.app.middleware import IdentityMiddleware
+from litigant_portal.app.models import UserIdentity
 
 User = get_user_model()
 
@@ -41,3 +46,36 @@ class AnonymousSessionKeyMiddlewareTests(TestCase):
         self.client.get("/")
 
         self.assertNotIn("_anonymous_session_key", self.client.session)
+
+
+@pytest.mark.postgres
+class IdentityMiddlewareTests(TestCase):
+    """Tests for the lazy request.identity attachment."""
+
+    def _request(self, user=None):
+        request = RequestFactory().get("/")
+        SessionMiddleware(lambda r: None).process_request(request)
+        request.user = user or AnonymousUser()
+        return request
+
+    def test_identity_is_lazy_until_accessed(self):
+        request = self._request()
+        IdentityMiddleware(lambda r: None)(request)
+        # Attached, but the get-or-create has not run yet.
+        self.assertEqual(UserIdentity.objects.count(), 0)
+        # First access resolves it (and creates the anonymous identity).
+        self.assertIsNone(request.identity.user)
+        self.assertEqual(UserIdentity.objects.count(), 1)
+
+    def test_authenticated_request_resolves_to_user_identity(self):
+        user = User.objects.create_user(username="u", password="p")
+        request = self._request(user=user)
+        IdentityMiddleware(lambda r: None)(request)
+        self.assertEqual(request.identity.user, user)
+
+    def test_resolution_is_memoized_per_request(self):
+        request = self._request()
+        IdentityMiddleware(lambda r: None)(request)
+        first_pk = request.identity.pk
+        self.assertEqual(request.identity.pk, first_pk)
+        self.assertEqual(UserIdentity.objects.count(), 1)

--- a/litigant_portal/app/tests/test_models.py
+++ b/litigant_portal/app/tests/test_models.py
@@ -15,9 +15,14 @@ from litigant_portal.app.models import (
     Deadline,
     Message,
     TimelineEvent,
+    UserIdentity,
 )
 
 User = get_user_model()
+
+
+def _anon_identity(**kwargs):
+    return UserIdentity.objects.create(**kwargs)
 
 
 @pytest.mark.postgres
@@ -29,7 +34,8 @@ class ChatSessionStrTests(TestCase):
         user = User.objects.create_user(
             username="testuser", password="testpass"
         )
-        session = ChatSession.objects.create(user=user)
+        identity = UserIdentity.objects.create(user=user)
+        session = ChatSession.objects.create(identity=identity)
 
         result = str(session)
 
@@ -38,7 +44,8 @@ class ChatSessionStrTests(TestCase):
 
     def test_str_shows_anonymous_when_no_user(self):
         """__str__ should show 'Anonymous' for sessions without user."""
-        session = ChatSession.objects.create(session_key="abc123")
+        identity = UserIdentity.objects.create(session_key="abc123")
+        session = ChatSession.objects.create(identity=identity)
 
         result = str(session)
 
@@ -51,7 +58,8 @@ class MessageStrTests(TestCase):
     """Tests for Message.__str__ truncation logic at 50-char boundary."""
 
     def setUp(self):
-        self.session = ChatSession.objects.create()
+        identity = _anon_identity()
+        self.session = ChatSession.objects.create(identity=identity)
 
     def test_str_no_truncation_at_50_chars(self):
         """Content exactly 50 chars should NOT be truncated."""
@@ -99,8 +107,9 @@ class CaseInfoStrTests(TestCase):
 
     def test_str_shows_case_type_and_username(self):
         user = User.objects.create_user(username="jane", password="testpass")
+        identity = UserIdentity.objects.create(user=user)
         case = CaseInfo.objects.create(
-            user=user, data={"case_type": "Eviction"}
+            identity=identity, data={"case_type": "Eviction"}
         )
 
         result = str(case)
@@ -109,8 +118,9 @@ class CaseInfoStrTests(TestCase):
         self.assertIn("jane", result)
 
     def test_str_shows_anonymous_when_no_user(self):
+        identity = UserIdentity.objects.create(session_key="abc123")
         case = CaseInfo.objects.create(
-            session_key="abc123", data={"case_type": "Eviction"}
+            identity=identity, data={"case_type": "Eviction"}
         )
 
         result = str(case)
@@ -119,7 +129,8 @@ class CaseInfoStrTests(TestCase):
         self.assertIn("Anonymous", result)
 
     def test_str_shows_unknown_when_no_case_type(self):
-        case = CaseInfo.objects.create(data={})
+        identity = _anon_identity()
+        case = CaseInfo.objects.create(identity=identity, data={})
 
         result = str(case)
 
@@ -131,7 +142,8 @@ class TimelineEventStrTests(TestCase):
     """Tests for TimelineEvent.__str__ display logic."""
 
     def setUp(self):
-        self.case = CaseInfo.objects.create(data={})
+        identity = _anon_identity()
+        self.case = CaseInfo.objects.create(identity=identity, data={})
 
     def test_str_uses_title_when_set(self):
         event = TimelineEvent.objects.create(
@@ -187,21 +199,28 @@ class TimelineEventStrTests(TestCase):
 class CaseInfoStatusTests(TestCase):
     """Tests for CaseInfo.status field."""
 
+    def setUp(self):
+        self.identity = _anon_identity()
+
     def test_default_status_is_active(self):
         """New CaseInfo should default to 'active' status."""
-        case = CaseInfo.objects.create(data={})
+        case = CaseInfo.objects.create(identity=self.identity, data={})
 
         self.assertEqual(case.status, "active")
 
     def test_status_accepts_resolved(self):
-        case = CaseInfo.objects.create(data={}, status="resolved")
+        case = CaseInfo.objects.create(
+            identity=self.identity, data={}, status="resolved"
+        )
 
         case.refresh_from_db()
 
         self.assertEqual(case.status, "resolved")
 
     def test_status_accepts_archived(self):
-        case = CaseInfo.objects.create(data={}, status="archived")
+        case = CaseInfo.objects.create(
+            identity=self.identity, data={}, status="archived"
+        )
 
         case.refresh_from_db()
 
@@ -213,7 +232,8 @@ class DeadlineToDictTests(TestCase):
     """Tests for Deadline.to_dict() serialization."""
 
     def setUp(self):
-        self.case = CaseInfo.objects.create(data={})
+        identity = _anon_identity()
+        self.case = CaseInfo.objects.create(identity=identity, data={})
 
     def test_to_dict_includes_id_as_string(self):
         """to_dict() must include id as a string (not UUID object)."""
@@ -262,7 +282,8 @@ class ActionItemToDictTests(TestCase):
     """Tests for ActionItemModel.to_dict() serialization."""
 
     def setUp(self):
-        self.case = CaseInfo.objects.create(data={})
+        identity = _anon_identity()
+        self.case = CaseInfo.objects.create(identity=identity, data={})
 
     def test_to_dict_includes_id_as_string(self):
         """to_dict() must include id as a string (not UUID object)."""
@@ -303,6 +324,7 @@ class ActionItemToDictTests(TestCase):
         self.assertEqual(normal.to_dict()["priority"], "normal")
 
 
+@pytest.mark.postgres
 class ActionItemOrderingTests(TestCase):
     """Tests for ActionItemModel default ordering (#329 sidebar pin).
 
@@ -311,7 +333,8 @@ class ActionItemOrderingTests(TestCase):
     """
 
     def setUp(self):
-        self.case = CaseInfo.objects.create(data={})
+        identity = _anon_identity()
+        self.case = CaseInfo.objects.create(identity=identity, data={})
 
     def test_urgent_items_come_before_normal(self):
         ActionItemModel.objects.create(

--- a/litigant_portal/app/tests/test_signals.py
+++ b/litigant_portal/app/tests/test_signals.py
@@ -1,11 +1,16 @@
-"""Tests for anonymous-to-authenticated data migration signal."""
+"""End-to-end coverage for the anonymous-to-authenticated merge signal.
+
+The merge *logic* is unit-tested in test_identity_services.py. These tests
+cover only what those can't: that the signal is actually wired to login, and
+that the request-bound session key is read correctly across cycle_key().
+"""
 
 import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase, override_settings
 
-from litigant_portal.app.models import CaseInfo, ChatSession
+from litigant_portal.app.models import CaseInfo, ChatSession, UserIdentity
 
 User = get_user_model()
 
@@ -13,17 +18,15 @@ User = get_user_model()
 def _create_anonymous_session(client):
     """Create an anonymous session and store the key for migration.
 
-    Simulates what happens in production: the middleware stores
-    _anonymous_session_key in session data on each anonymous request,
-    and cycle_key() preserves it across login.
+    Simulates production: the middleware stores _anonymous_session_key in
+    session data on each anonymous request, and cycle_key() preserves it
+    across login.
     """
     session = client.session
     session.create()
     session["_anonymous_session_key"] = session.session_key
     session.save()
-    # Set the session cookie so subsequent requests use this session
-    cookie_name = settings.SESSION_COOKIE_NAME
-    client.cookies[cookie_name] = session.session_key
+    client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
     return session.session_key
 
 
@@ -32,93 +35,35 @@ def _create_anonymous_session(client):
     ACCOUNT_EMAIL_VERIFICATION="none",
     ACCOUNT_AUTHENTICATION_METHOD="username",
 )
-class MigrateAnonymousDataTests(TestCase):
-    """Tests for the user_logged_in signal handler."""
+class MergeAnonymousIdentitySignalTests(TestCase):
+    """The signal wiring and request-key glue — not the merge logic itself."""
 
     def setUp(self):
         self.user = User.objects.create_user(
             username="testuser", password="testpass"
         )
 
-    def test_migrates_anonymous_chat_sessions(self):
-        """Anonymous chat sessions should be linked to user on login."""
+    def test_login_migrates_anonymous_data(self):
+        """Logging in fires the signal and folds anon data into the user."""
         client = Client()
         session_key = _create_anonymous_session(client)
-
-        chat_session = ChatSession.objects.create(session_key=session_key)
-
-        client.login(username="testuser", password="testpass")
-
-        chat_session.refresh_from_db()
-        self.assertEqual(chat_session.user, self.user)
-        self.assertEqual(chat_session.session_key, "")
-
-    def test_migrates_anonymous_case_info(self):
-        """Anonymous CaseInfo should be linked to user on login."""
-        client = Client()
-        session_key = _create_anonymous_session(client)
-
+        anon = UserIdentity.objects.create(session_key=session_key)
+        chat = ChatSession.objects.create(identity=anon)
         case = CaseInfo.objects.create(
-            session_key=session_key,
-            data={"case_type": "Eviction"},
+            identity=anon, data={"case_type": "Eviction"}
         )
 
         client.login(username="testuser", password="testpass")
 
+        chat.refresh_from_db()
         case.refresh_from_db()
-        self.assertEqual(case.user, self.user)
-        self.assertEqual(case.session_key, "")
-        self.assertEqual(case.data["case_type"], "Eviction")
+        self.assertEqual(chat.identity.user, self.user)
+        self.assertEqual(case.identity.user, self.user)
 
-    def test_deletes_duplicate_anonymous_case(self):
-        """If user already has CaseInfo, anonymous one is deleted."""
-        client = Client()
-        session_key = _create_anonymous_session(client)
-
-        # User already has a case
-        CaseInfo.objects.create(
-            user=self.user,
-            data={"case_type": "Foreclosure"},
-        )
-        # Anonymous case exists too
-        CaseInfo.objects.create(
-            session_key=session_key,
-            data={"case_type": "Eviction"},
-        )
-
-        client.login(username="testuser", password="testpass")
-
-        # User's existing case should remain
-        self.assertEqual(CaseInfo.objects.count(), 1)
-        remaining = CaseInfo.objects.first()
-        self.assertEqual(remaining.user, self.user)
-        self.assertEqual(remaining.data["case_type"], "Foreclosure")
-
-    def test_noop_without_anonymous_data(self):
-        """Login without anonymous data should not error."""
+    def test_login_without_anonymous_data_is_safe(self):
+        """No anonymous key in the session → no-op, no error."""
         client = Client()
         client.login(username="testuser", password="testpass")
 
         self.assertEqual(ChatSession.objects.count(), 0)
         self.assertEqual(CaseInfo.objects.count(), 0)
-
-    def test_timeline_events_follow_case(self):
-        """TimelineEvents should follow their CaseInfo to the user."""
-        client = Client()
-        session_key = _create_anonymous_session(client)
-
-        case = CaseInfo.objects.create(
-            session_key=session_key,
-            data={"case_type": "Eviction"},
-        )
-        case.timeline_events.create(
-            event_type="upload",
-            title="Test upload",
-            content="Test content",
-        )
-
-        client.login(username="testuser", password="testpass")
-
-        case.refresh_from_db()
-        self.assertEqual(case.user, self.user)
-        self.assertEqual(case.timeline_events.count(), 1)

--- a/litigant_portal/app/tests/test_views.py
+++ b/litigant_portal/app/tests/test_views.py
@@ -12,7 +12,12 @@ from django.test import Client, TestCase, override_settings
 
 from litigant_portal.agents import agent_registry
 from litigant_portal.agents.base import Agent
-from litigant_portal.app.models import ChatSession, Document, Message
+from litigant_portal.app.models import (
+    ChatSession,
+    Document,
+    Message,
+    UserIdentity,
+)
 
 User = get_user_model()
 
@@ -165,7 +170,7 @@ class StreamAuthTests(TestCase):
         list(response.streaming_content)
 
         session = ChatSession.objects.first()
-        self.assertEqual(session.user, self.user)
+        self.assertEqual(session.identity.user, self.user)
 
 
 @pytest.mark.postgres
@@ -187,10 +192,11 @@ class StreamOwnershipTests(TestCase):
 
     def test_403_for_wrong_session_key(self):
         """Anonymous user cannot access another's session."""
-        # Create session with different session key
-        other_session = ChatSession.objects.create(
+        # Create session belonging to a different anonymous identity
+        other_identity = UserIdentity.objects.create(
             session_key="other-session-key"
         )
+        other_session = ChatSession.objects.create(identity=other_identity)
 
         response = self.client.post(
             "/api/chat/stream/",
@@ -204,7 +210,8 @@ class StreamOwnershipTests(TestCase):
         other_user = User.objects.create_user(
             username="other", password="pass"
         )
-        other_session = ChatSession.objects.create(user=other_user)
+        other_identity = UserIdentity.objects.create(user=other_user)
+        other_session = ChatSession.objects.create(identity=other_identity)
 
         User.objects.create_user(username="testuser", password="testpass")
         self.client.login(username="testuser", password="testpass")

--- a/litigant_portal/app/views/endpoints.py
+++ b/litigant_portal/app/views/endpoints.py
@@ -19,19 +19,6 @@ from litigant_portal.app.services.pdf_service import pdf_service
 from litigant_portal.app.services.search_service import search_service
 
 
-def _ownership_filter(request: HttpRequest) -> dict:
-    """Return query filter for the current user's data.
-
-    Authenticated users match by user FK, anonymous users by session_key.
-    Same dual-ownership pattern as ChatSession.
-    """
-    if request.user.is_authenticated:
-        return {"user": request.user}
-    if not request.session.session_key:
-        request.session.create()
-    return {"session_key": request.session.session_key}
-
-
 @require_POST
 @ratelimit(key="ip", rate="20/m", method="POST", block=True)
 def stream(request: HttpRequest):
@@ -240,8 +227,9 @@ def summarize_conversation(request: HttpRequest) -> JsonResponse:
 @ratelimit(key="ip", rate="60/m", method="GET", block=True)
 def case_get(request: HttpRequest) -> JsonResponse:
     """Return case info + timeline for the current user/session."""
-    ownership = _ownership_filter(request)
-    case = CaseInfo.objects.filter(status="active", **ownership).first()
+    case = CaseInfo.objects.filter(
+        status="active", identity=request.identity
+    ).first()
 
     if not case:
         return JsonResponse({"case_info": None, "timeline": []})
@@ -287,11 +275,10 @@ def case_save(request: HttpRequest) -> JsonResponse:
     key_dates = data.pop("key_dates", [])
     action_items = data.pop("action_items", [])
 
-    ownership = _ownership_filter(request)
     case, created = CaseInfo.objects.update_or_create(
         status="active",
         defaults={"data": data},
-        **ownership,
+        identity=request.identity,
     )
 
     # Upsert key_dates into Deadline model
@@ -344,8 +331,7 @@ def case_timeline_add(request: HttpRequest) -> JsonResponse:
     except json.JSONDecodeError:
         return JsonResponse({"error": "Invalid JSON in metadata"}, status=400)
 
-    ownership = _ownership_filter(request)
-    case, _ = CaseInfo.objects.get_or_create(**ownership)
+    case, _ = CaseInfo.objects.get_or_create(identity=request.identity)
 
     event = TimelineEvent.objects.create(
         case=case,
@@ -362,8 +348,7 @@ def case_timeline_add(request: HttpRequest) -> JsonResponse:
 @ratelimit(key="ip", rate="60/m", method="GET", block=True)
 def action_plan(request: HttpRequest):
     """Render a print-friendly action plan document from CaseInfo data."""
-    ownership = _ownership_filter(request)
-    case = CaseInfo.objects.filter(**ownership).first()
+    case = CaseInfo.objects.filter(identity=request.identity).first()
     data = case.data if case else {}
 
     key_dates = [d.to_dict() for d in case.deadlines.all()] if case else []
@@ -392,10 +377,9 @@ def action_plan(request: HttpRequest):
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 def case_clear(request: HttpRequest) -> JsonResponse:
     """Archive active case info. Clear chat session from Django session."""
-    ownership = _ownership_filter(request)
-    archived = CaseInfo.objects.filter(status="active", **ownership).update(
-        status="archived"
-    )
+    archived = CaseInfo.objects.filter(
+        status="active", identity=request.identity
+    ).update(status="archived")
     request.session.pop("chat_session_id", None)
 
     return JsonResponse({"archived": archived > 0})
@@ -405,8 +389,9 @@ def case_clear(request: HttpRequest) -> JsonResponse:
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 def case_resolve(request: HttpRequest) -> JsonResponse:
     """Mark the active case as resolved and create a resolution timeline event."""
-    ownership = _ownership_filter(request)
-    case = CaseInfo.objects.filter(status="active", **ownership).first()
+    case = CaseInfo.objects.filter(
+        status="active", identity=request.identity
+    ).first()
 
     if not case:
         return JsonResponse({"resolved": False})
@@ -427,11 +412,10 @@ def case_resolve(request: HttpRequest) -> JsonResponse:
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 def action_item_toggle(request: HttpRequest, item_id: str) -> JsonResponse:
     """Toggle an action item's completed state."""
-    ownership = _ownership_filter(request)
     item = ActionItemModel.objects.filter(
         id=item_id,
         case__status="active",
-        **{"case__" + k: v for k, v in ownership.items()},
+        case__identity=request.identity,
     ).first()
 
     if not item:
@@ -449,11 +433,10 @@ def deadline_reminder_toggle(
     request: HttpRequest, deadline_id: str
 ) -> JsonResponse:
     """Toggle a deadline's reminder_requested state."""
-    ownership = _ownership_filter(request)
     deadline = Deadline.objects.filter(
         id=deadline_id,
         case__status="active",
-        **{"case__" + k: v for k, v in ownership.items()},
+        case__identity=request.identity,
     ).first()
 
     if not deadline:

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -62,6 +62,7 @@ MIDDLEWARE = [
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "litigant_portal.app.middleware.AnonymousSessionKeyMiddleware",
+    "litigant_portal.app.middleware.IdentityMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",


### PR DESCRIPTION
Fixes #405

This PR adds the UserIdentity model as the chokepoint where data associated with chats can either be linked ot a user or, for anonymous users, to a session id. It does a few things:

- Updates the agents and chat models to rely on a reference to a user identity object instead of spreading the bifurcated session-or-user logic to multiple places
- Adds middleware so that a user identity will be accessible and lazily created via `request.session`
- Updates the middleware for storing `_anonymous_session_key` which was previously forcing a db write every request
- Updates signals and the cleanup_sessions management command to use the user identity model.
- Simplifies the logic for ownership filters (now endpoints write `.filter(identity=request.identity)` inline instead of having a helper to manage the session-or-user logic).