### PR TITLE
feat(topic-flow): fact_gather POST + deadline math (Item 5)

### DIFF
--- a/litigant_portal/app/tests/test_topic_flow_deadlines.py
+++ b/litigant_portal/app/tests/test_topic_flow_deadlines.py
@@ -1,0 +1,53 @@
+"""Deadline math for Topic Flow — pure, DB-free (runs in the fast suite).
+
+``compute_deadline`` turns a corpus ``Deadline`` (an ``offset_days`` from a
+gathered date) plus the answer dict into a concrete date. The date string is
+whatever the ``<input type=date>`` submitted (ISO ``YYYY-MM-DD``). Validity of
+the *corpus* is guaranteed upstream at load; the only thing that can go wrong
+here is **missing or malformed user input**, which must yield ``None`` (the
+"fill the date first" affordance) rather than raise — a half-filled form is the
+normal state, not an error.
+"""
+
+from datetime import date
+
+from litigant_portal.app.topic_flow.deadlines import compute_deadline
+from litigant_portal.app.topic_flow.schema import Deadline
+
+
+def _deadline(offset_days=30, offset_from="publication_date"):
+    return Deadline(
+        id="d1", label="L", offset_days=offset_days, offset_from=offset_from
+    )
+
+
+def test_adds_offset_days_to_the_gathered_date():
+    # The core contract: gathered date + offset_days = the computed deadline.
+    result = compute_deadline(_deadline(30), {"publication_date": "2026-01-01"})
+    assert result == date(2026, 1, 31)
+
+
+def test_zero_offset_returns_the_gathered_date_itself():
+    result = compute_deadline(_deadline(0), {"publication_date": "2026-01-01"})
+    assert result == date(2026, 1, 1)
+
+
+def test_negative_offset_returns_an_earlier_date():
+    # offset_days can point backward (e.g. "respond N days *before* the hearing").
+    result = compute_deadline(_deadline(-10), {"publication_date": "2026-01-01"})
+    assert result == date(2025, 12, 22)
+
+
+def test_absent_answer_returns_none():
+    # The source question hasn't been answered yet — not an error.
+    assert compute_deadline(_deadline(), {}) is None
+
+
+def test_empty_string_answer_returns_none():
+    # A rendered-but-blank date field submits "" — still "no date yet".
+    assert compute_deadline(_deadline(), {"publication_date": ""}) is None
+
+
+def test_unparseable_date_returns_none_without_raising():
+    # Defensive: never let a malformed value 500 the page.
+    assert compute_deadline(_deadline(), {"publication_date": "not-a-date"}) is None

--- a/litigant_portal/app/tests/test_topic_flow_deadlines.py
+++ b/litigant_portal/app/tests/test_topic_flow_deadlines.py
@@ -23,7 +23,9 @@ def _deadline(offset_days=30, offset_from="publication_date"):
 
 def test_adds_offset_days_to_the_gathered_date():
     # The core contract: gathered date + offset_days = the computed deadline.
-    result = compute_deadline(_deadline(30), {"publication_date": "2026-01-01"})
+    result = compute_deadline(
+        _deadline(30), {"publication_date": "2026-01-01"}
+    )
     assert result == date(2026, 1, 31)
 
 
@@ -34,7 +36,9 @@ def test_zero_offset_returns_the_gathered_date_itself():
 
 def test_negative_offset_returns_an_earlier_date():
     # offset_days can point backward (e.g. "respond N days *before* the hearing").
-    result = compute_deadline(_deadline(-10), {"publication_date": "2026-01-01"})
+    result = compute_deadline(
+        _deadline(-10), {"publication_date": "2026-01-01"}
+    )
     assert result == date(2025, 12, 22)
 
 
@@ -50,4 +54,7 @@ def test_empty_string_answer_returns_none():
 
 def test_unparseable_date_returns_none_without_raising():
     # Defensive: never let a malformed value 500 the page.
-    assert compute_deadline(_deadline(), {"publication_date": "not-a-date"}) is None
+    assert (
+        compute_deadline(_deadline(), {"publication_date": "not-a-date"})
+        is None
+    )

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -253,3 +253,60 @@ def test_headingless_fact_gather_skipped_in_toc_but_body_still_renders(
     assert 'href="#overview"' in html  # heading section -> TOC link
     assert 'href="#key_dates"' not in html  # headingless -> no empty link
     assert 'name="publication_date"' in html  # body still renders
+
+
+# --- fact_gather POST + prefill (Item 5, needs DB) --------------------------
+# The form rendered by #486 now persists. POST writes answers to the
+# session-backed AnswerStore and redirects (PRG); the redirected GET prefills
+# the form. Functional contract — answers survive a reload — not markup.
+
+
+@pytest.mark.django_db
+def test_post_persists_answers_and_redirects_prg(client, monkeypatch):
+    # Post-Redirect-Get: the POST must 302 back to the flow URL, never render
+    # 200 in place. Otherwise a browser reload re-submits the form.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
+    )
+    assert response.status_code == 302
+    assert response["Location"] == URL
+
+
+@pytest.mark.django_db
+def test_posted_answers_prefill_on_the_redirected_get(client, monkeypatch):
+    # The whole point: what you submitted comes back filled in. Text echoes its
+    # value; the choice marks its option selected.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
+    )
+    html = client.get(URL).content.decode()
+    flat = re.sub(r"\s+", " ", html)
+    assert 'value="2026-02-01"' in _field_tag(html, "publication_date")
+    assert re.search(r'<option value="Cass"[^>]*selected', flat)
+
+
+@pytest.mark.django_db
+def test_get_prefills_form_from_existing_session_answers(client, monkeypatch):
+    # Answers already in the session (e.g. a returning guest) prefill on a plain
+    # GET — the AnswerStore is the source, not just the immediately-prior POST.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    session = client.session
+    session["topic_flow"] = {
+        f"{COURT}/{TOPIC}/{ROLE}": {"publication_date": "2026-03-15"}
+    }
+    session.save()
+    html = client.get(URL).content.decode()
+    assert 'value="2026-03-15"' in _field_tag(html, "publication_date")
+
+
+@pytest.mark.django_db
+def test_post_stores_only_known_question_ids(client, monkeypatch):
+    # The handler accepts only the corpus's question ids — csrf tokens and any
+    # stray/injected POST keys must not land in the answer store.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    client.post(URL, {"publication_date": "2026-02-01", "not_a_question": "x"})
+    flow = client.session["topic_flow"][f"{COURT}/{TOPIC}/{ROLE}"]
+    assert flow.get("publication_date") == "2026-02-01"
+    assert "not_a_question" not in flow

--- a/litigant_portal/app/topic_flow/deadlines.py
+++ b/litigant_portal/app/topic_flow/deadlines.py
@@ -1,0 +1,31 @@
+"""Deadline math for Topic Flow.
+
+A corpus ``Deadline`` is an ``offset_days`` from a gathered date — e.g. "30 days
+after the notice was published". This module turns that relative definition plus
+the user's answers into a concrete ``date``.
+
+Pure and AI-free, mirroring ``renderer.py``: no session/request machinery, no
+corpus re-validation (validity is guaranteed upstream at load). The one thing it
+guards is *user* input — an absent or malformed date yields ``None`` (the
+"fill the date first" state), never an exception.
+"""
+
+from datetime import date, timedelta
+
+
+def compute_deadline(deadline, answers):
+    """Return ``deadline``'s date from ``answers``, or ``None`` if uncomputable.
+
+    Reads the answer to ``deadline.offset_from`` (a ``date`` question, so an ISO
+    ``YYYY-MM-DD`` string) and adds ``offset_days``. Returns ``None`` when that
+    answer is absent, blank, or unparseable — a half-filled form is normal, not
+    an error.
+    """
+    raw = answers.get(deadline.offset_from)
+    if not raw:
+        return None
+    try:
+        gathered = date.fromisoformat(raw)
+    except ValueError:
+        return None
+    return gathered + timedelta(days=deadline.offset_days)

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -93,31 +93,32 @@ def _render_fact_gather(section, corpus, answers):
     )
 
 
+def _fact_gather_questions(corpus):
+    """Yield every fact_gather Question, in corpus order.
+
+    The single walk over the section union; ``question_ids`` and the summary
+    builder both consume it, so the ``isinstance`` dispatch lives in one place,
+    confined to the renderer rather than leaking into the view.
+    """
+    for section in corpus.sections:
+        if isinstance(section, FactGatherSection):
+            yield from section.questions
+
+
 def question_ids(corpus):
     """All fact_gather question ids, in corpus order.
 
     The set of POST keys the entry view accepts — everything else (csrf token,
-    stray keys) is ignored. Kept here so the section-union ``isinstance``
-    dispatch stays confined to the renderer, not the view.
+    stray keys) is ignored.
     """
-    return [
-        question.id
-        for section in corpus.sections
-        if isinstance(section, FactGatherSection)
-        for question in section.questions
-    ]
+    return [question.id for question in _fact_gather_questions(corpus)]
 
 
 def _answered_in_corpus_order(corpus, answers):
     """Yield ``{label, value}`` for answered questions, in corpus order."""
-    for section in corpus.sections:
-        if isinstance(section, FactGatherSection):
-            for question in section.questions:
-                if question.id in answers:
-                    yield {
-                        "label": question.label,
-                        "value": answers[question.id],
-                    }
+    for question in _fact_gather_questions(corpus):
+        if question.id in answers:
+            yield {"label": question.label, "value": answers[question.id]}
 
 
 @renderer("summary")

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -93,6 +93,21 @@ def _render_fact_gather(section, corpus, answers):
     )
 
 
+def question_ids(corpus):
+    """All fact_gather question ids, in corpus order.
+
+    The set of POST keys the entry view accepts — everything else (csrf token,
+    stray keys) is ignored. Kept here so the section-union ``isinstance``
+    dispatch stays confined to the renderer, not the view.
+    """
+    return [
+        question.id
+        for section in corpus.sections
+        if isinstance(section, FactGatherSection)
+        for question in section.questions
+    ]
+
+
 def _answered_in_corpus_order(corpus, answers):
     """Yield ``{label, value}`` for answered questions, in corpus order."""
     for section in corpus.sections:

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -11,8 +11,12 @@ from django.views.generic import DetailView, UpdateView
 from litigant_portal.agents import agent_registry
 from litigant_portal.app.forms import UserProfileForm
 from litigant_portal.app.models import UserProfile
+from litigant_portal.app.topic_flow.answer_store import AnswerStore
 from litigant_portal.app.topic_flow.registry import registry
-from litigant_portal.app.topic_flow.renderer import render_section
+from litigant_portal.app.topic_flow.renderer import (
+    question_ids,
+    render_section,
+)
 
 TOPICS = {
     "eviction": {
@@ -238,17 +242,33 @@ def deep_link(request, court, topic):
 def topic_flow(request, court, topic, role):
     """Topic Flow entry: /t/{court}/{topic}/{role}/ → rendered corpus sections.
 
-    Resolves the corpus from the registry (404 on miss) and renders each
-    section to a RenderedSection via SectionRenderer. The view stays thin —
-    all dispatch lives in renderer.py; the template only loops and displays.
-    Answers are empty here; fact_gather prefill + POST arrive with AnswerStore
-    wiring, and per-kind section bodies with the section templates.
+    Resolves the corpus from the registry (404 on miss). GET renders each
+    section via SectionRenderer with the guest's stored answers (so fact_gather
+    fields prefill). POST persists the submitted answers to the session-backed
+    AnswerStore and redirects (PRG) so a reload re-GETs rather than re-submits —
+    the whole flow works with JS off. The view stays thin: section dispatch
+    lives in renderer.py, deadline math in deadlines.py.
     """
     corpus = registry.get(court, topic, role)
     if corpus is None:
         raise Http404(f"No Topic Flow for {court}/{topic}/{role}")
+
+    store = AnswerStore(request.session, court, topic, role)
+
+    if request.method == "POST":
+        submitted = {
+            qid: request.POST[qid]
+            for qid in question_ids(corpus)
+            if qid in request.POST
+        }
+        store.update(submitted)
+        return redirect(
+            "pages:topic_flow", court=court, topic=topic, role=role
+        )
+
+    answers = store.all()
     rendered_sections = [
-        render_section(section, corpus, {}) for section in corpus.sections
+        render_section(section, corpus, answers) for section in corpus.sections
     ]
     return render(
         request,


### PR DESCRIPTION
Makes the fact_gather form from #486 persist. GET prefills fields from the session-backed AnswerStore; POST stores only the corpus's known question ids and PRG-redirects, so the flow is reload-safe and works with JS off. Adds `topic_flow/deadlines.py::compute_deadline` (gathered date + offset_days → date; absent/blank/unparseable → None, never raises) and `renderer.question_ids()` to keep section-union dispatch out of the view.

`compute_deadline` is unit-tested in isolation here; its display consumers (.ics, summary) wire it in Items 7/9 — intentional per the v1 plan.

Closes #492
Part of #389

Test plan:
- [x] deadlines unit tests RED-first → green (DB-free)
- [x] view POST/PRG/prefill + known-ids tests green (Docker, make test)
- [x] lint + full suite green
- [ ] end-to-end JS-on/off smoke deferred to Item 12 (QA)