### PR TITLE
feat(topic-flow): render personalized deadlines in ics output

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_ics.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_ics.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+
+{# ics output body: deadlines computed from fact_gather answers, server-rendered #}
+{# and JS-off (#494). Each deadline shows its concrete date once the source date #}
+{# is entered, else a "fill the date first" hint. The add-to-calendar (.ics) #}
+{# download button lands with #441. #}
+<ul class="space-y-4">
+  {% for deadline in ctx.deadlines %}
+  <li>
+    <div class="font-medium text-greyscale-900">{{ deadline.label }}</div>
+    {% if deadline.date_display %}
+    <p class="text-greyscale-900">
+      <time datetime="{{ deadline.date_iso }}">{{ deadline.date_display }}</time>
+    </p>
+    {% else %}
+    <p class="text-sm text-greyscale-500">
+      {% trans "Enter your dates above to see this deadline." %}
+    </p>
+    {% endif %}
+    {% if deadline.description %}
+    <p class="text-sm text-greyscale-500">{{ deadline.description }}</p>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -3,8 +3,9 @@
 The renderer is a fat, pure function of ``(section, corpus, answers)`` → a
 ``RenderedSection`` carrying a template path + flat, dumb context. It takes a
 plain ``answers`` dict (not an AnswerStore), so these tests need no session or
-DB. Handlers for ``ics`` / ``vcf`` are intentionally unregistered here — they
-land with their download-view items — so rendering one fails fast.
+DB. The ``ics`` handler renders its deadline list here (#494); ``vcf`` is still
+intentionally unregistered — it lands with its download-view item (#441) — so
+rendering one fails fast.
 """
 
 import pytest
@@ -15,6 +16,7 @@ from litigant_portal.app.topic_flow.renderer import (
 )
 from litigant_portal.app.topic_flow.schema import (
     Corpus,
+    Deadline,
     FactGatherSection,
     IcsOutput,
     InfoSection,
@@ -22,12 +24,14 @@ from litigant_portal.app.topic_flow.schema import (
     PacketOutput,
     Question,
     SummaryOutput,
+    VcfOutput,
 )
 
 
-def _corpus(*sections):
+def _corpus(*sections, deadlines=None):
     return Corpus(
         metadata=Metadata(court="c", topic="t", role="r", title="T"),
+        deadlines=deadlines or [],
         sections=list(sections),
     )
 
@@ -182,16 +186,99 @@ def test_each_kind_dispatches_to_a_distinct_template():
     assert all(t for t in templates)  # all non-empty
 
 
-# --- fail-fast on unregistered (ics/vcf land with their view items) ---------
+# --- ics (deadline rendering, #494) -----------------------------------------
+# The ics output renders each referenced deadline computed from the user's
+# answers (compute_deadline's first caller). The .ics download button lands
+# with #441; this is the visible, JS-off date list.
+
+_PUB_Q = Question(id="publication_date", label="Publication date", type="date")
+_PUB_DEADLINE = Deadline(
+    id="publication_wait",
+    label="30-day publication wait",
+    offset_days=30,
+    offset_from="publication_date",
+    description="The judge can review 30 days after publication.",
+)
 
 
-def test_unregistered_output_type_raises():
+def _ics_corpus(
+    deadline_ids=("publication_wait",), deadlines=(_PUB_DEADLINE,)
+):
     ics = IcsOutput(
         kind="output",
         output_type="ics",
         id="cal",
-        heading="Deadlines",
-        deadline_ids=["respond"],
+        heading="Add deadlines to your calendar",
+        deadline_ids=list(deadline_ids),
     )
-    with pytest.raises(ValueError, match="ics"):
-        render_section(ics, _corpus(ics), {})
+    corpus = _corpus(_fg([_PUB_Q], id="dates"), ics, deadlines=list(deadlines))
+    return corpus, ics
+
+
+def test_ics_renders_computed_deadline_from_answer():
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {"publication_date": "2026-02-01"})
+    (d,) = rendered.context["deadlines"]
+    assert d["label"] == "30-day publication wait"
+    # 30 days after 2026-02-01 = 2026-03-03 (Feb 2026 has 28 days).
+    assert d["date_iso"] == "2026-03-03"
+    assert "March 3, 2026" in d["date_display"]
+
+
+def test_ics_deadline_pending_when_answer_missing():
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {})
+    (d,) = rendered.context["deadlines"]
+    assert d["date_iso"] is None
+    assert d["date_display"] is None
+    assert d["label"] == "30-day publication wait"  # label still shown
+
+
+def test_ics_deadline_pending_when_answer_malformed():
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {"publication_date": "not-a-date"})
+    (d,) = rendered.context["deadlines"]
+    assert d["date_iso"] is None
+
+
+def test_ics_carries_deadline_description():
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {})
+    (d,) = rendered.context["deadlines"]
+    assert (
+        d["description"] == "The judge can review 30 days after publication."
+    )
+
+
+def test_ics_lists_deadlines_in_deadline_ids_order():
+    # Order follows the section's deadline_ids, not corpus.deadlines order.
+    second = Deadline(
+        id="second",
+        label="Second",
+        offset_days=5,
+        offset_from="publication_date",
+    )
+    corpus, ics = _ics_corpus(
+        deadline_ids=("second", "publication_wait"),
+        deadlines=(_PUB_DEADLINE, second),
+    )
+    rendered = render_section(ics, corpus, {"publication_date": "2026-02-01"})
+    assert [d["label"] for d in rendered.context["deadlines"]] == [
+        "Second",
+        "30-day publication wait",
+    ]
+
+
+# --- fail-fast on unregistered (vcf lands with its download view, #441) ------
+
+
+def test_unregistered_output_type_raises():
+    vcf = VcfOutput(
+        kind="output",
+        output_type="vcf",
+        id="contact",
+        heading="Save the clerk's contact",
+        contact_ids=["clerk"],
+    )
+    with pytest.raises(ValueError, match="vcf"):
+        render_section(vcf, _corpus(vcf), {})

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -19,7 +19,9 @@ from django.urls import resolve, reverse
 from litigant_portal.app.topic_flow.renderer import RenderedSection
 from litigant_portal.app.topic_flow.schema import (
     Corpus,
+    Deadline,
     FactGatherSection,
+    IcsOutput,
     InfoSection,
     Metadata,
     PacketOutput,
@@ -310,3 +312,74 @@ def test_post_stores_only_known_question_ids(client, monkeypatch):
     flow = client.session["topic_flow"][f"{COURT}/{TOPIC}/{ROLE}"]
     assert flow.get("publication_date") == "2026-02-01"
     assert "not_a_question" not in flow
+
+
+# --- ics deadline rendering (#494, needs DB) --------------------------------
+# The ics output renders a personalized deadline computed from the stored
+# answer — fact_gather → AnswerStore → compute_deadline → on-page date, JS off.
+
+
+def _corpus_with_deadline():
+    return Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        deadlines=[
+            Deadline(
+                id="publication_wait",
+                label="30-day publication wait",
+                offset_days=30,
+                offset_from="publication_date",
+            )
+        ],
+        sections=[
+            FactGatherSection(
+                kind="fact_gather",
+                id="key_dates",
+                heading="Your dates",
+                questions=[
+                    Question(
+                        id="publication_date",
+                        label="Date your notice was published",
+                        type="date",
+                        required=True,
+                    )
+                ],
+            ),
+            IcsOutput(
+                kind="output",
+                output_type="ics",
+                id="deadlines_calendar",
+                heading="Add deadlines to your calendar",
+                deadline_ids=["publication_wait"],
+            ),
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_ics_section_renders_personalized_deadline(client, monkeypatch):
+    # The payoff: a stored answer drives compute_deadline and the concrete date
+    # appears on the page, server-rendered. 30 days after 2026-02-01 = 2026-03-03.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    session = client.session
+    session["topic_flow"] = {
+        f"{COURT}/{TOPIC}/{ROLE}": {"publication_date": "2026-02-01"}
+    }
+    session.save()
+    html = client.get(URL).content.decode()
+    assert 'datetime="2026-03-03"' in html  # machine-readable <time>
+    assert "March 3, 2026" in html  # human-readable date
+
+
+@pytest.mark.django_db
+def test_ics_section_pending_without_answer_still_renders(client, monkeypatch):
+    # Graceful missing-answer state: page still renders, deadline label shows,
+    # but no computed date is emitted (nothing to compute yet).
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    html = client.get(URL).content.decode()
+    assert "30-day publication wait" in html
+    assert "March 3, 2026" not in html
+    assert 'datetime="2026-03-03"' not in html

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -13,12 +13,15 @@ session/request machinery.
 
 Corpus validity is guaranteed upstream at load, so the renderer never
 re-validates data; an unhandled section type is a *code* gap (a union member
-with no registered handler) and fails fast. Handlers for ``ics`` and ``vcf``
-register with their download-view items; until then, rendering one raises.
+with no registered handler) and fails fast. The ``ics`` handler renders its
+deadline list here (its first caller of ``compute_deadline``); the ``.ics``
+download button and the ``vcf`` handler land with their download-view item, so
+rendering a ``vcf`` still raises.
 """
 
 from dataclasses import dataclass
 
+from litigant_portal.app.topic_flow.deadlines import compute_deadline
 from litigant_portal.app.topic_flow.schema import FactGatherSection
 
 
@@ -138,4 +141,46 @@ def _render_packet(section, corpus, answers):
         heading=section.heading,
         template=f"{_TEMPLATE_DIR}/flow_section_packet.html",
         context={"forms": list(section.forms)},
+    )
+
+
+def _format_deadline_date(value):
+    """Human-readable deadline date, e.g. "Tuesday, March 3, 2026".
+
+    ``%-d`` drops the leading zero (POSIX; the app runs on Linux/macOS).
+    """
+    return value.strftime("%A, %B %-d, %Y")
+
+
+def _deadline_context(deadline, answers):
+    """Flat, template-ready view of one deadline computed from ``answers``.
+
+    ``date_display``/``date_iso`` are ``None`` when the source answer is absent
+    or unparseable — the "fill the date first" state — so the template shows the
+    label without a date rather than erroring. ``date_iso`` feeds the ``<time>``
+    element now and the ``.ics`` export later (#441).
+    """
+    computed = compute_deadline(deadline, answers)
+    return {
+        "label": deadline.label,
+        "description": deadline.description,
+        "date_display": _format_deadline_date(computed) if computed else None,
+        "date_iso": computed.isoformat() if computed else None,
+    }
+
+
+@renderer("ics")
+def _render_ics(section, corpus, answers):
+    # Resolve the section's deadline_ids against corpus-level deadlines, in the
+    # section's declared order. The loader guarantees every id resolves, so the
+    # lookup never misses for a valid corpus.
+    by_id = {deadline.id: deadline for deadline in corpus.deadlines}
+    deadlines = [
+        _deadline_context(by_id[did], answers) for did in section.deadline_ids
+    ]
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_ics.html",
+        context={"deadlines": deadlines},
     )


### PR DESCRIPTION
The `ics` output section now renders each referenced deadline's concrete date, computed from the user's `fact_gather` answers — server-rendered, JS-off. This is the first caller of `compute_deadline` (shipped tested-but-uncalled in #492) and the personalization payoff in the epic's v1 DoD. An absent or unparseable source date shows the deadline label with a "fill the date first" hint instead of erroring; `date_iso` drives a `<time>` element now and feeds the `.ics` export later.

The `.ics` download button and the `vcf` handler still land with #441; rendering a `vcf` output still fails fast.

Closes #494

Test plan:
- `tox -e fast` — renderer units: computed date, pending (missing answer), malformed answer, description carried, deadline_ids ordering
- `make test` (Docker) — view tests: end-to-end personalized deadline render + graceful pending state
- Verified directly: 2026-02-01 + 30d → 2026-03-03 ("Tuesday, March 3, 2026"); pending/malformed → no date emitted