### PR TITLE
fix(cd): sync deploy tree to QA box before compose up

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,8 +72,17 @@ jobs:
           username: ${{ secrets.QA_USER }}
           key: ${{ secrets.QA_SSH_KEY }}
           script: |
+            set -e
             cd /opt/litigant-portal
-            docker compose pull django-prod
+            # Sync the deploy tree to the just-merged main BEFORE bringing the
+            # stack up. Pulling the image alone never updated docker-compose.yml
+            # / Caddy / env on the box, so a change that adds a new service
+            # (e.g. redis-prod) silently never started it and /api/health/
+            # returned 503 (#501). reset --hard keeps the box an exact mirror of
+            # main — the deploy box holds no local edits.
+            git fetch origin
+            git reset --hard origin/main
+            docker compose --profile prod pull
             docker compose --profile prod up -d --no-build
 
       - name: Verify deploy


### PR DESCRIPTION
The CD deploy step pulled the django image but never synced `docker-compose.yml` (or Caddy/env) to the QA server, so a change adding a new compose service — `redis-prod` in #496 — never started it. The new image then couldn't reach its cache, `/api/health/` returned 503, and the Verify step failed the deploy. This makes the box an exact mirror of `main` on every deploy (`git fetch` + `reset --hard origin/main`) and pulls all prod images before `up`, so new services/Caddy/env changes actually land.

Closes #501

Test plan:
- Verified the failure mode: #496's deploy left `redis-prod` unstarted; `/api/health/` 503 → CD red. QA recovered after a manual `git pull` + `compose up` on the box.
- This change is exercised on the next merge to main (CD deploys); the post-deploy `Verify` step (curls `/api/health/` for 200) is the built-in check that it worked.
- `set -e` ensures a failed sync aborts loudly instead of bringing up a stale stack.

Note: `reset --hard` assumes the deploy box holds no local edits (it shouldn't); `git pull --ff-only` is the gentler swap if preferred.