### PR TITLE
feat(topic-flow): .ics add-to-calendar handoff

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_ics.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_ics.html
@@ -3,7 +3,7 @@
 {# ics output body: deadlines computed from fact_gather answers, server-rendered #}
 {# and JS-off (#494). Each deadline shows its concrete date once the source date #}
 {# is entered, else a "fill the date first" hint. The add-to-calendar (.ics) #}
-{# download button lands with #441. #}
+{# download link (#504) appears once at least one deadline has a computed date. #}
 <ul class="space-y-4">
   {% for deadline in ctx.deadlines %}
   <li>
@@ -23,3 +23,15 @@
   </li>
   {% endfor %}
 </ul>
+
+{% if ctx.has_dates %}
+<div class="mt-4">
+  <c-atoms.button
+    href="{% url 'pages:topic_flow_download' court=ctx.court topic=ctx.topic role=ctx.role output_id=ctx.output_id %}"
+    variant="outline"
+  >
+    <c-atoms.icon name="calendar" class="w-4 h-4" />
+    {% trans "Add to calendar" %}
+  </c-atoms.button>
+</div>
+{% endif %}

--- a/litigant_portal/app/tests/test_topic_flow_artifacts.py
+++ b/litigant_portal/app/tests/test_topic_flow_artifacts.py
@@ -1,0 +1,90 @@
+"""File-artifact generators for Topic Flow — pure, DB-free (fast suite).
+
+``deadlines_to_ics`` turns a list of already-computed deadline events into an
+iCalendar (``.ics``) string. It is a pure projection — no corpus, no answers,
+no Django — so it tests standalone like ``deadlines.py``; the download view
+does the resolving/computing and hands this function plain events.
+
+Tests round-trip through ``vobject`` (parse the output back) rather than
+asserting raw lines, so they pin the *semantic* contract — summary, all-day
+date, optional description, escaping survive a serialize→parse cycle — without
+being brittle to vobject's exact line formatting, param order, or folding.
+"""
+
+from datetime import date, datetime
+
+import vobject
+
+from litigant_portal.app.topic_flow.artifacts import deadlines_to_ics
+
+
+def _event(
+    uid="publication_wait@litigantportal",
+    summary="30-day publication wait",
+    description=None,
+    on=date(2026, 3, 3),
+):
+    return {
+        "uid": uid,
+        "summary": summary,
+        "description": description,
+        "date": on,
+    }
+
+
+def test_wraps_events_in_a_parseable_vcalendar():
+    cal = vobject.readOne(deadlines_to_ics([_event()]))
+    assert cal.name == "VCALENDAR"
+    # VERSION is mandatory (RFC 5545); a calendar without it won't import.
+    assert cal.version.value == "2.0"
+
+
+def test_event_round_trips_summary_uid_and_date():
+    cal = vobject.readOne(deadlines_to_ics([_event(on=date(2026, 3, 3))]))
+    assert cal.vevent.summary.value == "30-day publication wait"
+    assert cal.vevent.uid.value == "publication_wait@litigantportal"
+    assert cal.vevent.dtstart.value == date(2026, 3, 3)
+
+
+def test_deadline_is_an_all_day_event_not_a_timed_one():
+    # All-day = a DATE value, not a DATE-TIME. A deadline has no clock time, and
+    # a timed event would drag in timezone ambiguity. ``date`` (not ``datetime``)
+    # is how that contract is expressed and parsed back.
+    cal = vobject.readOne(deadlines_to_ics([_event(on=date(2026, 3, 3))]))
+    value = cal.vevent.dtstart.value
+    assert isinstance(value, date)
+    assert not isinstance(value, datetime)
+
+
+def test_each_event_becomes_its_own_vevent():
+    out = deadlines_to_ics([_event(uid="a"), _event(uid="b"), _event(uid="c")])
+    cal = vobject.readOne(out)
+    assert {v.uid.value for v in cal.vevent_list} == {"a", "b", "c"}
+
+
+def test_description_present_when_given():
+    cal = vobject.readOne(
+        deadlines_to_ics([_event(description="Judge may review after this.")])
+    )
+    assert cal.vevent.description.value == "Judge may review after this."
+
+
+def test_description_omitted_when_none():
+    # Absent field → no line, never an empty DESCRIPTION:.
+    cal = vobject.readOne(deadlines_to_ics([_event(description=None)]))
+    assert "description" not in cal.vevent.contents
+
+
+def test_special_characters_survive_a_round_trip():
+    # RFC 5545 reserves comma / semicolon / backslash in TEXT values; if the
+    # generator didn't escape them, the parse back would split or corrupt the
+    # value. Round-tripping intact proves escaping is correct.
+    tricky = "Hearing, bring ID; see note\\ here"
+    cal = vobject.readOne(deadlines_to_ics([_event(summary=tricky)]))
+    assert cal.vevent.summary.value == tricky
+
+
+def test_empty_event_list_is_still_a_valid_calendar():
+    cal = vobject.readOne(deadlines_to_ics([]))
+    assert cal.name == "VCALENDAR"
+    assert "vevent" not in cal.contents

--- a/litigant_portal/app/tests/test_topic_flow_deadlines.py
+++ b/litigant_portal/app/tests/test_topic_flow_deadlines.py
@@ -10,8 +10,12 @@ normal state, not an error.
 """
 
 from datetime import date
+from types import SimpleNamespace
 
-from litigant_portal.app.topic_flow.deadlines import compute_deadline
+from litigant_portal.app.topic_flow.deadlines import (
+    compute_deadline,
+    resolve_ics_deadlines,
+)
 from litigant_portal.app.topic_flow.schema import Deadline
 
 
@@ -58,3 +62,70 @@ def test_unparseable_date_returns_none_without_raising():
         compute_deadline(_deadline(), {"publication_date": "not-a-date"})
         is None
     )
+
+
+# --- resolve_ics_deadlines --------------------------------------------------
+# The shared resolver an ics section's renderer AND its .ics download view both
+# call, so the page and the downloaded calendar compute from one source. It
+# duck-types on ``section.deadline_ids`` and ``corpus.deadlines``; the stand-ins
+# below carry just those attributes (real Deadline objects drive the math).
+
+
+def _named_deadline(id, label, offset_days=30, description=None):
+    return Deadline(
+        id=id,
+        label=label,
+        offset_days=offset_days,
+        offset_from="publication_date",
+        description=description,
+    )
+
+
+def _section(*deadline_ids):
+    return SimpleNamespace(deadline_ids=list(deadline_ids))
+
+
+def _corpus(*deadlines):
+    return SimpleNamespace(deadlines=list(deadlines))
+
+
+def test_resolve_computes_each_referenced_deadlines_date():
+    deadline = _named_deadline("pub_wait", "Publication wait", 30)
+    (resolved,) = resolve_ics_deadlines(
+        _section("pub_wait"),
+        _corpus(deadline),
+        {"publication_date": "2026-02-01"},
+    )
+    assert resolved["id"] == "pub_wait"
+    assert resolved["label"] == "Publication wait"
+    # 30 days after 2026-02-01 = 2026-03-03 — the raw date the .ics consumes.
+    assert resolved["date"] == date(2026, 3, 3)
+
+
+def test_resolve_date_is_none_when_answer_missing():
+    # The view filters on this: a None-date deadline isn't a calendar event yet.
+    (resolved,) = resolve_ics_deadlines(
+        _section("pub_wait"), _corpus(_named_deadline("pub_wait", "Wait")), {}
+    )
+    assert resolved["date"] is None
+
+
+def test_resolve_follows_section_order_not_corpus_order():
+    # Order tracks the section's deadline_ids, not corpus.deadlines order —
+    # the iteration source is the contract, so guard the wrong-collection bug.
+    first = _named_deadline("a", "A", 5)
+    second = _named_deadline("b", "B", 10)
+    resolved = resolve_ics_deadlines(
+        _section("b", "a"), _corpus(first, second), {}
+    )
+    assert [r["id"] for r in resolved] == ["b", "a"]
+
+
+def test_resolve_carries_description():
+    deadline = _named_deadline(
+        "pub_wait", "Wait", description="Judge reviews."
+    )
+    (resolved,) = resolve_ics_deadlines(
+        _section("pub_wait"), _corpus(deadline), {}
+    )
+    assert resolved["description"] == "Judge reviews."

--- a/litigant_portal/app/tests/test_topic_flow_downloads.py
+++ b/litigant_portal/app/tests/test_topic_flow_downloads.py
@@ -108,7 +108,7 @@ def test_none_for_an_unknown_id():
 def test_sets_calendar_content_type_and_filename():
     corpus = _corpus()
     artifact = build_download(_ics_section(corpus), corpus, ANSWERS)
-    assert artifact.content_type == "text/calendar"
+    assert artifact.content_type == "text/calendar; charset=utf-8"
     assert artifact.filename == "deadlines_calendar.ics"
 
 

--- a/litigant_portal/app/tests/test_topic_flow_downloads.py
+++ b/litigant_portal/app/tests/test_topic_flow_downloads.py
@@ -1,0 +1,141 @@
+"""Download dispatch for Topic Flow output sections — pure, DB-free.
+
+``find_downloadable`` resolves an output section by id and gates out the types
+with no download handler (info / fact_gather / summary / packet → the view's
+404). ``build_download`` turns a downloadable section + the user's answers into
+a ``DownloadArtifact`` (content type, filename, bytes).
+
+The ``.ics`` body is parsed back with ``vobject`` to assert the computed
+deadline became a real calendar event — and, crucially, that it goes through
+the same ``resolve_ics_deadlines`` the page renders with, so the download can't
+drift from what's on screen.
+"""
+
+from datetime import date
+
+import vobject
+
+from litigant_portal.app.topic_flow.downloads import (
+    build_download,
+    find_downloadable,
+)
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    Deadline,
+    FactGatherSection,
+    IcsOutput,
+    Metadata,
+    Question,
+    SummaryOutput,
+)
+
+# An answered publication_date; 30 days on = 2026-03-03.
+ANSWERS = {"publication_date": "2026-02-01"}
+
+
+def _corpus():
+    return Corpus(
+        metadata=Metadata(
+            court="test-court",
+            topic="test_topic",
+            role="petitioner",
+            title="T",
+        ),
+        deadlines=[
+            Deadline(
+                id="publication_wait",
+                label="30-day publication wait",
+                offset_days=30,
+                offset_from="publication_date",
+                description="Judge may review after this.",
+            )
+        ],
+        sections=[
+            FactGatherSection(
+                kind="fact_gather",
+                id="key_dates",
+                questions=[
+                    Question(id="publication_date", label="When", type="date")
+                ],
+            ),
+            IcsOutput(
+                kind="output",
+                output_type="ics",
+                id="deadlines_calendar",
+                heading="Add deadlines to your calendar",
+                deadline_ids=["publication_wait"],
+            ),
+            SummaryOutput(
+                kind="output",
+                output_type="summary",
+                id="recap",
+                heading="Summary",
+            ),
+        ],
+    )
+
+
+def _ics_section(corpus):
+    return find_downloadable(corpus, "deadlines_calendar")
+
+
+# --- find_downloadable ------------------------------------------------------
+
+
+def test_resolves_the_ics_output_section():
+    section = find_downloadable(_corpus(), "deadlines_calendar")
+    assert section is not None
+    assert section.output_type == "ics"
+
+
+def test_none_for_an_output_with_no_download_handler():
+    # summary is an output, but on-page only — not downloadable.
+    assert find_downloadable(_corpus(), "recap") is None
+
+
+def test_none_for_a_non_output_section():
+    # fact_gather isn't an output at all — a stray /download/key_dates/ → 404.
+    assert find_downloadable(_corpus(), "key_dates") is None
+
+
+def test_none_for_an_unknown_id():
+    assert find_downloadable(_corpus(), "nope") is None
+
+
+# --- build_download (ics) ---------------------------------------------------
+
+
+def test_sets_calendar_content_type_and_filename():
+    corpus = _corpus()
+    artifact = build_download(_ics_section(corpus), corpus, ANSWERS)
+    assert artifact.content_type == "text/calendar"
+    assert artifact.filename == "deadlines_calendar.ics"
+
+
+def test_body_carries_the_computed_deadline_as_an_event():
+    corpus = _corpus()
+    artifact = build_download(_ics_section(corpus), corpus, ANSWERS)
+    cal = vobject.readOne(artifact.body)
+    assert cal.vevent.summary.value == "30-day publication wait"
+    # The computed date (offset applied), not the raw gathered date.
+    assert cal.vevent.dtstart.value == date(2026, 3, 3)
+
+
+def test_omits_deadlines_without_a_computable_date():
+    # No answer yet → the deadline isn't a calendar event (empty, valid cal).
+    corpus = _corpus()
+    artifact = build_download(_ics_section(corpus), corpus, {})
+    cal = vobject.readOne(artifact.body)
+    assert "vevent" not in cal.contents
+
+
+def test_uid_is_stable_across_downloads():
+    # Same flow + section + deadline → same UID, so a re-download updates the
+    # calendar event rather than duplicating it.
+    corpus = _corpus()
+    first = build_download(_ics_section(corpus), corpus, ANSWERS)
+    again = build_download(_ics_section(corpus), corpus, ANSWERS)
+    assert (
+        vobject.readOne(first.body).vevent.uid.value
+        == vobject.readOne(again.body).vevent.uid.value
+    )

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -188,8 +188,8 @@ def test_each_kind_dispatches_to_a_distinct_template():
 
 # --- ics (deadline rendering, #494) -----------------------------------------
 # The ics output renders each referenced deadline computed from the user's
-# answers (compute_deadline's first caller). The .ics download button lands
-# with #441; this is the visible, JS-off date list.
+# answers, via resolve_ics_deadlines (shared with the .ics download, #504).
+# These cover the visible, JS-off date list + the download-link context.
 
 _PUB_Q = Question(id="publication_date", label="Publication date", type="date")
 _PUB_DEADLINE = Deadline(
@@ -267,6 +267,33 @@ def test_ics_lists_deadlines_in_deadline_ids_order():
         "Second",
         "30-day publication wait",
     ]
+
+
+def test_ics_has_dates_true_when_a_deadline_is_computed():
+    # Gates the download link: a calendar with at least one dated event.
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {"publication_date": "2026-02-01"})
+    assert rendered.context["has_dates"] is True
+
+
+def test_ics_has_dates_false_when_nothing_is_computed():
+    # No answer → no datable event → no download link shown.
+    corpus, ics = _ics_corpus()
+    rendered = render_section(ics, corpus, {})
+    assert rendered.context["has_dates"] is False
+
+
+def test_ics_context_carries_download_url_parts():
+    # The template builds {% url 'pages:topic_flow_download' ... %} from these,
+    # so the renderer stays Django-free (no reverse() call).
+    corpus, ics = _ics_corpus()
+    ctx = render_section(ics, corpus, {}).context
+    assert ctx["output_id"] == ics.id
+    assert (ctx["court"], ctx["topic"], ctx["role"]) == (
+        corpus.metadata.court,
+        corpus.metadata.topic,
+        corpus.metadata.role,
+    )
 
 
 # --- fail-fast on unregistered (vcf lands with its download view, #441) ------

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -383,3 +383,118 @@ def test_ics_section_pending_without_answer_still_renders(client, monkeypatch):
     assert "30-day publication wait" in html
     assert "March 3, 2026" not in html
     assert 'datetime="2026-03-03"' not in html
+
+
+# --- ics download (#504, needs DB) ------------------------------------------
+# The output-download route: GET .../download/<output_id>/ streams the section
+# as a file, dispatching on output_type. The .ics is built from the same stored
+# answers the page renders, so the calendar matches what's on screen.
+
+DOWNLOAD_URL = f"/t/{COURT}/{TOPIC}/{ROLE}/download/deadlines_calendar/"
+
+
+def test_download_url_resolves_to_the_download_view():
+    assert resolve(DOWNLOAD_URL).view_name == "pages:topic_flow_download"
+
+
+def test_download_url_reverses_with_the_output_id():
+    assert (
+        reverse(
+            "pages:topic_flow_download",
+            kwargs={
+                "court": COURT,
+                "topic": TOPIC,
+                "role": ROLE,
+                "output_id": "deadlines_calendar",
+            },
+        )
+        == DOWNLOAD_URL
+    )
+
+
+@pytest.mark.django_db
+def test_download_streams_ics_attachment_with_the_computed_deadline(
+    client, monkeypatch
+):
+    # The payoff: the stored answer drives the same compute_deadline path, and
+    # the downloaded calendar carries the concrete date as an all-day event.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    session = client.session
+    session["topic_flow"] = {
+        f"{COURT}/{TOPIC}/{ROLE}": {"publication_date": "2026-02-01"}
+    }
+    session.save()
+    response = client.get(DOWNLOAD_URL)
+    assert response.status_code == 200
+    assert "text/calendar" in response["Content-Type"]
+    assert (
+        'attachment; filename="deadlines_calendar.ics"'
+        in response["Content-Disposition"]
+    )
+    body = response.content.decode()
+    assert "BEGIN:VCALENDAR" in body
+    assert "20260303" in body  # all-day DATE form of 2026-03-03
+
+
+@pytest.mark.django_db
+def test_download_without_answers_is_an_empty_but_valid_calendar(
+    client, monkeypatch
+):
+    # No stored answer → 200 with a valid, event-free calendar (not a 500/404).
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    response = client.get(DOWNLOAD_URL)
+    assert response.status_code == 200
+    body = response.content.decode()
+    assert "BEGIN:VCALENDAR" in body
+    assert "BEGIN:VEVENT" not in body
+
+
+@pytest.mark.django_db
+def test_download_unknown_flow_returns_404(client, monkeypatch):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: None)
+    assert client.get(DOWNLOAD_URL).status_code == 404
+
+
+@pytest.mark.django_db
+def test_download_non_downloadable_output_returns_404(client, monkeypatch):
+    # key_dates is a fact_gather, not a downloadable output — gated to 404.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    url = f"/t/{COURT}/{TOPIC}/{ROLE}/download/key_dates/"
+    assert client.get(url).status_code == 404
+
+
+@pytest.mark.django_db
+def test_ics_section_links_to_the_download_once_a_date_is_entered(
+    client, monkeypatch
+):
+    # The page must surface a reachable link to the download URL — without it
+    # the litigant can't get the calendar file. Functional target, not markup.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    session = client.session
+    session["topic_flow"] = {
+        f"{COURT}/{TOPIC}/{ROLE}": {"publication_date": "2026-02-01"}
+    }
+    session.save()
+    html = client.get(URL).content.decode()
+    assert f'href="{DOWNLOAD_URL}"' in html
+
+
+@pytest.mark.django_db
+def test_ics_section_hides_download_link_until_a_date_is_entered(
+    client, monkeypatch
+):
+    # No computable date → no link (an empty calendar is no use). Guards the
+    # has_dates gate end-to-end, the mirror of the link-present case above.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_deadline()
+    )
+    html = client.get(URL).content.decode()
+    assert f'href="{DOWNLOAD_URL}"' not in html

--- a/litigant_portal/app/topic_flow/artifacts.py
+++ b/litigant_portal/app/topic_flow/artifacts.py
@@ -1,0 +1,54 @@
+"""Generate downloadable file artifacts from Topic Flow corpus data.
+
+Currently: an iCalendar (``.ics``) from a list of computed deadline events — a
+pure projection with no corpus, no answers, no host page, mirroring the pure
+style of ``deadlines.py``/``renderer.py``. The view layer resolves the corpus,
+reads the session AnswerStore, and computes the dates; this module only turns
+the resulting events into bytes, so the field mapping is unit-testable without
+Django and ``vobject`` owns RFC 5545 escaping and line folding.
+
+The future ``.vcf`` generator (a Contact → vCard, #473) lands here too — same
+"data shape in, file bytes out" contract — which is why the module is named for
+artifacts in general, not just calendars.
+"""
+
+from datetime import datetime
+
+import vobject
+
+# vobject's own UTC tzinfo (dateutil's ``tzutc``). DTSTAMP must be UTC, and
+# vobject only serializes a tzinfo it can map to a TZID — Python's stdlib
+# ``timezone.utc`` raises "Unable to guess TZID", so reuse vobject's singleton.
+from vobject.icalendar import utc
+
+# Identifies the product that produced the file (RFC 5545 PRODID). Overrides
+# vobject's generic default so calendar apps attribute the import to us.
+_PRODID = "-//Free Law Project//Litigant Portal Topic Flow//EN"
+
+
+def deadlines_to_ics(events) -> str:
+    """Serialize computed deadline ``events`` to an iCalendar string.
+
+    Each event is a dict ``{uid, summary, description, date}`` — already
+    resolved by the caller. ``date`` is a ``datetime.date`` (no clock time): a
+    deadline is an all-day event, emitted as a ``VALUE=DATE`` ``DTSTART`` so no
+    timezone is implied. ``description`` is optional — ``None``/empty emits no
+    ``DESCRIPTION`` line. ``uid`` is supplied by the caller (stable per
+    deadline) so re-downloading updates the event rather than duplicating it.
+
+    An empty ``events`` list yields a valid, event-free calendar.
+    """
+    cal = vobject.iCalendar()
+    cal.add("prodid").value = _PRODID
+    # One shared stamp for the whole file: the moment it was generated.
+    generated_at = datetime.now(utc)
+    for event in events:
+        vevent = cal.add("vevent")
+        vevent.add("uid").value = event["uid"]
+        vevent.add("dtstamp").value = generated_at
+        vevent.add("summary").value = event["summary"]
+        # A plain date (not datetime) makes vobject emit DTSTART;VALUE=DATE.
+        vevent.add("dtstart").value = event["date"]
+        if event.get("description"):
+            vevent.add("description").value = event["description"]
+    return cal.serialize()

--- a/litigant_portal/app/topic_flow/deadlines.py
+++ b/litigant_portal/app/topic_flow/deadlines.py
@@ -29,3 +29,31 @@ def compute_deadline(deadline, answers):
     except ValueError:
         return None
     return gathered + timedelta(days=deadline.offset_days)
+
+
+def resolve_ics_deadlines(section, corpus, answers):
+    """Resolve an ``ics`` output section's ``deadline_ids`` to computed events.
+
+    Returns one dict per referenced deadline, in the section's declared order:
+    ``{id, label, description, date}`` where ``date`` is the ``compute_deadline``
+    result — a ``date``, or ``None`` when the source answer isn't filled in yet.
+
+    The single place an ics section's deadlines are resolved and computed,
+    shared by the renderer's ``ics`` handler (which formats them for the page)
+    and the ``.ics`` download view (which turns the computed ones into calendar
+    events) — so the downloaded calendar can't drift from what the page shows.
+    The loader guarantees every id resolves, so the lookup never misses.
+    """
+    by_id = {deadline.id: deadline for deadline in corpus.deadlines}
+    resolved = []
+    for deadline_id in section.deadline_ids:
+        deadline = by_id[deadline_id]
+        resolved.append(
+            {
+                "id": deadline.id,
+                "label": deadline.label,
+                "description": deadline.description,
+                "date": compute_deadline(deadline, answers),
+            }
+        )
+    return resolved

--- a/litigant_portal/app/topic_flow/downloads.py
+++ b/litigant_portal/app/topic_flow/downloads.py
@@ -97,6 +97,9 @@ def _build_ics(section, corpus, answers):
         )
     return DownloadArtifact(
         filename=f"{section.id}.ics",
-        content_type="text/calendar",
+        # Declare UTF-8 explicitly: deadline labels/descriptions are author-
+        # supplied and may carry non-ASCII. RFC 5545 defaults text/calendar to
+        # UTF-8, but stating it beats relying on the client to honor the default.
+        content_type="text/calendar; charset=utf-8",
         body=deadlines_to_ics(events),
     )

--- a/litigant_portal/app/topic_flow/downloads.py
+++ b/litigant_portal/app/topic_flow/downloads.py
@@ -1,0 +1,102 @@
+"""Download dispatch for Topic Flow output sections.
+
+The seam that parallels ``renderer.py``'s ``SECTION_RENDERERS``: a downloadable
+output ``output_type`` registers a handler that turns its section + the user's
+answers into file bytes — a ``DownloadArtifact`` (content type, filename,
+body). The view resolves the output section by id and calls ``build_download``;
+an output_type with no registered handler (``summary``/``packet`` — on-page
+only) is simply not downloadable, surfaced as a 404 by the view.
+
+This keeps the download path open-ended *by design* (#441's "design the
+download path before the first generator lands"): a new file type — ``.vcf``
+(#473) and beyond — slots in as one ``@download_handler`` registration, with no
+new URL or view code. Generation lives in ``artifacts.py`` and resolution /
+date math in ``deadlines.py``; this module only wires ``output_type`` to *how
+to assemble the file*.
+"""
+
+from dataclasses import dataclass
+
+from litigant_portal.app.topic_flow.artifacts import deadlines_to_ics
+from litigant_portal.app.topic_flow.deadlines import resolve_ics_deadlines
+
+
+@dataclass(frozen=True)
+class DownloadArtifact:
+    filename: str
+    content_type: str
+    body: str
+
+
+# output_type -> handler(section, corpus, answers) -> DownloadArtifact
+DOWNLOAD_HANDLERS = {}
+
+
+def download_handler(output_type):
+    """Register a download handler under its output_type. Used as a decorator."""
+
+    def register(fn):
+        DOWNLOAD_HANDLERS[output_type] = fn
+        return fn
+
+    return register
+
+
+def find_downloadable(corpus, output_id):
+    """Return the downloadable output section with ``output_id``, or ``None``.
+
+    ``None`` covers both an unknown id and a section whose output_type has no
+    download handler (info / fact_gather / summary / packet) — the view turns
+    either into a 404, so a stray ``/download/overview/`` can't 500.
+    """
+    for section in corpus.sections:
+        if (
+            section.id == output_id
+            and getattr(section, "output_type", None) in DOWNLOAD_HANDLERS
+        ):
+            return section
+    return None
+
+
+def build_download(section, corpus, answers):
+    """Assemble the ``DownloadArtifact`` for a downloadable output section.
+
+    Callers resolve the section via ``find_downloadable`` first, so the handler
+    is guaranteed present here.
+    """
+    handler = DOWNLOAD_HANDLERS[section.output_type]
+    return handler(section, corpus, answers)
+
+
+@download_handler("ics")
+def _build_ics(section, corpus, answers):
+    """An ``ics`` output section's computed deadlines → a ``.ics`` calendar.
+
+    Only deadlines with a computable date become events — an unanswered date
+    question yields no event (the "enter your dates first" state), so an
+    all-pending section downloads an empty but valid calendar. The per-deadline
+    ``UID`` is stable across re-downloads (keyed by the flow + section + deadline
+    ids) so a calendar app updates the event instead of duplicating it.
+    """
+    meta = corpus.metadata
+    events = []
+    for resolved in resolve_ics_deadlines(section, corpus, answers):
+        if resolved["date"] is None:
+            continue
+        uid = (
+            f"{meta.court}-{meta.topic}-{meta.role}-"
+            f"{section.id}-{resolved['id']}@litigantportal.com"
+        )
+        events.append(
+            {
+                "uid": uid,
+                "summary": resolved["label"],
+                "description": resolved["description"],
+                "date": resolved["date"],
+            }
+        )
+    return DownloadArtifact(
+        filename=f"{section.id}.ics",
+        content_type="text/calendar",
+        body=deadlines_to_ics(events),
+    )

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -13,15 +13,16 @@ session/request machinery.
 
 Corpus validity is guaranteed upstream at load, so the renderer never
 re-validates data; an unhandled section type is a *code* gap (a union member
-with no registered handler) and fails fast. The ``ics`` handler renders its
-deadline list here (its first caller of ``compute_deadline``); the ``.ics``
-download button and the ``vcf`` handler land with their download-view item, so
-rendering a ``vcf`` still raises.
+with no registered handler) and fails fast. The ``ics`` handler formats the
+deadlines from ``resolve_ics_deadlines`` (deadlines.py) for the page; the
+``.ics`` download view (downloads.py) consumes the *same* resolver, so the
+downloaded calendar can't drift from what's rendered. The ``vcf`` handler is
+still intentionally unregistered (it lands with #473), so rendering one raises.
 """
 
 from dataclasses import dataclass
 
-from litigant_portal.app.topic_flow.deadlines import compute_deadline
+from litigant_portal.app.topic_flow.deadlines import resolve_ics_deadlines
 from litigant_portal.app.topic_flow.schema import FactGatherSection
 
 
@@ -152,18 +153,19 @@ def _format_deadline_date(value):
     return value.strftime("%A, %B %-d, %Y")
 
 
-def _deadline_context(deadline, answers):
-    """Flat, template-ready view of one deadline computed from ``answers``.
+def _deadline_display(resolved):
+    """Add page-display date strings to a resolved deadline.
 
-    ``date_display``/``date_iso`` are ``None`` when the source answer is absent
-    or unparseable — the "fill the date first" state — so the template shows the
-    label without a date rather than erroring. ``date_iso`` feeds the ``<time>``
-    element now and the ``.ics`` export later (#441).
+    ``date_display``/``date_iso`` are ``None`` when the computed ``date`` is
+    ``None`` (source answer absent or unparseable) — the "fill the date first"
+    state — so the template shows the label without a date rather than erroring.
+    ``date_iso`` feeds the ``<time>`` element; the ``.ics`` export consumes the
+    same ``resolve_ics_deadlines`` output one layer up, so the two can't drift.
     """
-    computed = compute_deadline(deadline, answers)
+    computed = resolved["date"]
     return {
-        "label": deadline.label,
-        "description": deadline.description,
+        "label": resolved["label"],
+        "description": resolved["description"],
         "date_display": _format_deadline_date(computed) if computed else None,
         "date_iso": computed.isoformat() if computed else None,
     }
@@ -171,16 +173,25 @@ def _deadline_context(deadline, answers):
 
 @renderer("ics")
 def _render_ics(section, corpus, answers):
-    # Resolve the section's deadline_ids against corpus-level deadlines, in the
-    # section's declared order. The loader guarantees every id resolves, so the
-    # lookup never misses for a valid corpus.
-    by_id = {deadline.id: deadline for deadline in corpus.deadlines}
     deadlines = [
-        _deadline_context(by_id[did], answers) for did in section.deadline_ids
+        _deadline_display(resolved)
+        for resolved in resolve_ics_deadlines(section, corpus, answers)
     ]
+    meta = corpus.metadata
+    # URL parts (not a built URL) so the template owns {% url %} resolution and
+    # the renderer stays Django-free. ``has_dates`` gates the download link:
+    # an empty calendar is no use, so the button only shows once at least one
+    # deadline has a computed date.
     return RenderedSection(
         anchor_id=section.id,
         heading=section.heading,
         template=f"{_TEMPLATE_DIR}/flow_section_ics.html",
-        context={"deadlines": deadlines},
+        context={
+            "deadlines": deadlines,
+            "has_dates": any(d["date_iso"] for d in deadlines),
+            "court": meta.court,
+            "topic": meta.topic,
+            "role": meta.role,
+            "output_id": section.id,
+        },
     )

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -18,6 +18,11 @@ app_patterns = [
         pages.topic_flow,
         name="topic_flow",
     ),
+    path(
+        "t/<slug:court>/<slug:topic>/<slug:role>/download/<slug:output_id>/",
+        pages.topic_flow_download,
+        name="topic_flow_download",
+    ),
     path("chat/", pages.chat_page, name="chat"),
     path("chat/action-plan/", endpoints.action_plan, name="action_plan"),
     path("style-guide/", pages.style_guide, name="style_guide"),

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils.http import urlencode
@@ -12,6 +12,10 @@ from litigant_portal.agents import agent_registry
 from litigant_portal.app.forms import UserProfileForm
 from litigant_portal.app.models import UserProfile
 from litigant_portal.app.topic_flow.answer_store import AnswerStore
+from litigant_portal.app.topic_flow.downloads import (
+    build_download,
+    find_downloadable,
+)
 from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
     question_ids,
@@ -270,6 +274,33 @@ def topic_flow(request, court, topic, role):
         "pages/topic_flow.html",
         {"corpus": corpus, "rendered_sections": rendered_sections},
     )
+
+
+def topic_flow_download(request, court, topic, role, output_id):
+    """Download a Topic Flow output section as a file (e.g. an ``.ics``).
+
+    The generic counterpart to ``topic_flow``: resolve the corpus and the
+    downloadable output section (404 on either miss — an unknown id or a
+    non-downloadable section), then dispatch on ``output_type`` to assemble the
+    file from the guest's stored answers. The view stays thin — file bytes come
+    from the download handlers in downloads.py, computed from the same
+    AnswerStore the page renders, so the download matches what's on screen.
+    """
+    corpus = registry.get(court, topic, role)
+    if corpus is None:
+        raise Http404(f"No Topic Flow for {court}/{topic}/{role}")
+
+    section = find_downloadable(corpus, output_id)
+    if section is None:
+        raise Http404(f"No downloadable output {output_id!r}")
+
+    store = AnswerStore(request.session, court, topic, role)
+    artifact = build_download(section, corpus, store.all())
+    response = HttpResponse(artifact.body, content_type=artifact.content_type)
+    response["Content-Disposition"] = (
+        f'attachment; filename="{artifact.filename}"'
+    )
+    return response
 
 
 def test_agent(request, agent_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pydantic>=2.0",
     # Topic Flow corpus loading (litigant_portal/app/topic_flow)
     "pyyaml>=6.0",
+    # Topic Flow file artifacts — .ics calendar export (and .vcf, #473)
+    "vobject>=0.9.6.1",
     # Security minimums (transitive deps — Dependabot #13-#25)
     "aiohttp>=3.13.4",
     "cryptography>=46.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -990,6 +990,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "requests" },
+    { name = "vobject" },
     { name = "whitenoise", extra = ["brotli"] },
 ]
 
@@ -1038,6 +1039,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.8" },
     { name = "tox-uv", marker = "extra == 'dev'", specifier = ">=1.29.0" },
     { name = "tox-uv", marker = "extra == 'test'", specifier = ">=1.29.0" },
+    { name = "vobject", specifier = ">=0.9.6.1" },
     { name = "whitenoise", extras = ["brotli"], specifier = ">=6.0" },
 ]
 provides-extras = ["dev", "test"]
@@ -1677,12 +1679,33 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -2186,6 +2209,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "vobject"
+version = "0.9.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/8a/15c34b3d27c43fc81a467d0f66577afc5542326804c42f30557e31c3259e/vobject-0.9.9.tar.gz", hash = "sha256:ac44e5d7e2079d84c1d52c50a615b9bec4b1ba958608c4c7fe40cbf33247b38e", size = 1208905, upload-time = "2024-12-16T07:29:39.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/20/6bba813bbd498c28edbbcf8253a6398cf4266ecf7bfa6129835c0a2bfbb1/vobject-0.9.9-py2.py3-none-any.whl", hash = "sha256:0fbdb982065cf4d1843a5d5950c88510041c6de026bda49c3502721de1c6ac3d", size = 47526, upload-time = "2024-12-16T07:31:08.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Render an output section's computed deadlines as a downloadable `.ics`, so a litigant can add their personalized deadlines to a phone calendar — the demo's add-to-calendar moment, pairing with on-page deadline rendering (#494).

- `deadlines_to_ics` (`artifacts.py`): pure generator via `vobject` — all-day events, stable UIDs, RFC 5545 escaping/folding.
- `resolve_ics_deadlines` (`deadlines.py`): one resolver shared by the page renderer and the download view, so the calendar can't drift from what's on screen.
- Generic output-download route dispatching on `output_type` (`downloads.py`); `.vcf` (#473) and future types slot in as one handler with no new routing or view code.
- Download link in the ics section, gated on a computed date (JS-off, CSP-clean); `vobject` added to deps.

**As-built note:** route is `t/<court>/<topic>/<role>/download/<output_id>/` (extension rides in `Content-Disposition`), not the `<output_id>.ics` in #504's body — more faithful to the dispatch-on-`output_type` seam, so new file types need zero routing changes.

## Test plan

31 tests: generator round-trips (vobject parse-back), shared-resolver contract, download dispatch + 404s + empty-state, view content-type/disposition, link gating. Full suite green via Docker; lint clean.

Closes #504
Part of #441