### PR TITLE
feat(topic-flow): .vcf add-to-contacts handoff

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_vcf.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_vcf.html
@@ -1,0 +1,47 @@
+{% load i18n %}
+
+{# vcf output body: corpus contacts (clerk, legal aid, etc.), server-rendered #}
+{# and JS-off (#473). Each contact shows its available details; the add-to- #}
+{# contacts (.vcf) download link bundles them all into one vCard file. Contacts #}
+{# are static corpus data, so the link always shows (no fill-in-first gate). #}
+<ul class="space-y-4">
+  {% for contact in ctx.contacts %}
+  <li>
+    <div class="font-medium text-greyscale-900">{{ contact.name }}</div>
+    {% if contact.phone %}
+    <p class="text-sm text-greyscale-700">
+      <c-atoms.link href="tel:{{ contact.phone }}">{{ contact.phone }}</c-atoms.link>
+    </p>
+    {% endif %}
+    {% if contact.email %}
+    <p class="text-sm text-greyscale-700">
+      <c-atoms.link href="mailto:{{ contact.email }}">{{ contact.email }}</c-atoms.link>
+    </p>
+    {% endif %}
+    {% if contact.url %}
+    <p class="text-sm text-greyscale-700">
+      <c-atoms.link href="{{ contact.url }}" target="_blank">{{ contact.url }}</c-atoms.link>
+    </p>
+    {% endif %}
+    {% if contact.address %}
+    <p class="text-sm text-greyscale-700">{{ contact.address }}</p>
+    {% endif %}
+    {% if contact.hours %}
+    <p class="text-sm text-greyscale-500">{% trans "Hours" %}: {{ contact.hours }}</p>
+    {% endif %}
+    {% if contact.note %}
+    <p class="text-sm text-greyscale-500">{{ contact.note }}</p>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+
+<div class="mt-4">
+  <c-atoms.button
+    href="{% url 'pages:topic_flow_download' court=ctx.court topic=ctx.topic role=ctx.role output_id=ctx.output_id %}"
+    variant="outline"
+  >
+    <c-atoms.icon name="identification" class="w-4 h-4" />
+    {% trans "Add to contacts" %}
+  </c-atoms.button>
+</div>

--- a/litigant_portal/app/tests/test_topic_flow_artifacts.py
+++ b/litigant_portal/app/tests/test_topic_flow_artifacts.py
@@ -15,7 +15,10 @@ from datetime import date, datetime
 
 import vobject
 
-from litigant_portal.app.topic_flow.artifacts import deadlines_to_ics
+from litigant_portal.app.topic_flow.artifacts import (
+    contacts_to_vcf,
+    deadlines_to_ics,
+)
 
 
 def _event(
@@ -88,3 +91,98 @@ def test_empty_event_list_is_still_a_valid_calendar():
     cal = vobject.readOne(deadlines_to_ics([]))
     assert cal.name == "VCALENDAR"
     assert "vevent" not in cal.contents
+
+
+# --- contacts_to_vcf --------------------------------------------------------
+# Same pure-projection contract as deadlines_to_ics: resolved contact dicts in,
+# vCard bytes out. Tests round-trip through vobject (parse the output back) to
+# pin the semantic contract, not vobject's exact line formatting.
+
+
+def _card(
+    uid="clerk@litigantportal",
+    name="Clerk of Court",
+    phone=None,
+    email=None,
+    url=None,
+    address=None,
+    note=None,
+):
+    return {
+        "uid": uid,
+        "name": name,
+        "phone": phone,
+        "email": email,
+        "url": url,
+        "address": address,
+        "note": note,
+    }
+
+
+def test_wraps_contacts_in_a_parseable_vcard():
+    card = vobject.readOne(contacts_to_vcf([_card()]))
+    assert card.name == "VCARD"
+    # VERSION is mandatory; a vCard without it won't import.
+    assert card.version.value == "3.0"
+
+
+def test_name_sets_both_fn_and_org():
+    # Our contacts are offices, so the name is the organization AND the display
+    # name — not a person's structured N. Both must carry it.
+    card = vobject.readOne(contacts_to_vcf([_card(name="Legal Aid Society")]))
+    assert card.fn.value == "Legal Aid Society"
+    assert card.org.value == ["Legal Aid Society"]
+
+
+def test_uid_round_trips():
+    card = vobject.readOne(
+        contacts_to_vcf([_card(uid="clerk@litigantportal")])
+    )
+    assert card.uid.value == "clerk@litigantportal"
+
+
+def test_optional_fields_present_when_given():
+    card = vobject.readOne(
+        contacts_to_vcf(
+            [
+                _card(
+                    phone="555-1234",
+                    email="clerk@court.gov",
+                    url="https://court.gov",
+                    note="Window 3",
+                )
+            ]
+        )
+    )
+    assert card.tel.value == "555-1234"
+    assert card.email.value == "clerk@court.gov"
+    assert card.url.value == "https://court.gov"
+    assert card.note.value == "Window 3"
+
+
+def test_optional_fields_omitted_when_absent():
+    # Absent field → no line, never an empty TEL:/EMAIL:.
+    card = vobject.readOne(contacts_to_vcf([_card()]))
+    assert "tel" not in card.contents
+    assert "email" not in card.contents
+    assert "note" not in card.contents
+
+
+def test_each_contact_becomes_its_own_vcard():
+    out = contacts_to_vcf([_card(uid="a", name="A"), _card(uid="b", name="B")])
+    cards = list(vobject.readComponents(out))
+    assert {c.uid.value for c in cards} == {"a", "b"}
+
+
+def test_vcf_special_characters_survive_a_round_trip():
+    # RFC 6350 reserves comma / semicolon / backslash in TEXT values; round-
+    # tripping intact proves vobject's escaping is applied.
+    tricky = "Legal Aid; Society, Inc.\\ here"
+    card = vobject.readOne(contacts_to_vcf([_card(name=tricky)]))
+    assert card.fn.value == tricky
+
+
+def test_empty_contact_list_is_an_empty_string():
+    # No contacts → no cards. (Schema guarantees a vcf section has ≥1, so this
+    # is the generator's own floor, not a reachable section state.)
+    assert contacts_to_vcf([]) == ""

--- a/litigant_portal/app/tests/test_topic_flow_contacts.py
+++ b/litigant_portal/app/tests/test_topic_flow_contacts.py
@@ -1,0 +1,77 @@
+"""Contact resolution for Topic Flow — pure, DB-free (runs in the fast suite).
+
+``resolve_vcf_contacts`` is the shared resolver a vcf section's renderer AND its
+.vcf download view both call, so the page and the downloaded vCard build from
+one source. It duck-types on ``section.contact_ids`` and ``corpus.contacts``;
+the stand-ins below carry just those attributes (real Contact objects supply
+the fields the resolver reads).
+"""
+
+from types import SimpleNamespace
+
+from litigant_portal.app.topic_flow.contacts import resolve_vcf_contacts
+from litigant_portal.app.topic_flow.schema import Contact
+
+
+def _contact(id, name, **fields):
+    return Contact(id=id, name=name, **fields)
+
+
+def _section(*contact_ids):
+    return SimpleNamespace(contact_ids=list(contact_ids))
+
+
+def _corpus(*contacts):
+    return SimpleNamespace(contacts=list(contacts))
+
+
+def test_resolves_a_referenced_contacts_fields():
+    contact = _contact(
+        "clerk",
+        "Clerk of Court",
+        phone="555-1234",
+        email="clerk@court.gov",
+        url="https://court.gov",
+        address="100 Main St",
+        hours="9-4 M-F",
+        note="Window 3",
+    )
+    (resolved,) = resolve_vcf_contacts(_section("clerk"), _corpus(contact))
+    assert resolved == {
+        "id": "clerk",
+        "name": "Clerk of Court",
+        "phone": "555-1234",
+        "email": "clerk@court.gov",
+        "url": "https://court.gov",
+        "address": "100 Main St",
+        "hours": "9-4 M-F",
+        "note": "Window 3",
+    }
+
+
+def test_absent_optional_fields_resolve_to_none():
+    # Only id + name supplied; the rest must come through as None, not missing.
+    contact = _contact("aid", "Legal Aid")
+    (resolved,) = resolve_vcf_contacts(_section("aid"), _corpus(contact))
+    assert resolved["phone"] is None
+    assert resolved["email"] is None
+    assert resolved["note"] is None
+
+
+def test_resolves_in_contact_ids_order_not_corpus_order():
+    # Order follows the section's contact_ids, not corpus.contacts order.
+    clerk = _contact("clerk", "Clerk")
+    aid = _contact("aid", "Legal Aid")
+    resolved = resolve_vcf_contacts(
+        _section("aid", "clerk"), _corpus(clerk, aid)
+    )
+    assert [c["name"] for c in resolved] == ["Legal Aid", "Clerk"]
+
+
+def test_resolves_every_referenced_contact():
+    clerk = _contact("clerk", "Clerk")
+    aid = _contact("aid", "Legal Aid")
+    resolved = resolve_vcf_contacts(
+        _section("clerk", "aid"), _corpus(clerk, aid)
+    )
+    assert len(resolved) == 2

--- a/litigant_portal/app/tests/test_topic_flow_downloads.py
+++ b/litigant_portal/app/tests/test_topic_flow_downloads.py
@@ -20,6 +20,7 @@ from litigant_portal.app.topic_flow.downloads import (
     find_downloadable,
 )
 from litigant_portal.app.topic_flow.schema import (
+    Contact,
     Corpus,
     Deadline,
     FactGatherSection,
@@ -27,6 +28,7 @@ from litigant_portal.app.topic_flow.schema import (
     Metadata,
     Question,
     SummaryOutput,
+    VcfOutput,
 )
 
 # An answered publication_date; 30 days on = 2026-03-03.
@@ -50,6 +52,15 @@ def _corpus():
                 description="Judge may review after this.",
             )
         ],
+        contacts=[
+            Contact(
+                id="clerk",
+                name="Clerk of Court",
+                phone="555-1234",
+                hours="9-4 M-F",
+                note="Window 3",
+            )
+        ],
         sections=[
             FactGatherSection(
                 kind="fact_gather",
@@ -64,6 +75,13 @@ def _corpus():
                 id="deadlines_calendar",
                 heading="Add deadlines to your calendar",
                 deadline_ids=["publication_wait"],
+            ),
+            VcfOutput(
+                kind="output",
+                output_type="vcf",
+                id="contacts_card",
+                heading="Save these contacts",
+                contact_ids=["clerk"],
             ),
             SummaryOutput(
                 kind="output",
@@ -138,4 +156,54 @@ def test_uid_is_stable_across_downloads():
     assert (
         vobject.readOne(first.body).vevent.uid.value
         == vobject.readOne(again.body).vevent.uid.value
+    )
+
+
+# --- build_download (vcf) ---------------------------------------------------
+# A vcf section dispatches to the vCard builder, independent of answers (contacts
+# are static corpus data). Body is parsed back with vobject to assert the contact
+# became a real card via the same resolve_vcf_contacts the page renders with.
+
+
+def _vcf_section(corpus):
+    return find_downloadable(corpus, "contacts_card")
+
+
+def test_resolves_the_vcf_output_section():
+    section = find_downloadable(_corpus(), "contacts_card")
+    assert section is not None
+    assert section.output_type == "vcf"
+
+
+def test_sets_vcard_content_type_and_filename():
+    corpus = _corpus()
+    artifact = build_download(_vcf_section(corpus), corpus, {})
+    assert artifact.content_type == "text/vcard; charset=utf-8"
+    assert artifact.filename == "contacts_card.vcf"
+
+
+def test_vcf_body_carries_the_contact_as_a_card():
+    corpus = _corpus()
+    artifact = build_download(_vcf_section(corpus), corpus, {})
+    card = vobject.readOne(artifact.body)
+    assert card.fn.value == "Clerk of Court"
+    assert card.tel.value == "555-1234"
+
+
+def test_vcf_folds_hours_into_the_note_so_import_keeps_it():
+    # vCard has no hours field; without folding, "call 9-4" is lost on import.
+    corpus = _corpus()
+    artifact = build_download(_vcf_section(corpus), corpus, {})
+    note = vobject.readOne(artifact.body).note.value
+    assert "Window 3" in note
+    assert "Hours: 9-4 M-F" in note
+
+
+def test_vcf_uid_is_stable_across_downloads():
+    corpus = _corpus()
+    first = build_download(_vcf_section(corpus), corpus, {})
+    again = build_download(_vcf_section(corpus), corpus, {})
+    assert (
+        vobject.readOne(first.body).uid.value
+        == vobject.readOne(again.body).uid.value
     )

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -8,6 +8,8 @@ intentionally unregistered — it lands with its download-view item (#441) — s
 rendering one fails fast.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from litigant_portal.app.topic_flow.renderer import (
@@ -15,6 +17,7 @@ from litigant_portal.app.topic_flow.renderer import (
     render_section,
 )
 from litigant_portal.app.topic_flow.schema import (
+    Contact,
     Corpus,
     Deadline,
     FactGatherSection,
@@ -28,10 +31,11 @@ from litigant_portal.app.topic_flow.schema import (
 )
 
 
-def _corpus(*sections, deadlines=None):
+def _corpus(*sections, deadlines=None, contacts=None):
     return Corpus(
         metadata=Metadata(court="c", topic="t", role="r", title="T"),
         deadlines=deadlines or [],
+        contacts=contacts or [],
         sections=list(sections),
     )
 
@@ -300,12 +304,70 @@ def test_ics_context_carries_download_url_parts():
 
 
 def test_unregistered_output_type_raises():
+    # Every real output_type is now registered, so the fail-fast invariant is
+    # tested with a stand-in carrying an output_type no handler knows. A new
+    # union member shipped without a renderer must blow up, not render blank.
+    bogus = SimpleNamespace(kind="output", output_type="zip", id="x")
+    # corpus is irrelevant — dispatch raises on the unknown key before using it.
+    with pytest.raises(ValueError, match="zip"):
+        render_section(bogus, None, {})
+
+
+# --- vcf (contact rendering, #473) ------------------------------------------
+# The vcf output renders each referenced contact via resolve_vcf_contacts
+# (shared with the .vcf download, #473). Contacts are static — no answers, no
+# pending state — so the download link always shows.
+
+_CLERK = Contact(
+    id="clerk",
+    name="Clerk of Court",
+    phone="555-1234",
+    note="Window 3",
+)
+
+
+def _vcf_corpus(contact_ids=("clerk",), contacts=(_CLERK,)):
     vcf = VcfOutput(
         kind="output",
         output_type="vcf",
-        id="contact",
-        heading="Save the clerk's contact",
-        contact_ids=["clerk"],
+        id="contacts",
+        heading="Save these contacts",
+        contact_ids=list(contact_ids),
     )
-    with pytest.raises(ValueError, match="vcf"):
-        render_section(vcf, _corpus(vcf), {})
+    corpus = _corpus(vcf, contacts=list(contacts))
+    return corpus, vcf
+
+
+def test_vcf_renders_referenced_contact():
+    corpus, vcf = _vcf_corpus()
+    (c,) = render_section(vcf, corpus, {}).context["contacts"]
+    assert c["name"] == "Clerk of Court"
+    assert c["phone"] == "555-1234"
+    assert c["note"] == "Window 3"
+
+
+def test_vcf_lists_contacts_in_contact_ids_order():
+    aid = Contact(id="aid", name="Legal Aid")
+    corpus, vcf = _vcf_corpus(
+        contact_ids=("aid", "clerk"), contacts=(_CLERK, aid)
+    )
+    contacts = render_section(vcf, corpus, {}).context["contacts"]
+    assert [c["name"] for c in contacts] == ["Legal Aid", "Clerk of Court"]
+
+
+def test_vcf_context_carries_download_url_parts():
+    # The template builds {% url 'pages:topic_flow_download' ... %} from these.
+    corpus, vcf = _vcf_corpus()
+    ctx = render_section(vcf, corpus, {}).context
+    assert ctx["output_id"] == vcf.id
+    assert (ctx["court"], ctx["topic"], ctx["role"]) == (
+        corpus.metadata.court,
+        corpus.metadata.topic,
+        corpus.metadata.role,
+    )
+
+
+def test_vcf_uses_the_vcf_template():
+    corpus, vcf = _vcf_corpus()
+    rendered = render_section(vcf, corpus, {})
+    assert rendered.template.endswith("flow_section_vcf.html")

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -3,9 +3,9 @@
 The renderer is a fat, pure function of ``(section, corpus, answers)`` → a
 ``RenderedSection`` carrying a template path + flat, dumb context. It takes a
 plain ``answers`` dict (not an AnswerStore), so these tests need no session or
-DB. The ``ics`` handler renders its deadline list here (#494); ``vcf`` is still
-intentionally unregistered — it lands with its download-view item (#441) — so
-rendering one fails fast.
+DB. The ``ics`` handler renders its deadline list here (#494); the ``vcf``
+handler renders its contact list (#473). An output_type with no registered
+handler is a code gap and fails fast.
 """
 
 from types import SimpleNamespace

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -18,6 +18,7 @@ from django.urls import resolve, reverse
 
 from litigant_portal.app.topic_flow.renderer import RenderedSection
 from litigant_portal.app.topic_flow.schema import (
+    Contact,
     Corpus,
     Deadline,
     FactGatherSection,
@@ -27,6 +28,7 @@ from litigant_portal.app.topic_flow.schema import (
     PacketOutput,
     Question,
     SummaryOutput,
+    VcfOutput,
 )
 from litigant_portal.app.views import pages
 
@@ -498,3 +500,62 @@ def test_ics_section_hides_download_link_until_a_date_is_entered(
     )
     html = client.get(URL).content.decode()
     assert f'href="{DOWNLOAD_URL}"' not in html
+
+
+# --- vcf download (#473, needs DB) ------------------------------------------
+# The same generic download route, dispatching on output_type to the vCard
+# builder. Contacts are static corpus data, so the .vcf needs no stored answers
+# — it downloads the same card set the page shows.
+
+VCF_DOWNLOAD_URL = f"/t/{COURT}/{TOPIC}/{ROLE}/download/contacts_card/"
+
+
+def _corpus_with_contact():
+    return Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        contacts=[
+            Contact(id="clerk", name="Clerk of Court", phone="555-1234")
+        ],
+        sections=[
+            VcfOutput(
+                kind="output",
+                output_type="vcf",
+                id="contacts_card",
+                heading="Save these contacts",
+                contact_ids=["clerk"],
+            ),
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_vcf_download_streams_vcard_attachment_with_the_contact(
+    client, monkeypatch
+):
+    # The payoff: the generic route dispatches a vcf section to the vCard
+    # builder and streams it as a .vcf attachment carrying the contact.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_contact()
+    )
+    response = client.get(VCF_DOWNLOAD_URL)
+    assert response.status_code == 200
+    assert "text/vcard" in response["Content-Type"]
+    assert (
+        'attachment; filename="contacts_card.vcf"'
+        in response["Content-Disposition"]
+    )
+    body = response.content.decode()
+    assert "BEGIN:VCARD" in body
+    assert "Clerk of Court" in body
+
+
+@pytest.mark.django_db
+def test_vcf_section_links_to_the_download(client, monkeypatch):
+    # The page must surface a reachable link to the .vcf — without it the
+    # litigant can't save the contacts. Functional target, not markup. No
+    # gate (unlike ics): contacts are always present, so the link always shows.
+    monkeypatch.setattr(
+        pages.registry, "get", lambda *a: _corpus_with_contact()
+    )
+    html = client.get(URL).content.decode()
+    assert f'href="{VCF_DOWNLOAD_URL}"' in html

--- a/litigant_portal/app/topic_flow/artifacts.py
+++ b/litigant_portal/app/topic_flow/artifacts.py
@@ -1,15 +1,16 @@
 """Generate downloadable file artifacts from Topic Flow corpus data.
 
-Currently: an iCalendar (``.ics``) from a list of computed deadline events — a
-pure projection with no corpus, no answers, no host page, mirroring the pure
-style of ``deadlines.py``/``renderer.py``. The view layer resolves the corpus,
-reads the session AnswerStore, and computes the dates; this module only turns
-the resulting events into bytes, so the field mapping is unit-testable without
-Django and ``vobject`` owns RFC 5545 escaping and line folding.
+Two generators, both pure projections — a list of already-resolved dicts in,
+file bytes out, no corpus / answers / host page, mirroring the pure style of
+``deadlines.py``/``renderer.py``:
 
-The future ``.vcf`` generator (a Contact → vCard, #473) lands here too — same
-"data shape in, file bytes out" contract — which is why the module is named for
-artifacts in general, not just calendars.
+- ``deadlines_to_ics`` — computed deadline events → an iCalendar (``.ics``).
+- ``contacts_to_vcf`` — resolved contacts → vCards (``.vcf``).
+
+The view layer resolves the corpus, reads the session AnswerStore, and computes
+the data; this module only turns the resulting dicts into bytes, so the field
+mapping is unit-testable without Django and ``vobject`` owns the RFC escaping
+and line folding (RFC 5545 for iCalendar, RFC 6350 for vCard).
 """
 
 from datetime import datetime
@@ -20,6 +21,7 @@ import vobject
 # vobject only serializes a tzinfo it can map to a TZID — Python's stdlib
 # ``timezone.utc`` raises "Unable to guess TZID", so reuse vobject's singleton.
 from vobject.icalendar import utc
+from vobject.vcard import Address
 
 # Identifies the product that produced the file (RFC 5545 PRODID). Overrides
 # vobject's generic default so calendar apps attribute the import to us.
@@ -52,3 +54,40 @@ def deadlines_to_ics(events) -> str:
         if event.get("description"):
             vevent.add("description").value = event["description"]
     return cal.serialize()
+
+
+def contacts_to_vcf(cards) -> str:
+    """Serialize resolved ``cards`` to a vCard (``.vcf``) string.
+
+    Each card is a dict ``{uid, name, phone, email, url, address, note}`` —
+    already resolved by the caller. ``name`` sets both ``FN`` (the display name)
+    and ``ORG``: our contacts are usually offices (clerk, legal aid), so a phone
+    imports them as an organization card rather than mangling an office name
+    into a person's given/family ``N``. Every other field is optional —
+    ``None``/empty emits no line. ``uid`` is supplied by the caller (stable per
+    contact) so re-downloading updates the card rather than duplicating it.
+
+    Multiple cards concatenate into one file (a valid ``.vcf`` holds many
+    vCards); an empty ``cards`` list yields an empty string.
+    """
+    out = []
+    for card in cards:
+        vcard = vobject.vCard()
+        vcard.add("uid").value = card["uid"]
+        vcard.add("fn").value = card["name"]
+        # ORG is a structured (list) value; a single-element list is one org.
+        vcard.add("org").value = [card["name"]]
+        if card.get("phone"):
+            vcard.add("tel").value = card["phone"]
+        if card.get("email"):
+            vcard.add("email").value = card["email"]
+        if card.get("url"):
+            vcard.add("url").value = card["url"]
+        if card.get("address"):
+            # A free-form one-line address rides in the ADR street component;
+            # vobject escapes any commas/semicolons within it.
+            vcard.add("adr").value = Address(street=card["address"])
+        if card.get("note"):
+            vcard.add("note").value = card["note"]
+        out.append(vcard.serialize())
+    return "".join(out)

--- a/litigant_portal/app/topic_flow/contacts.py
+++ b/litigant_portal/app/topic_flow/contacts.py
@@ -1,0 +1,39 @@
+"""Resolve a vcf output section's contacts — pure, AI-free, DB-free.
+
+Parallels ``deadlines.py``'s ``resolve_ics_deadlines``: the single place a vcf
+output section's ``contact_ids`` are resolved against corpus-level contacts, in
+the section's declared order. Both the page renderer (which displays the
+contacts) and the ``.vcf`` download handler (which turns them into vCards)
+consume this one resolver, so the downloaded card can't drift from what's shown
+on the page.
+
+Unlike deadlines there is no computation — a contact needs no user input — so
+this is a pure id lookup. The loader guarantees every ``contact_id`` resolves
+for a valid corpus, so the lookup never misses.
+"""
+
+
+def resolve_vcf_contacts(section, corpus):
+    """Return one flat dict per referenced contact, in declared order.
+
+    ``{id, name, phone, email, url, address, hours, note}`` — already
+    template-ready and decoupled from the schema model, so the renderer binds
+    it directly and the download handler maps it to vCard fields.
+    """
+    by_id = {contact.id: contact for contact in corpus.contacts}
+    resolved = []
+    for contact_id in section.contact_ids:
+        contact = by_id[contact_id]
+        resolved.append(
+            {
+                "id": contact.id,
+                "name": contact.name,
+                "phone": contact.phone,
+                "email": contact.email,
+                "url": contact.url,
+                "address": contact.address,
+                "hours": contact.hours,
+                "note": contact.note,
+            }
+        )
+    return resolved

--- a/litigant_portal/app/topic_flow/downloads.py
+++ b/litigant_portal/app/topic_flow/downloads.py
@@ -17,7 +17,11 @@ to assemble the file*.
 
 from dataclasses import dataclass
 
-from litigant_portal.app.topic_flow.artifacts import deadlines_to_ics
+from litigant_portal.app.topic_flow.artifacts import (
+    contacts_to_vcf,
+    deadlines_to_ics,
+)
+from litigant_portal.app.topic_flow.contacts import resolve_vcf_contacts
 from litigant_portal.app.topic_flow.deadlines import resolve_ics_deadlines
 
 
@@ -102,4 +106,57 @@ def _build_ics(section, corpus, answers):
         # UTF-8, but stating it beats relying on the client to honor the default.
         content_type="text/calendar; charset=utf-8",
         body=deadlines_to_ics(events),
+    )
+
+
+def _contact_note(resolved):
+    """Combine a contact's free-text note and hours into the vCard NOTE.
+
+    vCard has no native "hours" field, so opening hours would be lost on import
+    — for our audience ("call the clerk between 9–4") that's the useful part.
+    Fold it into NOTE under the existing note so it survives. Returns ``None``
+    when neither is present (no NOTE line emitted).
+    """
+    parts = []
+    if resolved["note"]:
+        parts.append(resolved["note"])
+    if resolved["hours"]:
+        parts.append(f"Hours: {resolved['hours']}")
+    return "\n".join(parts) or None
+
+
+@download_handler("vcf")
+def _build_vcf(section, corpus, answers):
+    """A ``vcf`` output section's contacts → a ``.vcf`` vCard file.
+
+    Contacts are static corpus data (no user input), so ``answers`` is unused —
+    the section always downloads the same card set. The per-contact ``UID`` is
+    stable across re-downloads (keyed by the flow + section + contact ids) so a
+    phone updates the saved contact instead of duplicating it.
+    """
+    meta = corpus.metadata
+    cards = []
+    for resolved in resolve_vcf_contacts(section, corpus):
+        uid = (
+            f"{meta.court}-{meta.topic}-{meta.role}-"
+            f"{section.id}-{resolved['id']}@litigantportal.com"
+        )
+        cards.append(
+            {
+                "uid": uid,
+                "name": resolved["name"],
+                "phone": resolved["phone"],
+                "email": resolved["email"],
+                "url": resolved["url"],
+                "address": resolved["address"],
+                "note": _contact_note(resolved),
+            }
+        )
+    return DownloadArtifact(
+        filename=f"{section.id}.vcf",
+        # Declare UTF-8 explicitly (see _build_ics): contact names/notes are
+        # author-supplied and may carry non-ASCII. RFC 6350 mandates UTF-8 for
+        # vCard, so stating it keeps strict importers happy.
+        content_type="text/vcard; charset=utf-8",
+        body=contacts_to_vcf(cards),
     )

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -13,15 +13,15 @@ session/request machinery.
 
 Corpus validity is guaranteed upstream at load, so the renderer never
 re-validates data; an unhandled section type is a *code* gap (a union member
-with no registered handler) and fails fast. The ``ics`` handler formats the
-deadlines from ``resolve_ics_deadlines`` (deadlines.py) for the page; the
-``.ics`` download view (downloads.py) consumes the *same* resolver, so the
-downloaded calendar can't drift from what's rendered. The ``vcf`` handler is
-still intentionally unregistered (it lands with #473), so rendering one raises.
+with no registered handler) and fails fast. The ``ics`` and ``vcf`` handlers
+format their data from a shared resolver (``resolve_ics_deadlines`` /
+``resolve_vcf_contacts``) that their download handlers (downloads.py) also
+consume, so what's downloaded can't drift from what's rendered on the page.
 """
 
 from dataclasses import dataclass
 
+from litigant_portal.app.topic_flow.contacts import resolve_vcf_contacts
 from litigant_portal.app.topic_flow.deadlines import resolve_ics_deadlines
 from litigant_portal.app.topic_flow.schema import FactGatherSection
 
@@ -189,6 +189,29 @@ def _render_ics(section, corpus, answers):
         context={
             "deadlines": deadlines,
             "has_dates": any(d["date_iso"] for d in deadlines),
+            "court": meta.court,
+            "topic": meta.topic,
+            "role": meta.role,
+            "output_id": section.id,
+        },
+    )
+
+
+@renderer("vcf")
+def _render_vcf(section, corpus, answers):
+    contacts = resolve_vcf_contacts(section, corpus)
+    meta = corpus.metadata
+    # Same shape as _render_ics: the flat contact dicts are template-ready, and
+    # the URL parts let the template own {% url %} resolution (renderer stays
+    # Django-free). No gate like ics's has_dates — contacts are static corpus
+    # data that always resolve (contact_ids is non-empty), so the download link
+    # always shows.
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_vcf.html",
+        context={
+            "contacts": contacts,
             "court": meta.court,
             "topic": meta.topic,
             "role": meta.role,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pydantic>=2.0",
     # Topic Flow corpus loading (litigant_portal/app/topic_flow)
     "pyyaml>=6.0",
-    # Topic Flow file artifacts — .ics calendar export (and .vcf, #473)
+    # Topic Flow file artifacts — .ics calendar + .vcf vCard export
     "vobject>=0.9.6.1",
     # Security minimums (transitive deps — Dependabot #13-#25)
     "aiohttp>=3.13.4",


### PR DESCRIPTION
Render a vcf output section's contacts on-page (JS-off) and offer them as a downloadable `.vcf` vCard the phone imports as contact cards — the save-the-clerk / legal-aid handoff. Slots into the generic download seam from #504 (.ics) with no new routing or view code.

- `contacts_to_vcf` (`artifacts.py`): pure `vobject` generator — `ORG`+`FN` (our contacts are offices, not people), optional fields omit cleanly, stable per-contact `UID`, RFC 6350 escaping, multiple contacts serialize into one file.
- `resolve_vcf_contacts` (`contacts.py`): one resolver shared by the page renderer and the download handler, so the downloaded card can't drift from what's on screen (mirrors `resolve_ics_deadlines`).
- `@download_handler("vcf")` (`downloads.py`): resolves the section's contacts into the vCard; folds office `hours` into `NOTE` (vCard has no native hours field) so "call between 9–4" survives import.
- `vcf` renderer + `flow_section_vcf.html`: contact list + always-on download link (contacts are static corpus data — no fill-in-first gate like ics), composed from existing atoms.

**As-built note:** #473 originally specced a per-contact route + its own download view + adding `vobject`. #504 since landed the generic `download/<output_id>/` seam (dispatch on `output_type`, `DownloadArtifact`, the `@download_handler` registry) and added `vobject`, so vcf lands section-based (matching the schema's `VcfOutput.contact_ids`) as one handler + renderer + template.

## Test plan

23 new tests across the generator, resolver, download dispatch, renderer, and view layers. Generator/handler bodies round-trip through `vobject` parse-back (semantic contract, not line formatting); shared-resolver contract pins contact-id order and field pass-through; download tests assert content-type/disposition/body; renderer + view tests cover on-page render and the download link. The section template was smoke-rendered through Django's engine (the `identification` icon, the `{% url %}` tag, and the JS-off `<a>` all resolve). The order and hours→NOTE logic were mutation-checked. Fast suite green; the `django_db` view tests run in the full Docker suite.

Closes #473
Part of #441
Part of #389
