### PR TITLE
feat(topic-flow): ND adult name-change demo corpus (standard + waiver tracks)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,20 @@ Litigant Portal is open source, and a court partner can stand up their own hoste
 
 ---
 
+## Topic Flow: Linear Structure, Forks at the Entry Point
+
+Applies to the **non-AI Topic Flow engine** (AI chat flows are a separate model, out of scope here).
+
+The engine renders one fixed, ordered corpus per `(court, topic, role)` as a single scrollable page. It has **no conditional/branching logic** — `fact_gather` answers drive deadline math and display (e.g. the summary) only, never which sections show. So a legal process with multiple procedural paths is modeled as **separate corpora selected by distinct URLs**, and the path-selection decision is pushed up to the linking surface — a court links straight to the right track from its own website. Each track corpus cross-links to the others in prose for mis-clicks.
+
+**Example.** North Dakota adult name change splits into `…/adult-name-change/standard/` (any change including the last name: 5 forms, publication, 30-day wait, `.ics` deadline) and `…/adult-name-change/waiver/` (first/middle only: 4 forms, no publication or wait, no deadline). Eviction will split tenant vs. landlord the same way.
+
+**"Linear" describes section order, not the user's path.** It is not a forward-only wizard: the whole flow is one page and users move back and forth — re-reading an info section, correcting an answer they already gave. Answers persist (PRG + the session `AnswerStore`), so revisiting is lossless. In-page wayfinding (a table of contents, section anchors, returning to the section you saved from) is therefore a first-class concern, not decoration.
+
+**Why.** Keeps the engine simple and static, keeps corpora authorable as plain content by non-engineers (including legal reviewers), and treats routing as a human/court concern rather than engine logic.
+
+---
+
 ## Tech Stack Decisions
 
 | Decision           | Choice                        | Rationale                                 |

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -34,9 +34,13 @@
               <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
               {% trans "Reset Demo" %}
             </button>
-            <a href="{% url 'pages:topic_flow' court='north-dakota' topic='adult-name-change' role='petitioner' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+            <a href="{% url 'pages:topic_flow' court='north-dakota' topic='adult-name-change' role='standard' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="beaker" class="w-5 h-5 text-greyscale-500" />
-              {% trans "Demo: Adult Name Change" %}
+              {% trans "Demo: Name Change — Standard" %}
+            </a>
+            <a href="{% url 'pages:topic_flow' court='north-dakota' topic='adult-name-change' role='waiver' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="beaker" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Demo: Name Change — Waiver" %}
             </a>
             <a href="{% url 'pages:style_guide' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="swatch" class="w-5 h-5 text-greyscale-500" />

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -34,6 +34,10 @@
               <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
               {% trans "Reset Demo" %}
             </button>
+            <a href="{% url 'pages:topic_flow' court='north-dakota' topic='adult-name-change' role='petitioner' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
+              <c-atoms.icon name="beaker" class="w-5 h-5 text-greyscale-500" />
+              {% trans "Demo: Adult Name Change" %}
+            </a>
             <a href="{% url 'pages:style_guide' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="swatch" class="w-5 h-5 text-greyscale-500" />
               {% trans "Style Guide" %}

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -1,0 +1,155 @@
+# Demo corpus — Adult Name Change (North Dakota), STANDARD track.
+#
+# The standard track applies to any change that includes the last name:
+# newspaper publication + a 30-day wait before the judge may consider it.
+# The court links to this flow directly for last-name changes; the waiver
+# track (first/middle only) is a separate flow — adult-name-change-waiver.yml.
+#
+# Content drawn from public ND sources already in the repo (the ND court/topic
+# prompts + name-change planning log, sourced from ndcourts.gov). Unverified
+# contact specifics (phone numbers, form-PDF links) are omitted pending a
+# primary-source pass (#495). Not yet legal-reviewed; #509 seeds it.
+
+metadata:
+  court: north-dakota
+  topic: adult-name-change
+  role: standard
+  title: 'Adult Name Change — North Dakota (Standard Track)'
+
+contacts:
+  - id: clerk
+    name: 'Burleigh County Clerk of District Court'
+    url: 'https://www.ndcourts.gov'
+    address: '514 East Thayer Avenue, Bismarck, ND'
+    note: 'Call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge. This is the one call to make first.'
+  - id: self_help
+    name: 'North Dakota Legal Self Help Center'
+    url: 'https://www.ndcourts.gov/legal-self-help'
+    note: 'Court-provided guidance and the official name-change forms for self-represented filers.'
+  - id: legal_aid
+    name: 'Legal Services of North Dakota'
+    note: 'Free legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter.'
+
+deadlines:
+  - id: publication_wait
+    label: '30-day publication waiting period ends'
+    offset_days: 30
+    offset_from: publication_date
+    description: 'Under North Dakota law the judge may not consider your petition until 30 days after the notice is published. After this date, check with the clerk about judge review.'
+
+sections:
+  - kind: info
+    id: overview
+    heading: 'Changing your name in North Dakota'
+    body: |
+      This walks you through a standalone adult name-change petition in North
+      Dakota district court, on the standard track — any change that includes
+      your last name. The standard track requires publishing a notice in a
+      newspaper and a 30-day wait before the judge can act.
+
+      If you are changing only your first and/or middle name (not your last
+      name), a judge may waive publication and the wait — use the waiver-track
+      page instead.
+
+      One common mix-up: if you wanted your name restored as part of a divorce,
+      that has to be requested inside the divorce case — it is not handled here.
+      If your divorce is final and didn't change your name, this standalone
+      petition is the way.
+
+      Official guidance and forms: ndcourts.gov/legal-self-help/name-change-adult
+
+  - kind: info
+    id: eligibility
+    heading: 'Who can file'
+    body: |
+      To petition for a name change in North Dakota you must be a U.S. citizen
+      or a U.S. permanent resident. You attest to this on the Petition.
+
+      A name change cannot be used to defraud anyone or to evade a legal
+      obligation (for example, debts or a criminal record). These are conditions
+      you confirm on the forms — not something you have to explain to anyone here.
+
+  - kind: fact_gather
+    id: your_details
+    heading: 'Your details'
+    questions:
+      - id: current_legal_name
+        label: 'Your current legal name'
+        type: text
+      - id: requested_name
+        label: 'The name you are requesting'
+        type: text
+      - id: filing_county
+        label: 'County where you will file'
+        type: text
+        help_text: 'You file in the district court for the county where you live.'
+      - id: publication_date
+        label: 'Date your notice was published'
+        type: date
+        help_text: 'Leave blank until your notice runs in the newspaper — then enter it here and your deadline updates. Found on the affidavit of publication from the paper.'
+
+  - kind: output
+    output_type: packet
+    id: filing_packet
+    heading: 'Your filing packet'
+    forms:
+      - 'Notice of Petition for Name Change'
+      - 'Petition for Name Change'
+      - 'Declaration in Support of Petition'
+      - 'Confidential Information Form'
+      - 'Proposed Order for Name Change'
+
+  - kind: info
+    id: form_gotchas
+    heading: 'Before you sign'
+    body: |
+      A few North Dakota specifics that trip people up:
+
+      Leave the case number blank — the clerk assigns it when you file.
+
+      Do not sign the proposed Order. Only the judge signs that one.
+
+      The Confidential Information Form is sealed and stays out of the public
+      file. Keep copies — it must be attached to every certified copy of your
+      Order, or North Dakota Vital Records will reject your updates later.
+
+  - kind: info
+    id: hearing
+    heading: 'Will there be a hearing?'
+    body: |
+      North Dakota does not presumptively require a hearing for a name change,
+      but the judge may decide one is needed. If a hearing is scheduled, the
+      Clerk of District Court will send notice with the date, time, and location.
+
+  - kind: output
+    output_type: ics
+    id: deadlines_calendar
+    heading: 'Add your deadline to your calendar'
+    deadline_ids:
+      - publication_wait
+
+  - kind: output
+    output_type: vcf
+    id: save_contacts
+    heading: 'Save these contacts'
+    contact_ids:
+      - clerk
+      - self_help
+      - legal_aid
+
+  - kind: info
+    id: after_order
+    heading: 'After the judge signs your Order'
+    body: |
+      Ask the clerk for at least three certified copies of your Order — each one
+      needs the Confidential Information Form attached.
+
+      Then update your records in this order, because each step verifies against
+      the one before it: Social Security Administration first, then the North
+      Dakota DMV, then your passport, then financial accounts, your employer and
+      health insurance, your home title, and voter registration.
+
+  - kind: output
+    output_type: summary
+    id: recap
+    heading: 'Summary of what you entered'

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -1,29 +1,31 @@
-# Demo corpus — Adult Name Change (North Dakota), standard track.
+# Demo corpus — Adult Name Change (North Dakota), WAIVER track.
 #
-# Content is drawn from public ND sources already assembled in this repo: the
-# ND court prompt (litigant_portal/prompts/courts/north-dakota/prompt.md), the
-# adult-name-change topic prompt, and docs/nd-name-change-planning-log.md —
-# which were sourced from ndcourts.gov/legal-self-help/name-change-adult.
+# The waiver track applies when changing the first and/or middle name only,
+# leaving the last name unchanged: 4 forms (no Notice of Petition), and the
+# judge MAY waive newspaper publication and the 30-day wait. The court links to
+# this flow directly for first/middle-only changes; last-name changes use the
+# standard track — adult-name-change-standard.yml.
 #
-# This models the STANDARD track (any change involving the last name:
-# publication + 30-day wait). The engine renders sections statically, so the
-# waiver track (first/middle only) is described in-line rather than branched.
-# Real but unverified contact details (clerk phone, legal-aid phone, form PDF
-# links) are intentionally omitted pending a primary-source pass — see #495.
-# Not yet legal-reviewed; #509 seeds it to make the flow clickable.
+# Because publication and the wait can be waived, this flow has no fixed date
+# deadline (hence no calendar export) — it shows how a shorter track renders.
+#
+# Content drawn from public ND sources already in the repo (the ND court/topic
+# prompts + name-change planning log, sourced from ndcourts.gov). Unverified
+# contact specifics (phone numbers, form-PDF links) are omitted pending a
+# primary-source pass (#495). Not yet legal-reviewed; #509 seeds it.
 
 metadata:
   court: north-dakota
   topic: adult-name-change
-  role: petitioner
-  title: 'Adult Name Change — North Dakota'
+  role: waiver
+  title: 'Adult Name Change — North Dakota (Waiver Track)'
 
 contacts:
   - id: clerk
     name: 'Burleigh County Clerk of District Court'
     url: 'https://www.ndcourts.gov'
     address: '514 East Thayer Avenue, Bismarck, ND'
-    note: 'Call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge. This is the one call to make first.'
+    note: 'Call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge, and the waiver track does not remove this. This is the one call to make first.'
   - id: self_help
     name: 'North Dakota Legal Self Help Center'
     url: 'https://www.ndcourts.gov/legal-self-help'
@@ -32,29 +34,25 @@ contacts:
     name: 'Legal Services of North Dakota'
     note: 'Free legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter.'
 
-deadlines:
-  - id: publication_wait
-    label: '30-day publication waiting period ends'
-    offset_days: 30
-    offset_from: publication_date
-    description: 'Under North Dakota law the judge may not consider your petition until 30 days after the notice is published. After this date, check with the clerk about judge review.'
-
 sections:
   - kind: info
     id: overview
-    heading: 'Changing your name in North Dakota'
+    heading: 'Changing your first or middle name in North Dakota'
     body: |
       This walks you through a standalone adult name-change petition in North
-      Dakota district court. A common mix-up: if you wanted your name restored in
-      a divorce, that has to be requested inside the divorce case — it is not
-      handled here. If your divorce is final and didn't change your name, a
-      standalone petition (this flow) is the way.
+      Dakota district court, on the waiver track — for changing your first
+      and/or middle name only, leaving your last name unchanged.
 
-      North Dakota has two paths. This page covers the standard track — any
-      change that includes your last name, which requires publishing a notice
-      and a 30-day wait. If you are changing only your first and/or middle name,
-      a judge may waive publication and the wait; ask the clerk about the waiver
-      track.
+      On this track a judge may waive the newspaper publication requirement, and
+      if publication is waived there is no 30-day waiting period. The waiver is
+      the judge's decision on the facts you present — it is not guaranteed, so
+      plan for the possibility that publication is still required.
+
+      If you are changing your last name (or any combination that includes it),
+      use the standard-track page instead.
+
+      One common mix-up: if you wanted your name changed as part of a divorce,
+      that has to be requested inside the divorce case — it is not handled here.
 
       Official guidance and forms: ndcourts.gov/legal-self-help/name-change-adult
 
@@ -79,34 +77,34 @@ sections:
       - id: requested_name
         label: 'The name you are requesting'
         type: text
-      - id: what_changing
-        label: 'What are you changing?'
-        type: choice
-        choices:
-          - 'First name only'
-          - 'Middle name only'
-          - 'First and middle name'
-          - 'Last name (or any change including the last name)'
-        help_text: 'Changing the last name puts you on the standard track (publication + 30-day wait). First/middle only may qualify for the waiver track.'
+        help_text: 'On this track, your last name stays the same.'
       - id: filing_county
         label: 'County where you will file'
         type: text
         help_text: 'You file in the district court for the county where you live.'
-      - id: publication_date
-        label: 'Date your notice was published'
-        type: date
-        help_text: 'Leave blank until your notice runs in the newspaper — then enter it here and your deadline updates. Found on the affidavit of publication from the paper.'
 
   - kind: output
     output_type: packet
     id: filing_packet
-    heading: 'Your filing packet (standard track)'
+    heading: 'Your filing packet'
     forms:
-      - 'Notice of Petition for Name Change'
       - 'Petition for Name Change'
       - 'Declaration in Support of Petition'
       - 'Confidential Information Form'
       - 'Proposed Order for Name Change'
+
+  - kind: info
+    id: publication_waiver
+    heading: 'About the publication waiver'
+    body: |
+      Because you are not changing your last name, you can ask the judge to
+      waive the requirement to publish a notice in the newspaper. If the judge
+      grants the waiver, there is no 30-day waiting period and your petition can
+      be considered sooner.
+
+      The judge decides this on your particular facts, so it is not automatic.
+      Ask the clerk how your county handles the waiver request, and be ready in
+      case publication is still required.
 
   - kind: info
     id: form_gotchas
@@ -129,13 +127,6 @@ sections:
       North Dakota does not presumptively require a hearing for a name change,
       but the judge may decide one is needed. If a hearing is scheduled, the
       Clerk of District Court will send notice with the date, time, and location.
-
-  - kind: output
-    output_type: ics
-    id: deadlines_calendar
-    heading: 'Add your deadline to your calendar'
-    deadline_ids:
-      - publication_wait
 
   - kind: output
     output_type: vcf

--- a/litigant_portal/content/adult-name-change.yml
+++ b/litigant_portal/content/adult-name-change.yml
@@ -1,10 +1,16 @@
-# Demo corpus — Adult Name Change (North Dakota).
+# Demo corpus — Adult Name Change (North Dakota), standard track.
 #
-# Court-neutral stand-in seeded to make the Topic Flow engine clickable
-# end-to-end for stakeholder review (#509). Not the legal-reviewed ND content
-# (that is tracked separately in #495) — copy here is generic and illustrative.
-# No leading underscore, so the registry indexes it and it renders at
-# /t/north-dakota/adult-name-change/petitioner/.
+# Content is drawn from public ND sources already assembled in this repo: the
+# ND court prompt (litigant_portal/prompts/courts/north-dakota/prompt.md), the
+# adult-name-change topic prompt, and docs/nd-name-change-planning-log.md —
+# which were sourced from ndcourts.gov/legal-self-help/name-change-adult.
+#
+# This models the STANDARD track (any change involving the last name:
+# publication + 30-day wait). The engine renders sections statically, so the
+# waiver track (first/middle only) is described in-line rather than branched.
+# Real but unverified contact details (clerk phone, legal-aid phone, form PDF
+# links) are intentionally omitted pending a primary-source pass — see #495.
+# Not yet legal-reviewed; #509 seeds it to make the flow clickable.
 
 metadata:
   court: north-dakota
@@ -14,60 +20,122 @@ metadata:
 
 contacts:
   - id: clerk
-    name: 'District Court Clerk'
-    phone: '701-555-0100'
-    email: 'clerk@example.gov'
+    name: 'Burleigh County Clerk of District Court'
     url: 'https://www.ndcourts.gov'
-    address: '100 Courthouse Square, Bismarck, ND'
-    hours: 'Mon–Fri 8am–4pm'
-    note: 'Call before filing to confirm fees and how many copies to bring.'
+    address: '514 East Thayer Avenue, Bismarck, ND'
+    note: 'Call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge. This is the one call to make first.'
+  - id: self_help
+    name: 'North Dakota Legal Self Help Center'
+    url: 'https://www.ndcourts.gov/legal-self-help'
+    note: 'Court-provided guidance and the official name-change forms for self-represented filers.'
   - id: legal_aid
     name: 'Legal Services of North Dakota'
-    phone: '800-555-0111'
-    url: 'https://www.example.org'
-    note: 'Free help for those who qualify by income.'
+    note: 'Free legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter.'
 
 deadlines:
   - id: publication_wait
-    label: 'Publication period ends'
+    label: '30-day publication waiting period ends'
     offset_days: 30
     offset_from: publication_date
-    description: 'The court can act on your petition once the 30-day published notice period closes.'
-  - id: hearing_ready
-    label: 'Earliest you can request a hearing'
-    offset_days: 35
-    offset_from: publication_date
-    description: 'Allow a few days after the notice period closes before asking the clerk to set a hearing.'
+    description: 'Under North Dakota law the judge may not consider your petition until 30 days after the notice is published. After this date, check with the clerk about judge review.'
 
 sections:
   - kind: info
     id: overview
     heading: 'Changing your name in North Dakota'
     body: |
-      An adult name change is a standalone court petition. Read each step, enter
-      your publication date below, then use the tools at the bottom to put your
-      deadlines and the clerk's contact straight onto your phone.
+      This walks you through a standalone adult name-change petition in North
+      Dakota district court. A common mix-up: if you wanted your name restored in
+      a divorce, that has to be requested inside the divorce case — it is not
+      handled here. If your divorce is final and didn't change your name, a
+      standalone petition (this flow) is the way.
+
+      North Dakota has two paths. This page covers the standard track — any
+      change that includes your last name, which requires publishing a notice
+      and a 30-day wait. If you are changing only your first and/or middle name,
+      a judge may waive publication and the wait; ask the clerk about the waiver
+      track.
+
+      Official guidance and forms: ndcourts.gov/legal-self-help/name-change-adult
+
+  - kind: info
+    id: eligibility
+    heading: 'Who can file'
+    body: |
+      To petition for a name change in North Dakota you must be a U.S. citizen
+      or a U.S. permanent resident. You attest to this on the Petition.
+
+      A name change cannot be used to defraud anyone or to evade a legal
+      obligation (for example, debts or a criminal record). These are conditions
+      you confirm on the forms — not something you have to explain to anyone here.
 
   - kind: fact_gather
-    id: key_dates
+    id: your_details
     heading: 'Your details'
     questions:
-      - id: full_legal_name
+      - id: current_legal_name
         label: 'Your current legal name'
         type: text
+      - id: requested_name
+        label: 'The name you are requesting'
+        type: text
+      - id: what_changing
+        label: 'What are you changing?'
+        type: choice
+        choices:
+          - 'First name only'
+          - 'Middle name only'
+          - 'First and middle name'
+          - 'Last name (or any change including the last name)'
+        help_text: 'Changing the last name puts you on the standard track (publication + 30-day wait). First/middle only may qualify for the waiver track.'
+      - id: filing_county
+        label: 'County where you will file'
+        type: text
+        help_text: 'You file in the district court for the county where you live.'
       - id: publication_date
         label: 'Date your notice was published'
         type: date
-        required: true
-        help_text: 'Found on the affidavit of publication from the newspaper.'
+        help_text: 'Leave blank until your notice runs in the newspaper — then enter it here and your deadline updates. Found on the affidavit of publication from the paper.'
+
+  - kind: output
+    output_type: packet
+    id: filing_packet
+    heading: 'Your filing packet (standard track)'
+    forms:
+      - 'Notice of Petition for Name Change'
+      - 'Petition for Name Change'
+      - 'Declaration in Support of Petition'
+      - 'Confidential Information Form'
+      - 'Proposed Order for Name Change'
+
+  - kind: info
+    id: form_gotchas
+    heading: 'Before you sign'
+    body: |
+      A few North Dakota specifics that trip people up:
+
+      Leave the case number blank — the clerk assigns it when you file.
+
+      Do not sign the proposed Order. Only the judge signs that one.
+
+      The Confidential Information Form is sealed and stays out of the public
+      file. Keep copies — it must be attached to every certified copy of your
+      Order, or North Dakota Vital Records will reject your updates later.
+
+  - kind: info
+    id: hearing
+    heading: 'Will there be a hearing?'
+    body: |
+      North Dakota does not presumptively require a hearing for a name change,
+      but the judge may decide one is needed. If a hearing is scheduled, the
+      Clerk of District Court will send notice with the date, time, and location.
 
   - kind: output
     output_type: ics
     id: deadlines_calendar
-    heading: 'Add your deadlines to your calendar'
+    heading: 'Add your deadline to your calendar'
     deadline_ids:
       - publication_wait
-      - hearing_ready
 
   - kind: output
     output_type: vcf
@@ -75,15 +143,20 @@ sections:
     heading: 'Save these contacts'
     contact_ids:
       - clerk
+      - self_help
       - legal_aid
 
-  - kind: output
-    output_type: packet
-    id: filing_packet
-    heading: 'Your filing packet'
-    forms:
-      - 'Petition for Name Change'
-      - 'Confidential Information Form'
+  - kind: info
+    id: after_order
+    heading: 'After the judge signs your Order'
+    body: |
+      Ask the clerk for at least three certified copies of your Order — each one
+      needs the Confidential Information Form attached.
+
+      Then update your records in this order, because each step verifies against
+      the one before it: Social Security Administration first, then the North
+      Dakota DMV, then your passport, then financial accounts, your employer and
+      health insurance, your home title, and voter registration.
 
   - kind: output
     output_type: summary

--- a/litigant_portal/content/adult-name-change.yml
+++ b/litigant_portal/content/adult-name-change.yml
@@ -1,0 +1,91 @@
+# Demo corpus — Adult Name Change (North Dakota).
+#
+# Court-neutral stand-in seeded to make the Topic Flow engine clickable
+# end-to-end for stakeholder review (#509). Not the legal-reviewed ND content
+# (that is tracked separately in #495) — copy here is generic and illustrative.
+# No leading underscore, so the registry indexes it and it renders at
+# /t/north-dakota/adult-name-change/petitioner/.
+
+metadata:
+  court: north-dakota
+  topic: adult-name-change
+  role: petitioner
+  title: 'Adult Name Change — North Dakota'
+
+contacts:
+  - id: clerk
+    name: 'District Court Clerk'
+    phone: '701-555-0100'
+    email: 'clerk@example.gov'
+    url: 'https://www.ndcourts.gov'
+    address: '100 Courthouse Square, Bismarck, ND'
+    hours: 'Mon–Fri 8am–4pm'
+    note: 'Call before filing to confirm fees and how many copies to bring.'
+  - id: legal_aid
+    name: 'Legal Services of North Dakota'
+    phone: '800-555-0111'
+    url: 'https://www.example.org'
+    note: 'Free help for those who qualify by income.'
+
+deadlines:
+  - id: publication_wait
+    label: 'Publication period ends'
+    offset_days: 30
+    offset_from: publication_date
+    description: 'The court can act on your petition once the 30-day published notice period closes.'
+  - id: hearing_ready
+    label: 'Earliest you can request a hearing'
+    offset_days: 35
+    offset_from: publication_date
+    description: 'Allow a few days after the notice period closes before asking the clerk to set a hearing.'
+
+sections:
+  - kind: info
+    id: overview
+    heading: 'Changing your name in North Dakota'
+    body: |
+      An adult name change is a standalone court petition. Read each step, enter
+      your publication date below, then use the tools at the bottom to put your
+      deadlines and the clerk's contact straight onto your phone.
+
+  - kind: fact_gather
+    id: key_dates
+    heading: 'Your details'
+    questions:
+      - id: full_legal_name
+        label: 'Your current legal name'
+        type: text
+      - id: publication_date
+        label: 'Date your notice was published'
+        type: date
+        required: true
+        help_text: 'Found on the affidavit of publication from the newspaper.'
+
+  - kind: output
+    output_type: ics
+    id: deadlines_calendar
+    heading: 'Add your deadlines to your calendar'
+    deadline_ids:
+      - publication_wait
+      - hearing_ready
+
+  - kind: output
+    output_type: vcf
+    id: save_contacts
+    heading: 'Save these contacts'
+    contact_ids:
+      - clerk
+      - legal_aid
+
+  - kind: output
+    output_type: packet
+    id: filing_packet
+    heading: 'Your filing packet'
+    forms:
+      - 'Petition for Name Change'
+      - 'Confidential Information Form'
+
+  - kind: output
+    output_type: summary
+    id: recap
+    heading: 'Summary of what you entered'


### PR DESCRIPTION
## What

Seeds the North Dakota adult name-change demo flow as **registered corpora**, so the (non-AI) Topic Flow engine renders end-to-end and is reachable for stakeholder review. No engine code changes — this is content + entry points + a design-principle doc.

- **Two tracks as two corpora**, selected by distinct URLs (the engine doesn't branch internally — the fork lives at the entry point):
  - `…/adult-name-change/standard/` — any change including the last name: 5 forms, newspaper publication, 30-day wait, `.ics` deadline.
  - `…/adult-name-change/waiver/` — first/middle only: 4 forms (no Notice of Petition), judge may waive publication and the wait, so no fixed deadline.
- **Real, public-sourced content** drawn from the repo's ND court/topic prompts + planning log (sourced from `ndcourts.gov`): eligibility, the form gotchas, the background-check pre-filing blocker, real contacts (Burleigh clerk, ND Legal Self Help Center, Legal Services of ND), and the post-order records cascade.
- **Dev-menu demo links** (one per track), shown on dev/QA only.
- **`docs/ARCHITECTURE.md`**: documents the engine principle this demonstrates — non-AI flows are one linear corpus per `(court, topic, role)`, multi-path processes fork at the entry point, "linear" is section order (not a forward-only path).

## Demo

`https://qa.litigantportal.com/t/north-dakota/adult-name-change/standard/` (and `/waiver/`), or via the dev-menu demo links.

## Notes

- Content is **not yet legal-reviewed**; a few contact specifics (clerk/legal-aid phone numbers, form-PDF links) are intentionally omitted rather than fabricated, pending a primary-source pass tracked in #495.
- Validated via `CorpusLoader` + the `checks.py` startup guard; both track pages render 200 (verified through a real Django render).

Closes #509