### PR TITLE
feat(topic-flow): flow navigation UX — scroll-restore on Save + in-flow header TOC

### DIFF
--- a/litigant_portal/app/src/main.css
+++ b/litigant_portal/app/src/main.css
@@ -658,6 +658,18 @@
     @apply hover:border-primary-300 hover:shadow-sm transition-all;
   }
 
+  /* Topic Flow in-header table-of-contents (<details> disclosure).
+     Hide the native disclosure triangle so the summary reads as a plain
+     hamburger button; flex display handles Chrome/Firefox, the webkit rule
+     covers older iOS Safari. */
+  .topic-flow-toc > summary {
+    @apply list-none;
+  }
+
+  .topic-flow-toc > summary::-webkit-details-marker {
+    display: none;
+  }
+
   /* ==========================================================================
      PRINT STYLES — action plan document view
      ========================================================================== */

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -1,6 +1,6 @@
 {% load static i18n %}
 
-<c-vars sticky="" />
+<c-vars sticky="" toc="" />
 <header class="mobile-header flex-shrink-0 {% if sticky %}mobile-header-sticky{% endif %} {{ class }}"
         {{ attrs }}>
   <div class="mobile-header-inner">
@@ -11,7 +11,37 @@
     </a>
     <div class="flex items-center gap-1 sm:gap-2">
       <c-molecules.user-menu class="hidden sm:flex" />
-      {% if deployment_env != "prod" %}
+      {% if toc %}
+        {% trans "On this page" as toc_label %}
+        {% trans "Exit this guide" as exit_label %}
+        {# In-flow wayfinding: a native <details> disclosure so the TOC works #}
+        {# with JS off and exposes its open/closed state to assistive tech #}
+        {# without any aria wiring (WCAG 4.1.2). Replaces the dev-tools menu #}
+        {# while inside a flow — one control, in the consistent header slot. #}
+        <details class="topic-flow-toc relative">
+          <summary
+            class="flex items-center justify-center p-2 rounded-lg cursor-pointer hover:bg-greyscale-100 list-none"
+            aria-label="{{ toc_label }}"
+          >
+            <c-atoms.icon name="bars-3" class="w-6 h-6" />
+          </summary>
+          <nav
+            aria-label="{{ toc_label }}"
+            class="absolute right-0 mt-2 w-64 max-w-[90vw] bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
+          >
+            <p class="px-4 py-2 text-xs font-semibold text-greyscale-400">{{ toc_label }}</p>
+            {% for item in toc %}
+            <a href="#{{ item.anchor }}" class="block px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100">{{ item.heading }}</a>
+            {% endfor %}
+            <div class="border-t border-greyscale-200 mt-1">
+              <a href="{% url 'pages:home' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100">
+                <c-atoms.icon name="home" class="w-5 h-5 text-greyscale-500" />
+                {{ exit_label }}
+              </a>
+            </div>
+          </nav>
+        </details>
+      {% elif deployment_env != "prod" %}
         {% trans "Dev tools" as dev_tools_label %}
         <div x-data="devMenu" class="relative">
           <c-atoms.button type="button" variant="ghost" aria_label="{{ dev_tools_label }}" class="!p-2" x-on:click="toggle" x-bind:aria-expanded="open" aria-haspopup="true">

--- a/litigant_portal/app/templates/pages/topic_flow.html
+++ b/litigant_portal/app/templates/pages/topic_flow.html
@@ -6,6 +6,13 @@
   {{ corpus.metadata.title }} - {% trans "Litigant Portal" %}
 {% endblock title %}
 
+{# In a flow, the header menu becomes this flow's table of contents (+ Exit), #}
+{# so wayfinding lives in the consistent header slot instead of a jump-link #}
+{# wall above the content. #}
+{% block header %}
+  <c-organisms.header :toc="toc" />
+{% endblock header %}
+
 {% block content %}
 <div class="border-b border-greyscale-100 bg-primary-50 px-4 py-4">
   <p class="text-sm text-greyscale-500">
@@ -15,19 +22,6 @@
 </div>
 
 <div class="mx-auto max-w-3xl px-4 py-8">
-  {% trans "On this page" as toc_label %}
-  <nav aria-label="{{ toc_label }}" class="mb-8">
-    <ul class="space-y-1">
-      {% for section in rendered_sections %}
-      {% if section.heading %}
-      <li>
-        <c-atoms.link href="#{{ section.anchor_id }}">{{ section.heading }}</c-atoms.link>
-      </li>
-      {% endif %}
-      {% endfor %}
-    </ul>
-  </nav>
-
   {% for section in rendered_sections %}
   <section id="{{ section.anchor_id }}" class="mb-8 scroll-mt-4">
     {% if section.heading %}

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -382,7 +382,9 @@ def test_vcf_uses_the_vcf_template():
 
 def test_anchor_is_the_section_owning_the_submitted_ids():
     section = _fg([Question(id="pubdate", label="Date")], id="key_dates")
-    assert submitted_section_anchor(_corpus(section), {"pubdate"}) == "key_dates"
+    assert (
+        submitted_section_anchor(_corpus(section), {"pubdate"}) == "key_dates"
+    )
 
 
 def test_anchor_picks_the_form_that_was_submitted_not_just_the_first():

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -15,6 +15,7 @@ import pytest
 from litigant_portal.app.topic_flow.renderer import (
     RenderedSection,
     render_section,
+    submitted_section_anchor,
 )
 from litigant_portal.app.topic_flow.schema import (
     Contact,
@@ -371,3 +372,28 @@ def test_vcf_uses_the_vcf_template():
     corpus, vcf = _vcf_corpus()
     rendered = render_section(vcf, corpus, {})
     assert rendered.template.endswith("flow_section_vcf.html")
+
+
+# --- submitted_section_anchor (PRG scroll restore, #510) --------------------
+# The entry view redirects a saved form back to its section anchor so the
+# litigant keeps their place. The anchor is matched by submitted question-id
+# overlap, so the right section wins even with multiple fact_gather forms.
+
+
+def test_anchor_is_the_section_owning_the_submitted_ids():
+    section = _fg([Question(id="pubdate", label="Date")], id="key_dates")
+    assert submitted_section_anchor(_corpus(section), {"pubdate"}) == "key_dates"
+
+
+def test_anchor_picks_the_form_that_was_submitted_not_just_the_first():
+    dates = _fg([Question(id="pubdate", label="Date")], id="dates")
+    contact = _fg([Question(id="phone", label="Phone")], id="contact_info")
+    corpus = _corpus(dates, contact)
+    # Only the second form's field was posted → its anchor, not "dates".
+    assert submitted_section_anchor(corpus, {"phone"}) == "contact_info"
+
+
+def test_anchor_is_none_when_nothing_overlaps():
+    section = _fg([Question(id="pubdate", label="Date")], id="key_dates")
+    assert submitted_section_anchor(_corpus(section), {"unknown"}) is None
+    assert submitted_section_anchor(_corpus(section), set()) is None

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -274,7 +274,19 @@ def test_post_persists_answers_and_redirects_prg(client, monkeypatch):
         URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
     )
     assert response.status_code == 302
-    assert response["Location"] == URL
+    assert response["Location"].startswith(URL)
+
+
+@pytest.mark.django_db
+def test_post_redirects_to_the_saved_section_anchor(client, monkeypatch):
+    # Scroll restore (#510): the PRG lands on the fact_gather section's anchor,
+    # so saving returns the litigant to the form they were filling — and the
+    # deadlines that recompute just below it — not the top of the page.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
+    )
+    assert response["Location"] == f"{URL}#key_dates"
 
 
 @pytest.mark.django_db

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -118,6 +118,24 @@ def question_ids(corpus):
     return [question.id for question in _fact_gather_questions(corpus)]
 
 
+def submitted_section_anchor(corpus, submitted_ids):
+    """Anchor id of the fact_gather section a set of submitted answers came from.
+
+    The entry view redirects (PRG) back to this anchor so saving answers returns
+    the litigant to the form they were filling — and to the deadlines that
+    recompute just below it — rather than the top of the page. Matched on
+    question-id overlap, so it stays correct with multiple fact_gather sections;
+    returns ``None`` when nothing matches, leaving the redirect bare (page top).
+    """
+    submitted = set(submitted_ids)
+    for section in corpus.sections:
+        if isinstance(section, FactGatherSection) and any(
+            question.id in submitted for question in section.questions
+        ):
+            return section.id
+    return None
+
+
 def _answered_in_corpus_order(corpus, answers):
     """Yield ``{label, value}`` for answered questions, in corpus order."""
     for question in _fact_gather_questions(corpus):

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -278,10 +278,21 @@ def topic_flow(request, court, topic, role):
     rendered_sections = [
         render_section(section, corpus, answers) for section in corpus.sections
     ]
+    # Table of contents for the in-header wayfinding menu — one entry per
+    # headed section, so a litigant can jump back to re-read or revise.
+    toc = [
+        {"anchor": section.anchor_id, "heading": section.heading}
+        for section in rendered_sections
+        if section.heading
+    ]
     return render(
         request,
         "pages/topic_flow.html",
-        {"corpus": corpus, "rendered_sections": rendered_sections},
+        {
+            "corpus": corpus,
+            "rendered_sections": rendered_sections,
+            "toc": toc,
+        },
     )
 
 

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -20,6 +20,7 @@ from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
     question_ids,
     render_section,
+    submitted_section_anchor,
 )
 
 TOPICS = {
@@ -261,9 +262,17 @@ def topic_flow(request, court, topic, role):
             if qid in request.POST
         }
         store.update(submitted)
-        return redirect(
-            "pages:topic_flow", court=court, topic=topic, role=role
+        # PRG back to the section just saved (#anchor) so the litigant keeps
+        # their place and sees the recomputed deadlines, instead of the browser
+        # jumping to the top of the page on the redirected GET.
+        url = reverse(
+            "pages:topic_flow",
+            kwargs={"court": court, "topic": topic, "role": role},
         )
+        anchor = submitted_section_anchor(corpus, submitted)
+        if anchor:
+            url = f"{url}#{anchor}"
+        return redirect(url)
 
     answers = store.all()
     rendered_sections = [


### PR DESCRIPTION
## What

Flow navigation UX for the Topic Flow engine — two changes about *moving through and back within* a flow.

**Scroll-restore on Save (#510).** The `fact_gather` POST used Post-Redirect-Get but redirected to the bare URL, so every Save dropped the litigant at the top of the page. It now redirects to the anchor of the section they saved from, so they keep their place and see the recomputed deadlines just below. JS-off safe (reuses the section anchors the page already renders). New `renderer.submitted_section_anchor` matches the section by submitted question-id overlap — correct with multiple `fact_gather` sections.

**In-flow header table of contents (#511).** The "On this page" jump-link list rendered above all content — a wall that pushed the flow down on mobile. Inside a flow the header menu now *becomes* that flow's TOC plus an Exit link; the in-page wall is gone, and the dev-tools menu shows only off-flow (one control at a time). Built as a native `<details>`/`<summary>` disclosure (not Alpine):

- Works with JS off; the flow stays fully usable by scrolling regardless.
- Exposes open/closed state to assistive tech natively — WCAG 4.1.2 with no aria wiring. Also covers 2.5.1 (tap, no swipe), 2.5.8 (target size), 1.3.2 (DOM order = visual). Header is non-sticky, so after a jump the open panel scrolls away (focus not obscured, 2.4.11).
- CSS hides the disclosure triangle (flex for Chrome/Firefox, a webkit rule for older iOS Safari) — needs a Tailwind rebuild, which the Docker/QA build runs.

## Stacked PR

Targets `509-demo-corpus` (#512) — the TOC change builds on the same `header.html` block that PR's dev-menu links live in. **Retarget to `main` after #512 merges.**

## Test

- Both track pages render 200 with the TOC; off-flow pages keep the dev menu (verified via real Django render).
- `renderer.submitted_section_anchor` covered by fast-suite unit tests, **mutation-checked** (dropping the overlap match fails them). View test pins the `#anchor` in the redirect `Location`.

Fixes #510
Closes #511