### PR TITLE
feat(topic-flow): drop raw-slug breadcrumb on the flow page

### DIFF
--- a/litigant_portal/app/templates/pages/topic_flow.html
+++ b/litigant_portal/app/templates/pages/topic_flow.html
@@ -15,10 +15,7 @@
 
 {% block content %}
 <div class="border-b border-greyscale-100 bg-primary-50 px-4 py-4">
-  <p class="text-sm text-greyscale-500">
-    {{ corpus.metadata.court }} · {{ corpus.metadata.topic }} · {{ corpus.metadata.role }}
-  </p>
-  <h1 class="mt-1 text-xl font-bold text-greyscale-900">{{ corpus.metadata.title }}</h1>
+  <h1 class="text-xl font-bold text-greyscale-900">{{ corpus.metadata.title }}</h1>
 </div>
 
 <div class="mx-auto max-w-3xl px-4 py-8">


### PR DESCRIPTION
Removes the raw `court · topic · role` slug breadcrumb from the Topic Flow sub-header — it read like dev output to a litigant. The page title heading already carries the context.

Closes #517

Test plan: open a flow page (e.g. `/t/north-dakota/adult-name-change/standard/`) — the sub-header shows just the title, no slug line; the rest of the flow is unchanged.
