### PR TITLE
revert: S3 storage migration (#516)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,11 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Production Environment Variables
 ##############################################################################
 
-# Django config
-# ALLOWED_HOSTS=litigantportal.com
-# DEPLOYMENT_ENV=prod
-# SECRET_KEY=something-random
-
 # Domain for Caddy
-# DOMAIN=https://litigantportal.com
+# DOMAIN=https://yourdomain.com
+
+# Django allowed hosts — must include DOMAIN (comma-separated, no spaces)
+# ALLOWED_HOSTS=yourdomain.com
 
 # PostgreSQL connection details
 # POSTGRES_HOST=localhost
@@ -27,12 +25,3 @@ OPENAI_API_KEY=your-openai-api-key-here
 
 # Redis connection details
 # REDIS_URL=redis://localhost:6379/0
-
-# S3 object storage (static + public/private media)
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_S3_REGION_NAME=
-# AWS_S3_ENDPOINT_URL=
-# AWS_STORAGE_PUBLIC_BUCKET_NAME=
-# AWS_STORAGE_PRIVATE_BUCKET_NAME=
-# AWS_S3_CUSTOM_DOMAIN=storage.litigantportal.com

--- a/.gitignore
+++ b/.gitignore
@@ -45,12 +45,9 @@ tailwindcss
 # Tailwind CLI output (source is litigant_portal/app/src/main.css)
 litigant_portal/app/static/css/main.built.css
 
-# Django collectstatic output
+# Django collectstatic output (STATIC_ROOT → litigant_portal/app/staticfiles)
 litigant_portal/app/staticfiles
 /staticfiles/
-
-# Filesystem storage
-litigant_portal/app/media/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,13 +132,6 @@ services:
       - CHAT_ENABLED=${CHAT_ENABLED:-true}
       - CHAT_MODEL=${CHAT_MODEL:-openai/gpt-4o-mini}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME:-us-east-1}
-      - AWS_S3_ENDPOINT_URL=${AWS_S3_ENDPOINT_URL:-}
-      - AWS_S3_CUSTOM_DOMAIN=${AWS_S3_CUSTOM_DOMAIN:-}
-      - AWS_STORAGE_PUBLIC_BUCKET_NAME=${AWS_STORAGE_PUBLIC_BUCKET_NAME}
-      - AWS_STORAGE_PRIVATE_BUCKET_NAME=${AWS_STORAGE_PRIVATE_BUCKET_NAME}
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/health/']
       interval: 5s

--- a/litigant_portal/app/services/health.py
+++ b/litigant_portal/app/services/health.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.core.cache import cache
-from django.core.files.storage import storages
 from django.db import connection
 
 logger = logging.getLogger(__name__)
@@ -24,14 +23,4 @@ def check_redis() -> bool:
         return cache.get("healthcheck") == "ok"
     except Exception:
         logger.exception("Health check failed: Redis unavailable")
-        return False
-
-
-def check_storage(alias: str) -> bool:
-    """Return True if the named storage backend is reachable."""
-    try:
-        storages[alias].exists("healthcheck")
-        return True
-    except Exception:
-        logger.exception("Health check failed: %r storage unavailable", alias)
         return False

--- a/litigant_portal/app/tests/conftest.py
+++ b/litigant_portal/app/tests/conftest.py
@@ -10,19 +10,3 @@ def test_cache(settings):
         }
     }
     settings.RATELIMIT_ENABLE = False
-
-
-@pytest.fixture(autouse=True)
-def test_storage(settings):
-    """Use in-memory storage for tests."""
-    settings.STORAGES = {
-        "default": {
-            "BACKEND": "django.core.files.storage.InMemoryStorage",
-        },
-        "public": {
-            "BACKEND": "django.core.files.storage.InMemoryStorage",
-        },
-        "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-        },
-    }

--- a/litigant_portal/app/views/endpoints.py
+++ b/litigant_portal/app/views/endpoints.py
@@ -15,11 +15,7 @@ from litigant_portal.app.models import (
     TimelineEvent,
 )
 from litigant_portal.app.services.chat_service import ChatService
-from litigant_portal.app.services.health import (
-    check_database,
-    check_redis,
-    check_storage,
-)
+from litigant_portal.app.services.health import check_database, check_redis
 from litigant_portal.app.services.pdf_service import pdf_service
 from litigant_portal.app.services.search_service import search_service
 
@@ -30,8 +26,6 @@ def health(request: HttpRequest) -> JsonResponse:
     services = {
         "database": check_database(),
         "redis": check_redis(),
-        "storage_private": check_storage("default"),
-        "storage_public": check_storage("public"),
     }
     healthy = all(services.values())
     return JsonResponse(

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "csp.middleware.CSPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -155,68 +156,16 @@ STATIC_ROOT = BASE_DIR / "app" / "staticfiles"
 STATICFILES_DIRS = [
     BASE_DIR / "app" / "static",
 ]
-MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
-MEDIA_ROOT = BASE_DIR / "app" / "media"
 
-# Storage — local filesystem in dev/test, S3 in prod/QA.
-S3_CONNECTION = {
-    "access_key": os.environ.get("AWS_ACCESS_KEY_ID", ""),
-    "secret_key": os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
-    "region_name": os.environ.get("AWS_S3_REGION_NAME", "us-east-1"),
-    "endpoint_url": os.environ.get("AWS_S3_ENDPOINT_URL") or None,
-    "url_protocol": os.environ.get("AWS_S3_URL_PROTOCOL", "https:"),
-}
-AWS_STORAGE_PRIVATE_BUCKET_NAME = os.environ.get(
-    "AWS_STORAGE_PRIVATE_BUCKET_NAME", "litigant-portal-private"
-)
-AWS_STORAGE_PUBLIC_BUCKET_NAME = os.environ.get(
-    "AWS_STORAGE_PUBLIC_BUCKET_NAME", "litigant-portal-public"
-)
-AWS_S3_PUBLIC_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
-
-if DEBUG:
-    STORAGES = {
-        "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
-        "public": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
-        "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
-        },
-    }
-else:
+# Use ManifestStaticFilesStorage in production for cache busting
+# In development (DEBUG=True), Django uses the default storage
+if not DEBUG:
     STORAGES = {
         "default": {
-            "BACKEND": "storages.backends.s3.S3Storage",
-            "OPTIONS": {
-                **S3_CONNECTION,
-                "bucket_name": AWS_STORAGE_PRIVATE_BUCKET_NAME,
-                "default_acl": "private",
-                "querystring_auth": True,
-                "file_overwrite": False,
-                "location": "media",
-            },
-        },
-        "public": {
-            "BACKEND": "storages.backends.s3.S3Storage",
-            "OPTIONS": {
-                **S3_CONNECTION,
-                "bucket_name": AWS_STORAGE_PUBLIC_BUCKET_NAME,
-                "custom_domain": AWS_S3_PUBLIC_CUSTOM_DOMAIN,
-                "default_acl": "public-read",
-                "querystring_auth": False,
-                "file_overwrite": False,
-                "location": "media",
-            },
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
         },
         "staticfiles": {
-            "BACKEND": "storages.backends.s3.S3ManifestStaticStorage",
-            "OPTIONS": {
-                **S3_CONNECTION,
-                "bucket_name": AWS_STORAGE_PUBLIC_BUCKET_NAME,
-                "custom_domain": AWS_S3_PUBLIC_CUSTOM_DOMAIN,
-                "default_acl": "public-read",
-                "querystring_auth": False,
-                "location": "static",
-            },
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
         },
     }
 
@@ -250,23 +199,16 @@ if DEBUG:
 
 # Content Security Policy (django-csp)
 # https://django-csp.readthedocs.io/
-if AWS_S3_PUBLIC_CUSTOM_DOMAIN:
-    asset_host = AWS_S3_PUBLIC_CUSTOM_DOMAIN.split("/", 1)[0]
-    ASSET_ORIGINS = (f"{S3_CONNECTION['url_protocol']}//{asset_host}",)
-else:
-    ASSET_ORIGINS = ()
-
 CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", *ASSET_ORIGINS)
-CSP_STYLE_SRC = ("'self'", *ASSET_ORIGINS)
+CSP_SCRIPT_SRC = ("'self'",)  # Alpine.js served locally
+CSP_STYLE_SRC = ("'self'",)
 CSP_IMG_SRC = (
     "'self'",
     "data:",
     "blob:",
-    *ASSET_ORIGINS,
 )  # data: for inline, blob: for camera
-CSP_FONT_SRC = ("'self'", "data:", *ASSET_ORIGINS)
-CSP_CONNECT_SRC = ("'self'", *ASSET_ORIGINS)
+CSP_FONT_SRC = ("'self'", "data:")
+CSP_CONNECT_SRC = ("'self'",)
 # Alpine.js CSP build — no unsafe-eval needed
 
 # Default primary key field type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "django-csp>=3.8",
     "django-pydantic-field>=0.5.1",
     "gunicorn>=23.0",
+    "whitenoise[brotli]>=6.0",
     "heroicons>=2.0",
     # AI Chat
     "litellm>=1.50",
@@ -56,7 +57,6 @@ dependencies = [
     # PostgreSQL driver
     "psycopg[binary]>=3.2",
     "redis>=5.0",
-    "django-storages[s3]>=1.14",
     # Rate limiting
     "django-ratelimit>=4.1",
     # PDF text extraction

--- a/uv.lock
+++ b/uv.lock
@@ -153,31 +153,31 @@ wheels = [
 ]
 
 [[package]]
-name = "boto3"
-version = "1.43.27"
+name = "brotli"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/ad/32ac82224c571776d1119c8d2a5eafeab97bace3b4ed2870cb80d5cda140/boto3-1.43.27.tar.gz", hash = "sha256:dc0d1b47f391983d8b3047e49402d31f9aaa4d7b398d3b4ea986fe680cbea43a", size = 113143, upload-time = "2026-06-10T19:38:35.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1b/e423f7ed0177f0cc629f9bba39f505ad4a571b1f73c51402e6000bbf453b/boto3-1.43.27-py3-none-any.whl", hash = "sha256:b3eea072c2fdbbdd8c6161f912f603be10c8ec477625926dea8b91a0842a3482", size = 140538, upload-time = "2026-06-10T19:38:34.012Z" },
-]
-
-[[package]]
-name = "botocore"
-version = "1.43.27"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/4e/db50ef135f1d9ffc85e209a124004a5829d8f12f4a7a0afdf380cb19866d/botocore-1.43.27.tar.gz", hash = "sha256:2093c316c24214e50e18640b1869513b759bb8cc48b95b004a8306cb9f0d6703", size = 15504242, upload-time = "2026-06-10T19:38:25.389Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/46/05b227b34e434b54867c2c942b0bfbbe2fe41789c18bb15ef787d03e9a56/botocore-1.43.27-py3-none-any.whl", hash = "sha256:4976544e652d5a1d8eca135da019f8e1c2d749efa2f9a31a8fb8c76f1895a40b", size = 15190293, upload-time = "2026-06-10T19:38:22.298Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
 ]
 
 [[package]]
@@ -481,23 +481,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/8f/94038fe739b095aca3e4708ecc8a4e77f1fcfd87bed5d6baff43d4c80bc4/django-ratelimit-4.1.0.tar.gz", hash = "sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b", size = 11551, upload-time = "2023-07-24T20:34:32.374Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/78/2c59b30cd8bc8068d02349acb6aeed5c4e05eb01cdf2107ccd76f2e81487/django_ratelimit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92", size = 11608, upload-time = "2023-07-24T20:34:31.362Z" },
-]
-
-[[package]]
-name = "django-storages"
-version = "1.14.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/d6/2e50e378fff0408d558f36c4acffc090f9a641fd6e084af9e54d45307efa/django_storages-1.14.6.tar.gz", hash = "sha256:7a25ce8f4214f69ac9c7ce87e2603887f7ae99326c316bc8d2d75375e09341c9", size = 87587, upload-time = "2025-04-02T02:34:55.103Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/21/3cedee63417bc5553eed0c204be478071c9ab208e5e259e97287590194f1/django_storages-1.14.6-py3-none-any.whl", hash = "sha256:11b7b6200e1cb5ffcd9962bd3673a39c7d6a6109e8096f0e03d46fab3d3aabd9", size = 33095, upload-time = "2025-04-02T02:34:53.291Z" },
-]
-
-[package.optional-dependencies]
-s3 = [
-    { name = "boto3" },
 ]
 
 [[package]]
@@ -865,15 +848,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jmespath"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
-]
-
-[[package]]
 name = "jsbeautifier"
 version = "1.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1005,7 +979,6 @@ dependencies = [
     { name = "django-csp" },
     { name = "django-pydantic-field" },
     { name = "django-ratelimit" },
-    { name = "django-storages", extra = ["s3"] },
     { name = "gunicorn" },
     { name = "heroicons" },
     { name = "jsonschema" },
@@ -1018,6 +991,7 @@ dependencies = [
     { name = "redis" },
     { name = "requests" },
     { name = "vobject" },
+    { name = "whitenoise", extra = ["brotli"] },
 ]
 
 [package.optional-dependencies]
@@ -1045,7 +1019,6 @@ requires-dist = [
     { name = "django-csp", specifier = ">=3.8" },
     { name = "django-pydantic-field", specifier = ">=0.5.1" },
     { name = "django-ratelimit", specifier = ">=4.1" },
-    { name = "django-storages", extras = ["s3"], specifier = ">=1.14" },
     { name = "djlint", marker = "extra == 'dev'", specifier = ">=1.36.4" },
     { name = "gunicorn", specifier = ">=23.0" },
     { name = "heroicons", specifier = ">=2.0" },
@@ -1067,6 +1040,7 @@ requires-dist = [
     { name = "tox-uv", marker = "extra == 'dev'", specifier = ">=1.29.0" },
     { name = "tox-uv", marker = "extra == 'test'", specifier = ">=1.29.0" },
     { name = "vobject", specifier = ">=0.9.6.1" },
+    { name = "whitenoise", extras = ["brotli"], specifier = ">=6.0" },
 ]
 provides-extras = ["dev", "test"]
 
@@ -1984,18 +1958,6 @@ wheels = [
 ]
 
 [[package]]
-name = "s3transfer"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
-]
-
-[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2261,6 +2223,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d0/8a/15c34b3d27c43fc81a467d0f66577afc5542326804c42f30557e31c3259e/vobject-0.9.9.tar.gz", hash = "sha256:ac44e5d7e2079d84c1d52c50a615b9bec4b1ba958608c4c7fe40cbf33247b38e", size = 1208905, upload-time = "2024-12-16T07:29:39.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/20/6bba813bbd498c28edbbcf8253a6398cf4266ecf7bfa6129835c0a2bfbb1/vobject-0.9.9-py2.py3-none-any.whl", hash = "sha256:0fbdb982065cf4d1843a5d5950c88510041c6de026bda49c3502721de1c6ac3d", size = 47526, upload-time = "2024-12-16T07:31:08.493Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/2a/55b3f3a4ec326cd077c1c3defeee656b9298372a69229134d930151acd01/whitenoise-6.12.0.tar.gz", hash = "sha256:f723ebb76a112e98816ff80fcea0a6c9b8ecde835f8ddda25df7a30a3c2db6ad", size = 26841, upload-time = "2026-02-27T00:05:42.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/eb/d5583a11486211f3ebd4b385545ae787f32363d453c19fffd81106c9c138/whitenoise-6.12.0-py3-none-any.whl", hash = "sha256:fc5e8c572e33ebf24795b47b6a7da8da3c00cff2349f5b04c02f28d0cc5a3cc2", size = 20302, upload-time = "2026-02-27T00:05:40.086Z" },
+]
+
+[package.optional-dependencies]
+brotli = [
+    { name = "brotli" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts #516. With `DEBUG=False` the `STORAGES` backends are S3 (`S3ManifestStaticStorage` for staticfiles). The `web-prod` entrypoint runs `manage collectstatic --noinput --clear` at boot, which uploads to the S3 public bucket. QA has no AWS credentials or buckets configured, so collectstatic fails; the entrypoint runs under `set -e`, so `django-prod` exits(1) and the stack fails to start (QA down). whitenoise removal left no local static-serving fallback.

Restores local/whitenoise static serving so non-S3 environments boot. S3 to be re-landed once buckets and credentials are provisioned and wired into QA/prod.

Closes #522

Test plan:
- Deploy to QA (or run the prod profile with `DEBUG=False` and no AWS_* vars): `django-prod` starts, `collectstatic` completes locally, `/api/health/` returns 200.
