### PR TITLE
ci(cd): prune unused images before pull to stop QA disk fill

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,17 @@ jobs:
             # main — the deploy box holds no local edits.
             git fetch origin
             git reset --hard origin/main
+            # Reclaim disk BEFORE pulling. Each deploy pulls a fresh image and
+            # the superseded ones accumulate unbounded — the box hit 99% full /
+            # "no space left on device" mid-pull and QA went down (#521). The
+            # running stack's image is referenced by its container, so it's
+            # kept; only orphaned images are removed. Prune images only (not
+            # `system prune`): image accumulation is the whole problem, and
+            # `image prune` leaves stopped containers, networks, and build cache
+            # alone — smallest blast radius on a box compose fully manages.
+            # There's no build cache to reclaim here anyway (deploys pull, never
+            # build). Images carry no --volumes flag, so postgres data is safe.
+            docker image prune -af
             docker compose --profile prod pull
             docker compose --profile prod up -d --no-build
 


### PR DESCRIPTION
Each QA deploy pulls a fresh image but never prunes the superseded ones, so they accumulate until the box hits 99% disk and the deploy dies mid-layer-extraction (\`no space left on device\`) — the QA outage on 2026-06-11 (57 images, ~44 GB reclaimable). Adds \`docker system prune -af\` before the pull so disk stays bounded across deploys. Running-stack images are referenced and kept; no \`--volumes\`, so the postgres data volume is untouched.

Closes #521

Test plan: merge to \`main\` triggers the CD deploy; confirm the workflow runs the prune step, the deploy goes green, and QA stays up. Verify \`docker system df\` on the box shows reclaimed space.