### PR TITLE
fix(topic-flow): format deadline day portably, not strftime %-d

### DIFF
--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -8,12 +8,14 @@ handler renders its contact list (#473). An output_type with no registered
 handler is a code gap and fails fast.
 """
 
+from datetime import date
 from types import SimpleNamespace
 
 import pytest
 
 from litigant_portal.app.topic_flow.renderer import (
     RenderedSection,
+    _format_deadline_date,
     render_section,
     submitted_section_anchor,
 )
@@ -228,6 +230,23 @@ def test_ics_renders_computed_deadline_from_answer():
     # 30 days after 2026-02-01 = 2026-03-03 (Feb 2026 has 28 days).
     assert d["date_iso"] == "2026-03-03"
     assert "March 3, 2026" in d["date_display"]
+
+
+def test_format_deadline_date_single_digit_day_has_no_leading_zero():
+    # The display drops the leading zero on the day ("March 3", not "March 03")
+    # and must do so without strftime's %-d — a glibc/BSD extension that raises
+    # ValueError on platforms whose C library lacks it (Windows), which would
+    # crash deadline rendering for a partner self-hosting there (#526). Pinning
+    # the exact string guards both the no-leading-zero contract and a regression
+    # back to %d.
+    assert _format_deadline_date(date(2026, 3, 3)) == "Tuesday, March 3, 2026"
+
+
+def test_format_deadline_date_double_digit_day():
+    assert (
+        _format_deadline_date(date(2026, 12, 25))
+        == "Friday, December 25, 2026"
+    )
 
 
 def test_ics_deadline_pending_when_answer_missing():

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -166,9 +166,14 @@ def _render_packet(section, corpus, answers):
 def _format_deadline_date(value):
     """Human-readable deadline date, e.g. "Tuesday, March 3, 2026".
 
-    ``%-d`` drops the leading zero (POSIX; the app runs on Linux/macOS).
+    The day is interpolated as ``value.day`` rather than via strftime's ``%-d``.
+    ``%-d`` (no-leading-zero day) is a glibc/BSD extension, not standard C, so it
+    raises ``ValueError`` on platforms whose C library lacks it — notably Windows
+    — which would crash deadline rendering for a partner self-hosting LP there
+    (#526). Weekday/month stay on strftime: ``%A``/``%B`` are standard and
+    portable.
     """
-    return value.strftime("%A, %B %-d, %Y")
+    return f"{value.strftime('%A, %B')} {value.day}, {value.year}"
 
 
 def _deadline_display(resolved):


### PR DESCRIPTION
\`_format_deadline_date\` formatted the day with strftime \`%-d\`, a glibc/BSD extension that isn't standard C — it raises \`ValueError\` on platforms whose C library lacks it (notably Windows). LP is open source and a court partner can self-host their own instance, so a partner on a Windows host would have every flow page with a computed deadline 500 on render. An access-to-justice product must not bar access by chosen operating system.

Fix interpolates the day as \`value.day\` and keeps weekday/month on strftime (\`%A\`/\`%B\` are standard and portable). Output is byte-identical on POSIX ("Tuesday, March 3, 2026").

Closes #526

Test plan: two direct unit tests on \`_format_deadline_date\` pin the exact string for single- and double-digit days; the no-leading-zero assertion guards a regression back to \`%d\`. Verified the function output directly on macOS (unchanged from the old code). \`make pre-commit\` for the full run.