### PR TITLE
chore(docassemble): local-dev bench for authoring document-assembly interviews

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: help build css clean install migrate test test-v collectstatic lint fmt-check fmt \
        file-issue messages compilemessages docker-build docker-dev docker-prod docker-rebuild \
-	   docker-down docker-logs docker-shell docker-migrate docker-clean
+	   docker-down docker-logs docker-shell docker-migrate docker-clean \
+	   docassemble-up docassemble-down
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -106,3 +107,9 @@ docker-migrate: ## Run migrations in Docker
 
 docker-clean: ## Remove containers, volumes, and images
 	docker compose --profile dev --profile prod down -v --rmi local
+
+docassemble-up: ## Start the local-dev docassemble bench (http://localhost:8100)
+	docker compose -f docker-compose.docassemble.yml up -d
+
+docassemble-down: ## Stop the local-dev docassemble bench
+	docker compose -f docker-compose.docassemble.yml down

--- a/docker-compose.docassemble.yml
+++ b/docker-compose.docassemble.yml
@@ -1,0 +1,44 @@
+# Local-dev ONLY: a standalone docassemble instance for authoring and testing
+# the Topic Flow → docassemble document-assembly interviews.
+#
+# NOT production, and deliberately NOT wired into LP's dev/prod profiles —
+# docassemble is a ~20 GB all-in-one container (Postgres/Redis/RabbitMQ/Celery/
+# nginx under supervisor), so it's opt-in for anyone working on the handoff.
+# Real hosting waits for the infra-team move; this is just the local test bench.
+#
+# Config grounded in docassemble's docker docs (docassemble.org/docs/docker.html):
+#   - single jhpyle/docassemble container; nginx is internal on :80
+#   - LP's Caddy owns :80 locally, so map to :8100
+#   - DAHOSTNAME MUST include the non-standard port (localhost:8100)
+#   - websockets work locally with no extra port/env (only needed behind a proxy)
+#   - 600s stop grace for a DB-safe shutdown
+#
+# Bring up:   docker compose -f docker-compose.docassemble.yml up -d
+#             (first run pulls ~20 GB / takes a while)
+# Open:       http://localhost:8100
+# Default login: admin@admin.com / password  — change it immediately on first login
+# Tear down:  docker compose -f docker-compose.docassemble.yml down
+#             (named volumes below persist Playground work across down/up)
+
+services:
+  docassemble:
+    image: jhpyle/docassemble
+    container_name: docassemble-dev
+    ports:
+      - '8100:80'
+    environment:
+      DAHOSTNAME: 'localhost:8100'
+      USEHTTPS: 'false'
+      TIMEZONE: 'America/New_York'
+    stop_grace_period: 600s
+    restart: unless-stopped
+    volumes:
+      # Persist Playground projects + docassemble's auto-DB-backup across
+      # restarts so interview work survives `down`. docassemble restores from
+      # the backup dir on start. Verify persistence holds on the first down/up.
+      - docassemble_backup:/usr/share/docassemble/backup
+      - docassemble_files:/usr/share/docassemble/files
+
+volumes:
+  docassemble_backup:
+  docassemble_files:

--- a/docs/docassemble-local-dev.md
+++ b/docs/docassemble-local-dev.md
@@ -1,0 +1,67 @@
+# docassemble — local dev bench
+
+A standalone local docassemble instance for authoring and testing the Topic Flow
+→ document-assembly interviews. **Local dev only** — real hosting waits for the
+infra-team move. It is intentionally _not_ part of LP's `dev`/`prod` compose
+profiles: docassemble is a ~20 GB all-in-one container, so it's opt-in for anyone
+working on the handoff.
+
+Part of the docassemble handoff epic (under #123). Config grounded in
+[docassemble's docker docs](https://docassemble.org/docs/docker.html).
+
+## Run it
+
+```sh
+make docassemble-up      # docker compose -f docker-compose.docassemble.yml up -d
+# first run pulls ~20 GB — give it a few minutes, then watch logs:
+docker logs -f docassemble-dev
+```
+
+Open **http://localhost:8100** once the logs settle.
+
+- Default login: `admin@admin.com` / `password` — **change the email and password
+  immediately** (User List → Edit). docassemble ships with this well-known default.
+- Port is `8100` because LP's Caddy already owns `:80` in dev. `DAHOSTNAME` is set
+  to `localhost:8100` (the port must be included) so websockets and generated URLs
+  resolve. No separate websockets port is needed for local access.
+
+```sh
+make docassemble-down    # stop (named volumes persist Playground work across down/up)
+```
+
+## Extract a form's fillable fields (the immediate task)
+
+docassemble's Playground reads a fillable PDF's AcroForm field names and scaffolds
+the interview for you — no manual field hunting.
+
+1. Log in → **Playground**.
+2. **Utilities** (top menu) → "Get list of fields from a PDF or DOCX file".
+3. Upload the form PDF (start with the ND `Petition for Name Change`, confirmed
+   tab-fillable). docassemble lists every AcroForm field name and emits a starter
+   `fields:` block + a sample interview.
+4. Hand that field list back — it's the mapping target for the interview's
+   `attachment` block.
+
+## How the interview is structured
+
+`question`/`fields` blocks collect the data (reusing the Topic Flow corpus's data
+points — current name, requested name, county — plus per-form extras the Petition
+needs: residency-since date, citizenship, criminal-history flag, publication/waiver
+choice). An `attachment` block then maps each AcroForm field name to a value:
+
+```yaml
+mandatory: True
+attachment:
+  pdf template file: petition.pdf
+  fields:
+    - '<acroform field name>': ${ requested_full_name }
+    - '<acroform field name>': ${ filing_county }
+```
+
+## Notes
+
+- The current Petition (NC Pet/Rev. May 2024) still cites the repealed
+  § 14-07.1-01 for the domestic-violence waiver reason — interview copy and the
+  corpus content must reflect the corrected reference (tracked on #495).
+- Persistence: Playground work and the auto-DB-backup live on named volumes; if a
+  `down`/`up` ever loses state, verify the backup-restore on startup.


### PR DESCRIPTION
A local-dev-only docassemble bench for authoring and testing the Topic Flow → document-assembly interviews. Lets us extract a fillable form's AcroForm field names and scaffold the interview before any real hosting exists.

**What's here** (no app code — bench + docs only):
- `docker-compose.docassemble.yml` — standalone `jhpyle/docassemble` container on `:8100` (LP's Caddy owns `:80` in dev), `DAHOSTNAME=localhost:8100`, named volumes to persist Playground work across `down`/`up`.
- `make docassemble-up` / `make docassemble-down` targets.
- `docs/docassemble-local-dev.md` — run instructions, the field-extraction workflow, interview structure, and the security note to change the default `admin@admin.com` login on first run.

**Deliberately not** wired into LP's `dev`/`prod` profiles — docassemble is a ~20 GB all-in-one container, so it's opt-in for whoever's working the handoff. Real hosting waits for the infra-team move.

Draft: parking the bench so the work is visible and reviewable; not requesting merge yet.

Part of #123

Test plan: `make docassemble-up`, confirm http://localhost:8100 serves, log in, run Utilities → "Get list of fields from a PDF" against the ND Petition. `down`/`up` and confirm Playground state persists.
