### PR TITLE
Exempt user-story issues from the stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,8 +39,8 @@ jobs:
             like to continue this work.
 
           # Never mark these as stale
-          exempt-issue-labels: 'pinned,security,good first issue,blocked,user-story'
-          exempt-pr-labels: 'pinned,security,blocked'
+          exempt-issue-labels: 'pinned,security,good first issue,user story'
+          exempt-pr-labels: 'pinned,security'
 
           # Don't touch assigned issues (someone owns it)
           exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -39,7 +39,7 @@ jobs:
             like to continue this work.
 
           # Never mark these as stale
-          exempt-issue-labels: 'pinned,security,good first issue,blocked'
+          exempt-issue-labels: 'pinned,security,good first issue,blocked,user-story'
           exempt-pr-labels: 'pinned,security,blocked'
 
           # Don't touch assigned issues (someone owns it)

--- a/docs/issue-conventions.md
+++ b/docs/issue-conventions.md
@@ -73,16 +73,17 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 
 ### Workflow / state
 
-| Label              | Color     | Notes                                        |
-| ------------------ | --------- | -------------------------------------------- |
-| `duplicate`        | `#cfd3d7` | GH default — triage convenience              |
-| `good first issue` | `#7057ff` | GH default                                   |
-| `help wanted`      | `#008672` | GH default                                   |
-| `pinned`           | `#006b75` | Exempt from stale bot                        |
-| `question`         | `#d876e3` | GH default — further information requested   |
-| `research`         | `#06B6D4` | Investigation / learning, not code           |
-| `stale`            | `#ededed` | No activity for 90+ days                     |
-| `tech debt`        | `#D4C5F9` | Deferred cleanup, consolidation, refactoring |
+| Label              | Color     | Notes                                                        |
+| ------------------ | --------- | ------------------------------------------------------------ |
+| `duplicate`        | `#cfd3d7` | GH default — triage convenience                              |
+| `good first issue` | `#7057ff` | GH default                                                   |
+| `help wanted`      | `#008672` | GH default                                                   |
+| `pinned`           | `#006b75` | Exempt from stale bot                                        |
+| `question`         | `#d876e3` | GH default — further information requested                   |
+| `research`         | `#06B6D4` | Investigation / learning, not code                           |
+| `stale`            | `#ededed` | No activity for 90+ days                                     |
+| `tech debt`        | `#D4C5F9` | Deferred cleanup, consolidation, refactoring                 |
+| `user-story`       | `#0FB3A1` | Persona user story — living reference, exempt from stale bot |
 
 ## Conventions
 
@@ -103,3 +104,4 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 - 2026-05-20 — initial issue templates set up (bug-report, feature, task) + chooser config + qa-round URL fix. PRs #433 (qa) and #435 (main).
 - 2026-05-21 — templates tightened per QA feedback: `feature` renamed to `enhancement`; priority and size dropdowns removed from all templates; title prefixes dropped; `qa-round` converted from markdown to issue form; root `SECURITY.md` added for VDP routing. PR #436 (qa) + direct cherry-pick to main.
 - 2026-05-21 — label audit: 32 → 28 labels. Resolved color collisions (`security`, `research`, `a11y`); sizes unified to soft grey; deleted unused `blocked`, `invalid`, `wontfix`, `Chat Flow`. Created `task` label; renamed `QA` → `qa` (lowercase).
+- 2026-06-15 — added `user-story` label (`#0FB3A1`) and added it to the stale bot's exempt list, so persona stories under #22 don't auto-close. Applied to #26, #190, #191, #192, #311, #312.

--- a/docs/issue-conventions.md
+++ b/docs/issue-conventions.md
@@ -83,7 +83,7 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 | `research`         | `#06B6D4` | Investigation / learning, not code                           |
 | `stale`            | `#ededed` | No activity for 90+ days                                     |
 | `tech debt`        | `#D4C5F9` | Deferred cleanup, consolidation, refactoring                 |
-| `user-story`       | `#0FB3A1` | Persona user story — living reference, exempt from stale bot |
+| `user story`       | `#0FB3A1` | Persona user story — living reference, exempt from stale bot |
 
 ## Conventions
 
@@ -104,4 +104,5 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 - 2026-05-20 — initial issue templates set up (bug-report, feature, task) + chooser config + qa-round URL fix. PRs #433 (qa) and #435 (main).
 - 2026-05-21 — templates tightened per QA feedback: `feature` renamed to `enhancement`; priority and size dropdowns removed from all templates; title prefixes dropped; `qa-round` converted from markdown to issue form; root `SECURITY.md` added for VDP routing. PR #436 (qa) + direct cherry-pick to main.
 - 2026-05-21 — label audit: 32 → 28 labels. Resolved color collisions (`security`, `research`, `a11y`); sizes unified to soft grey; deleted unused `blocked`, `invalid`, `wontfix`, `Chat Flow`. Created `task` label; renamed `QA` → `qa` (lowercase).
-- 2026-06-15 — added `user-story` label (`#0FB3A1`) and added it to the stale bot's exempt list, so persona stories under #22 don't auto-close. Applied to #26, #190, #191, #192, #311, #312.
+- 2026-06-15 — added `user story` label (`#0FB3A1`) and added it to the stale bot's exempt list, so persona stories under #22 don't auto-close. Applied to #26, #190, #191, #192, #311, #312.
+- 2026-06-16 — dropped the dead `blocked` reference from `stale.yml` (label was deleted in the 2026-05-21 audit); renamed the new label `user-story` → `user story` to match the no-hyphens convention.


### PR DESCRIPTION
Add a `user-story` label to the stale workflow's exempt list so persona stories under #22 (living reference docs) don't auto-close. Sandra (#311) was closed because she was unassigned and unlabeled; the other stories survived only incidentally via `exempt-all-assignees`.

Documents the new label (`#0FB3A1`, grouped with `pinned` as a stale-exempt lifecycle label) in `issue-conventions.md`. The label is already created and applied to #26, #190, #191, #192, #311, #312 (all mapped under #22).

Closes #537

Test plan:
- The weekly stale workflow skips `user-story`-labeled issues (exempt list updated).
- `issue-conventions.md` reflects the new label + a dated history entry.