### PR TITLE
Structure name fields + document docassemble data contract

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,18 @@ Litigant Portal is open source, and a court partner can stand up their own hoste
 
 **In LP today.** The Topic Flow corpus is exactly this: `schema.py` (`extra="forbid"`) + the loader's id cross-reference checks + the `checks.py` startup guard _are_ the partner-facing contract. A conformant corpus flows through one validated path regardless of what authored it; a non-conformant one fails loudly at the boundary.
 
+### Topic Flow → docassemble handoff contract
+
+The `packet` output hands off to a [docassemble](https://docassemble.org) interview that fills the actual court forms. Two systems, two jobs, one contract — and a deliberate split of _which_ facts each side owns:
+
+- **Topic Flow owns** the light fact set it already needs for deadlines and the summary recap, named to match the interview's variables 1:1 so a future prefill is lossless (no ambiguous name-splitting). These `fact_gather` question ids are the contract:
+  `current_first` · `current_middle` · `current_last` · `requested_first` · `requested_middle` (· `requested_last`, standard track only — the waiver track leaves the last name unchanged) · `filing_county` · `publication_date`.
+- **The interview owns** the full document fact set Topic Flow never collects: residence street/city/zip, residency-since, citizenship, criminal history, publication newspaper, and any track-specific fields. Asking these in the AI-free flow would duplicate the interview and bloat a deliberately light surface.
+
+Names are collected as structured first / middle / last (not a single free-text field) precisely because the forms and the interview are structured that way — splitting a combined name string back apart is lossy and ambiguous.
+
+**v1 is link-out + manual return, no prefill** (#543): the flow links out to the interview, the litigant completes and downloads their packet there, then returns to LP for filing steps. The prefill seam — POSTing this answer set to start a prefilled session, keeping PII out of the URL — is the deferred v2 (#531), and an AI-free session-state "Briefcase" (#177) is the natural carrier for it. The contract above is what makes that future drop-in: same ids, no rework.
+
 ---
 
 ## Topic Flow: Linear Structure, Forks at the Entry Point

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -73,12 +73,30 @@ sections:
     id: your_details
     heading: 'Your details'
     questions:
-      - id: current_legal_name
-        label: 'Your current legal name'
+      - id: current_first
+        label: 'Your current first name'
         type: text
-      - id: requested_name
-        label: 'The name you are requesting'
+        required: true
+      - id: current_middle
+        label: 'Your current middle name(s)'
         type: text
+        help_text: 'Leave blank if you have none.'
+      - id: current_last
+        label: 'Your current last name'
+        type: text
+        required: true
+      - id: requested_first
+        label: 'Requested first name'
+        type: text
+        required: true
+      - id: requested_middle
+        label: 'Requested middle name(s)'
+        type: text
+        help_text: 'Leave blank if you have none.'
+      - id: requested_last
+        label: 'Requested last name'
+        type: text
+        required: true
       - id: filing_county
         label: 'County where you will file'
         type: text

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -71,13 +71,26 @@ sections:
     id: your_details
     heading: 'Your details'
     questions:
-      - id: current_legal_name
-        label: 'Your current legal name'
+      - id: current_first
+        label: 'Your current first name'
         type: text
-      - id: requested_name
-        label: 'The name you are requesting'
+        required: true
+      - id: current_middle
+        label: 'Your current middle name(s)'
         type: text
-        help_text: 'On this track, your last name stays the same.'
+        help_text: 'Leave blank if you have none.'
+      - id: current_last
+        label: 'Your current last name'
+        type: text
+        required: true
+      - id: requested_first
+        label: 'Requested first name'
+        type: text
+        required: true
+      - id: requested_middle
+        label: 'Requested middle name(s)'
+        type: text
+        help_text: 'Your last name stays the same on this track — only first and middle change.'
       - id: filing_county
         label: 'County where you will file'
         type: text


### PR DESCRIPTION
Replaces the single free-text `current_legal_name` / `requested_name` questions in the ND adult-name-change corpora with structured first / middle / last questions, named 1:1 with the docassemble interview variables so a future prefill is lossless. Documents the Topic Flow → docassemble handoff contract in `ARCHITECTURE.md` (who owns which facts, why names are structured).

Closes #542.

Test plan: corpora validate through the loader (the path `checks.py` runs); no engine code changed.