### PR TITLE
feat(topic-flow): docassemble interview link-out on packet output

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@ Litigant Portal is open source, and a court partner can stand up their own hoste
 
 ### Topic Flow → docassemble handoff contract
 
-The `packet` output hands off to a [docassemble](https://docassemble.org) interview that fills the actual court forms. Two systems, two jobs, one contract — and a deliberate split of *which* facts each side owns:
+The `packet` output hands off to a [docassemble](https://docassemble.org) interview that fills the actual court forms. Two systems, two jobs, one contract — and a deliberate split of _which_ facts each side owns:
 
 - **Topic Flow owns** the light fact set it already needs for deadlines and the summary recap, named to match the interview's variables 1:1 so a future prefill is lossless (no ambiguous name-splitting). These `fact_gather` question ids are the contract:
   `current_first` · `current_middle` · `current_last` · `requested_first` · `requested_middle` (· `requested_last`, standard track only — the waiver track leaves the last name unchanged) · `filing_county` · `publication_date`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,18 @@ Litigant Portal is open source, and a court partner can stand up their own hoste
 
 **In LP today.** The Topic Flow corpus is exactly this: `schema.py` (`extra="forbid"`) + the loader's id cross-reference checks + the `checks.py` startup guard _are_ the partner-facing contract. A conformant corpus flows through one validated path regardless of what authored it; a non-conformant one fails loudly at the boundary.
 
+### Topic Flow → docassemble handoff contract
+
+The `packet` output hands off to a [docassemble](https://docassemble.org) interview that fills the actual court forms. Two systems, two jobs, one contract — and a deliberate split of *which* facts each side owns:
+
+- **Topic Flow owns** the light fact set it already needs for deadlines and the summary recap, named to match the interview's variables 1:1 so a future prefill is lossless (no ambiguous name-splitting). These `fact_gather` question ids are the contract:
+  `current_first` · `current_middle` · `current_last` · `requested_first` · `requested_middle` (· `requested_last`, standard track only — the waiver track leaves the last name unchanged) · `filing_county` · `publication_date`.
+- **The interview owns** the full document fact set Topic Flow never collects: residence street/city/zip, residency-since, citizenship, criminal history, publication newspaper, and any track-specific fields. Asking these in the AI-free flow would duplicate the interview and bloat a deliberately light surface.
+
+Names are collected as structured first / middle / last (not a single free-text field) precisely because the forms and the interview are structured that way — splitting a combined name string back apart is lossy and ambiguous.
+
+**v1 is link-out + manual return, no prefill** (#543): the flow links out to the interview, the litigant completes and downloads their packet there, then returns to LP for filing steps. The prefill seam — POSTing this answer set to start a prefilled session, keeping PII out of the URL — is the deferred v2 (#531), and an AI-free session-state "Briefcase" (#177) is the natural carrier for it. The contract above is what makes that future drop-in: same ids, no rework.
+
 ---
 
 ## Topic Flow: Linear Structure, Forks at the Entry Point

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
@@ -1,6 +1,29 @@
-{# Packet section body: the forms the corpus says this flow needs. #}
+{% load i18n %}
+
+{# Packet section body: the forms the corpus says this flow needs. When the #}
+{# corpus sets interview_url, a warm link-out to a docassemble interview that #}
+{# fills these forms (v1: link-out + manual return, no prefill — #543). Unset #}
+{# => plain form list, so existing corpora are unaffected. #}
 <ul class="list-disc space-y-1 pl-5 text-greyscale-700">
   {% for form in ctx.forms %}
   <li>{{ form }}</li>
   {% endfor %}
 </ul>
+
+{% if ctx.interview_url %}
+<div class="mt-4 space-y-3">
+  <c-atoms.button
+    href="{{ ctx.interview_url }}"
+    variant="primary"
+    target="_blank"
+    rel="noopener"
+  >
+    <c-atoms.icon name="pencil-square" class="w-4 h-4" />
+    {% trans "Fill out your forms" %}
+    <span class="sr-only">{% trans "(opens in a new tab)" %}</span>
+  </c-atoms.button>
+  <p class="text-sm text-greyscale-700">
+    {% trans "Save your completed packet somewhere easy to find. You'll need to print and sign these forms and bring them with you to court (or mail them in, depending on your court's process)." %}
+  </p>
+</div>
+{% endif %}

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -172,6 +172,36 @@ def test_packet_renders_form_list():
     assert rendered.context["forms"] == ["Petition for Name Change", "Order"]
 
 
+def test_packet_without_interview_url_exposes_none():
+    """No interview_url → context carries None, so the template shows no
+    handoff button. Existing packet corpora are unaffected."""
+    section = PacketOutput(
+        kind="output",
+        output_type="packet",
+        id="forms",
+        heading="Your packet",
+        forms=["Petition for Name Change"],
+    )
+    rendered = render_section(section, _corpus(section), {})
+    assert rendered.context["interview_url"] is None
+
+
+def test_packet_with_interview_url_exposes_it_for_the_button():
+    """interview_url reaches the template context verbatim — that's what drives
+    the 'Fill out your forms' link-out (#543)."""
+    url = "https://da.example/interview?i=docassemble.playground"
+    section = PacketOutput(
+        kind="output",
+        output_type="packet",
+        id="forms",
+        heading="Your packet",
+        forms=["Petition for Name Change"],
+        interview_url=url,
+    )
+    rendered = render_section(section, _corpus(section), {})
+    assert rendered.context["interview_url"] == url
+
+
 # --- dispatch ---------------------------------------------------------------
 
 

--- a/litigant_portal/app/tests/test_topic_flow_schema.py
+++ b/litigant_portal/app/tests/test_topic_flow_schema.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from litigant_portal.app.topic_flow.schema import Corpus
+from litigant_portal.app.topic_flow.schema import Corpus, PacketOutput
 
 FIXTURE = Path(__file__).resolve().parents[2] / "content" / "_test_fixture.yml"
 
@@ -91,3 +91,24 @@ def test_optional_lists_and_question_defaults():
     question = corpus.sections[0].questions[0]
     assert question.type == "text"
     assert question.required is False
+
+
+def test_packet_interview_url_optional_and_accepted():
+    """interview_url defaults to None — the link-out is graceful when an author
+    omits it, so existing packet corpora are unaffected — and is carried through
+    when provided (the #543 docassemble handoff seam)."""
+    base = {
+        "kind": "output",
+        "output_type": "packet",
+        "id": "p",
+        "heading": "Your packet",
+        "forms": ["Petition for Name Change"],
+    }
+    assert PacketOutput.model_validate(base).interview_url is None
+    url = "https://da.example/interview?i=docassemble.playground"
+    assert (
+        PacketOutput.model_validate(
+            {**base, "interview_url": url}
+        ).interview_url
+        == url
+    )

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -159,7 +159,10 @@ def _render_packet(section, corpus, answers):
         anchor_id=section.id,
         heading=section.heading,
         template=f"{_TEMPLATE_DIR}/flow_section_packet.html",
-        context={"forms": list(section.forms)},
+        context={
+            "forms": list(section.forms),
+            "interview_url": section.interview_url,
+        },
     )
 
 

--- a/litigant_portal/app/topic_flow/schema.py
+++ b/litigant_portal/app/topic_flow/schema.py
@@ -107,6 +107,10 @@ class PacketOutput(_Base):
     id: Slug
     heading: str = Field(min_length=1)
     forms: list[str] = Field(min_length=1)
+    # Optional warm handoff to a docassemble interview that fills these forms.
+    # Unset (None) => the packet renders as a plain form list, so existing
+    # corpora are unaffected. v1 is link-out + manual return, no prefill (#543).
+    interview_url: str | None = None
 
 
 class SummaryOutput(_Base):

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -73,12 +73,30 @@ sections:
     id: your_details
     heading: 'Your details'
     questions:
-      - id: current_legal_name
-        label: 'Your current legal name'
+      - id: current_first
+        label: 'Your current first name'
         type: text
-      - id: requested_name
-        label: 'The name you are requesting'
+        required: true
+      - id: current_middle
+        label: 'Your current middle name(s)'
         type: text
+        help_text: 'Leave blank if you have none.'
+      - id: current_last
+        label: 'Your current last name'
+        type: text
+        required: true
+      - id: requested_first
+        label: 'Requested first name'
+        type: text
+        required: true
+      - id: requested_middle
+        label: 'Requested middle name(s)'
+        type: text
+        help_text: 'Leave blank if you have none.'
+      - id: requested_last
+        label: 'Requested last name'
+        type: text
+        required: true
       - id: filing_county
         label: 'County where you will file'
         type: text

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -71,13 +71,26 @@ sections:
     id: your_details
     heading: 'Your details'
     questions:
-      - id: current_legal_name
-        label: 'Your current legal name'
+      - id: current_first
+        label: 'Your current first name'
         type: text
-      - id: requested_name
-        label: 'The name you are requesting'
+        required: true
+      - id: current_middle
+        label: 'Your current middle name(s)'
         type: text
-        help_text: 'On this track, your last name stays the same.'
+        help_text: 'Leave blank if you have none.'
+      - id: current_last
+        label: 'Your current last name'
+        type: text
+        required: true
+      - id: requested_first
+        label: 'Requested first name'
+        type: text
+        required: true
+      - id: requested_middle
+        label: 'Requested middle name(s)'
+        type: text
+        help_text: 'Your last name stays the same on this track — only first and middle change.'
       - id: filing_county
         label: 'County where you will file'
         type: text


### PR DESCRIPTION
Optional `interview_url` on `PacketOutput` — when set, the packet renders a "Fill out your forms" button opening a docassemble interview in a new tab (`rel="noopener"` + sr-only new-tab cue); unset renders the plain form list, so existing corpora are unaffected. Handoff v1: link-out + manual return, no prefill. Corpora intentionally leave it unset until a hosted instance exists (a localhost bench URL would render a dead button on QA).

Closes #543.

Stacked on #546 — review/merge that first; this PR's base retargets to main on merge.

Test plan: 3 RED-first tests (schema default/accept, renderer pass-through); 114 pure-logic tests green. View-level coverage tracked as tech debt (#544).