### PR TITLE
Partner/QA ops: reboot durability + one-command update tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build css clean install migrate test test-v collectstatic lint fmt-check fmt \
        file-issue messages compilemessages docker-build docker-dev docker-prod docker-rebuild \
 	   docker-down docker-logs docker-shell docker-migrate docker-clean \
-	   docassemble-up docassemble-down
+	   docassemble-up docassemble-down update health
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -113,3 +113,9 @@ docassemble-up: ## Start the local-dev docassemble bench (http://localhost:8100)
 
 docassemble-down: ## Stop the local-dev docassemble bench
 	docker compose -f docker-compose.docassemble.yml down
+
+update: ## Update a hosted box: pull code+images, recreate, health (ARGS=... e.g. --docassemble)
+	./scripts/update.sh $(ARGS)
+
+health: ## Health/validation summary for a hosted box (no changes)
+	./scripts/update.sh health $(ARGS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,10 @@ services:
   postgres-prod:
     image: pgvector/pgvector:pg17
     profiles: ['prod']
+    # Reboot/crash durability for the always-on QA/prod box. unless-stopped (not
+    # always) so a deliberate `compose down` stays down. Dev services omit this
+    # on purpose — a laptop shouldn't resurrect the full stack on every boot.
+    restart: unless-stopped
     environment:
       - POSTGRES_DB=litigant_portal
       - POSTGRES_USER=postgres
@@ -70,6 +74,7 @@ services:
   redis-prod:
     image: redis:7-alpine
     profiles: ['prod']
+    restart: unless-stopped
     command: redis-server --save "" --appendonly no
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
@@ -117,6 +122,7 @@ services:
       context: .
       dockerfile: docker/django/Dockerfile
     profiles: ['prod']
+    restart: unless-stopped
     command: web-prod
     environment:
       - DEBUG=false
@@ -163,6 +169,7 @@ services:
   caddy-prod:
     image: caddy:2-alpine
     profiles: ['prod']
+    restart: unless-stopped
     ports:
       - '80:80'
       - '443:443'

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,66 @@
+# Updating a hosted Litigant Portal box
+
+For self-hosters and court-partner IT: how to pull the latest fixes. **One
+command**, no need to remember the compose syntax.
+
+> **Updates are opt-in.** A normal restart or server reboot keeps your current
+> versions — it reuses the images already on the box (the `restart: unless-stopped`
+> policy). You only move to newer code when you run the update below.
+
+## The one command
+
+From the project directory (e.g. `/opt/litigant-portal`):
+
+```bash
+make update                 # or: ./scripts/update.sh
+```
+
+That runs the whole sequence and prints a health summary at the end:
+
+1. **code** — `git pull` (latest compose, Caddy config, scripts).
+2. **images** — pull the latest container images for the service(s).
+3. **restart** — recreate the service(s). Brief interruption; the Django app
+   applies any new database migrations automatically on start.
+4. **health** — checks each service and prints a ✓/✗ summary, e.g.:
+
+   ```
+   ── status ─────────────────────────────────
+   litigant portal  200 ✓
+   docassemble      200 ✓
+   ───────────────────────────────────────────
+   ✓ all selected services healthy
+   ```
+
+## Update just one service
+
+```bash
+make update ARGS=--django         # only the Litigant Portal app
+make update ARGS=--docassemble    # only the docassemble interview
+```
+
+`--all` (the default) updates both — docassemble only if this box actually hosts it.
+
+## Run any single step on its own
+
+Each step is its own command, so you can do just the part you need:
+
+```bash
+./scripts/update.sh health        # check status, change nothing
+make health                       # same, via make
+./scripts/update.sh code          # git pull only
+./scripts/update.sh pull          # pull new images only
+./scripts/update.sh restart       # recreate the service(s) only
+./scripts/update.sh --help        # full usage
+```
+
+Add `--no-code` to skip the `git pull` during a full `update` (e.g. when you've
+already pulled).
+
+## If something looks wrong
+
+- The health summary shows the HTTP code per service; `---` means it didn't
+  respond. Re-run `./scripts/update.sh health` after a minute (docassemble takes
+  a bit to boot).
+- Container-level detail: `docker compose --profile prod ps` and
+  `docker compose --profile prod logs -f <service>`.
+- docassemble specifics (path routing, WebSocket): `docs/docassemble-qa-hosting.md`.

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -49,7 +49,9 @@ for arg in "$@"; do
 		--docassemble) MODE="docassemble" ;;
 		--no-code) PULL_CODE=false ;;
 		-h | --help)
-			sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+			# Print the leading comment block (after the shebang) as usage —
+			# stops at the first non-comment line, so it can't leak script body.
+			awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"
 			exit 0
 			;;
 		*)
@@ -62,7 +64,11 @@ done
 # ── what to act on ───────────────────────────────────────────────────────────
 DA_OVERRIDE="docker-compose.docassemble.qa.yml"
 
-da_running() { docker ps --format '{{.Names}}' | grep -qx 'docassemble-qa'; }
+# "Does this box host docassemble?" — its container exists in ANY state. Uses
+# `docker ps -a` (not just running), so `--all` still updates a docassemble
+# that's currently down (crash, OOM, prior stop) — the recovery case the script
+# exists for. A box that never ran it has no such container, so it's skipped.
+da_present() { docker ps -a --format '{{.Names}}' | grep -qx 'docassemble-qa'; }
 
 WANT_DJANGO=false
 WANT_DA=false
@@ -71,7 +77,7 @@ case "$MODE" in
 	docassemble) WANT_DA=true ;;
 	all)
 		WANT_DJANGO=true
-		if da_running; then WANT_DA=true; fi
+		if da_present; then WANT_DA=true; fi
 		;;
 esac
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# Litigant Portal — update tool for a self-hosted / partner box (#551).
+#
+# One command instead of the multi-file compose incantation. Pulls latest code +
+# images, recreates the selected service(s), and reports health.
+#
+# OPT-IN updates only: a normal restart or reboot never changes versions — that's
+# the `restart: unless-stopped` policy reusing the existing images (#548). Run
+# this when you actually want the latest fixes.
+#
+# Usage:
+#   scripts/update.sh [command] [--all | --django | --docassemble] [--no-code]
+#
+# Commands — run the whole flow, or any single step on its own:
+#   update    (default)  code → images → recreate → health
+#   code                 git pull only
+#   pull                 pull new images only
+#   restart              recreate the service(s) only (Django auto-migrates on boot)
+#   health               health / validation summary only
+#
+# Service selector (default --all):
+#   --django             only the Litigant Portal app
+#   --docassemble        only the docassemble interview
+#   --all                both (docassemble only if it's actually hosted here)
+#   --no-code            skip `git pull` during `update`
+#
+# Examples:
+#   scripts/update.sh                      # update everything
+#   scripts/update.sh --docassemble        # update just docassemble
+#   scripts/update.sh health               # check health, change nothing
+#   scripts/update.sh restart --django     # restart just the app
+
+set -euo pipefail
+
+# Run from the repo root regardless of where it's invoked.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── args ─────────────────────────────────────────────────────────────────────
+COMMAND="update"
+MODE="all"
+PULL_CODE=true
+
+for arg in "$@"; do
+	case "$arg" in
+		update | code | pull | restart | health) COMMAND="$arg" ;;
+		--all) MODE="all" ;;
+		--django) MODE="django" ;;
+		--docassemble) MODE="docassemble" ;;
+		--no-code) PULL_CODE=false ;;
+		-h | --help)
+			sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+			exit 0
+			;;
+		*)
+			echo "Unknown argument: $arg (try --help)" >&2
+			exit 2
+			;;
+	esac
+done
+
+# ── what to act on ───────────────────────────────────────────────────────────
+DA_OVERRIDE="docker-compose.docassemble.qa.yml"
+
+da_running() { docker ps --format '{{.Names}}' | grep -qx 'docassemble-qa'; }
+
+WANT_DJANGO=false
+WANT_DA=false
+case "$MODE" in
+	django) WANT_DJANGO=true ;;
+	docassemble) WANT_DA=true ;;
+	all)
+		WANT_DJANGO=true
+		if da_running; then WANT_DA=true; fi
+		;;
+esac
+
+if $WANT_DA && [[ ! -f "$DA_OVERRIDE" ]]; then
+	echo "✗ docassemble selected but $DA_OVERRIDE is missing — this box doesn't host docassemble." >&2
+	exit 1
+fi
+
+# Compose invocation: base always; docassemble override only when in scope, so a
+# Django-only box never accidentally starts docassemble.
+COMPOSE_FILES=(-f docker-compose.yml)
+if $WANT_DA; then COMPOSE_FILES+=(-f "$DA_OVERRIDE"); fi
+DC=(docker compose "${COMPOSE_FILES[@]}" --profile prod)
+
+SERVICES=()
+$WANT_DJANGO && SERVICES+=(django-prod)
+$WANT_DA && SERVICES+=(docassemble)
+
+# ── steps ────────────────────────────────────────────────────────────────────
+step() { printf '\n\033[1m▶ %s\033[0m\n' "$1"; }
+
+do_code() {
+	step "Pulling latest code (git)"
+	git pull --ff-only
+}
+
+do_pull() {
+	step "Pulling latest images: ${SERVICES[*]}"
+	"${DC[@]}" pull "${SERVICES[@]}"
+}
+
+do_restart() {
+	for svc in "${SERVICES[@]}"; do
+		step "Restarting $svc — this briefly interrupts it…"
+		"${DC[@]}" up -d "$svc"
+	done
+	# Django's entrypoint runs migrate + collectstatic on every start, so a
+	# recreate already applies any new migrations — no separate step needed.
+}
+
+# Health: hit each service's own endpoint from inside its container, so the check
+# needs no host networking and works the same on every box.
+http_status() { # service, url
+	"${DC[@]}" exec -T "$1" curl -fsS -o /dev/null -w '%{http_code}' "$2" 2>/dev/null || echo "---"
+}
+
+do_health() {
+	step "Health / validation"
+	printf '\n  ── status ─────────────────────────────────\n'
+	local ok=true code
+	if $WANT_DJANGO; then
+		code=$(http_status django-prod http://localhost:8000/api/health/)
+		_report "litigant portal" "$code" || ok=false
+	fi
+	if $WANT_DA; then
+		code=$(http_status docassemble http://localhost/interview/)
+		_report "docassemble    " "$code" || ok=false
+	fi
+	printf '  ───────────────────────────────────────────\n'
+	if $ok; then
+		printf '  \033[32m✓ all selected services healthy\033[0m\n\n'
+	else
+		printf '  \033[31m✗ one or more services unhealthy — check the codes above\033[0m\n\n' >&2
+		return 1
+	fi
+}
+
+_report() { # label, code  → 0 if 2xx/3xx
+	local label="$1" code="$2"
+	if [[ "$code" =~ ^[23][0-9][0-9]$ ]]; then
+		printf '  %s  \033[32m%s ✓\033[0m\n' "$label" "$code"
+	else
+		printf '  %s  \033[31m%s ✗\033[0m\n' "$label" "$code"
+		return 1
+	fi
+}
+
+# ── dispatch ─────────────────────────────────────────────────────────────────
+case "$COMMAND" in
+	update)
+		$PULL_CODE && do_code
+		do_pull
+		do_restart
+		do_health
+		;;
+	code) do_code ;;
+	pull) do_pull ;;
+	restart) do_restart ;;
+	health) do_health ;;
+esac


### PR DESCRIPTION
Two halves of the same partner/QA ops lifecycle:

1. **Reboot durability** — `restart: unless-stopped` on the four prod services, so a droplet reboot brings the LP stack back on its own. Today nothing restarts the containers after a reboot (a resize today left QA down until a manual `compose up`). Dev profile left untouched.
2. **One-command updates** — `scripts/update.sh` (+ `make update` / `make health`): pull code + images → recreate → health summary, or any single step (`code`/`pull`/`restart`/`health`) on its own, with `--django` / `--docassemble` / `--all`. Opt-in by design — a reboot never auto-updates (reuses existing images); this is the explicit path to new fixes.

Closes #548. Closes #551.

Test plan: restart policy applies live via `docker update --restart unless-stopped` (and on next deploy); update script is syntax-checked and `--help` renders — first real run is the docassemble update on QA.