### PR TITLE
feat(infra): docassemble at /interview/ over HTTPS (path-routed)

### DIFF
--- a/docker-compose.docassemble.qa.yml
+++ b/docker-compose.docassemble.qa.yml
@@ -10,8 +10,9 @@
 # routes /interview/* to docassemble under the existing LP hostname. Base-compose
 # -only deploys (prod) see none of this.
 #
-# Prereqs: DA_DOMAIN in .env = the existing LP host (e.g. qa.litigantportal.com) —
-# NO new DNS record, the interview lives at <host>/interview/. QA at >=4GB RAM
+# Prereqs: DA_HOSTNAME in .env = the existing LP host as a BARE hostname, e.g.
+# `qa.litigantportal.com` — NO scheme (unlike DOMAIN, which is `https://...`),
+# and no new DNS record; the interview lives at <host>/interview/. QA at >=4GB RAM
 # (docassemble idles ~2GB). NOT the local authoring bench — that's still
 # docker-compose.docassemble.yml (localhost:8100). See docs/docassemble-qa-hosting.md.
 
@@ -22,14 +23,15 @@ services:
     profiles: ['prod']
     restart: unless-stopped
     environment:
-      # Served under the LP hostname at /interview/ — DA_DOMAIN is the existing
-      # LP host (e.g. qa.litigantportal.com), NOT a new subdomain, so no extra
-      # DNS. POSTURLROOT mounts docassemble at the /interview/ prefix (it
-      # regenerates its nginx for it). TLS is terminated by Caddy; docassemble
-      # serves plain HTTP and trusts the proxy (BEHINDHTTPSLOADBALANCER) so it
-      # builds https URLs + secure cookies. Env names verified against
-      # jhpyle/docassemble Docker/initialize.sh.
-      DAHOSTNAME: ${DA_DOMAIN}
+      # Served under the LP hostname at /interview/. DA_HOSTNAME is the existing
+      # LP host as a BARE hostname (e.g. qa.litigantportal.com) — NOT a subdomain,
+      # and NOT scheme-prefixed like DOMAIN; docassemble's DAHOSTNAME must be a
+      # bare host or it builds https://https://… URLs. POSTURLROOT mounts
+      # docassemble at the /interview/ prefix (it regenerates its nginx for it).
+      # TLS is terminated by Caddy; docassemble serves plain HTTP and trusts the
+      # proxy (BEHINDHTTPSLOADBALANCER) so it still builds https URLs + secure
+      # cookies. Env names verified against jhpyle/docassemble Docker/initialize.sh.
+      DAHOSTNAME: ${DA_HOSTNAME}
       POSTURLROOT: '/interview/'
       USEHTTPS: 'false'
       BEHINDHTTPSLOADBALANCER: 'true'

--- a/docker-compose.docassemble.qa.yml
+++ b/docker-compose.docassemble.qa.yml
@@ -1,0 +1,55 @@
+# QA hosting for docassemble, behind the LP Caddy over HTTPS (#550).
+#
+# Layered ON TOP of the base compose so prod is untouched:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml \
+#     --profile prod up -d
+#
+# This adds the `docassemble` service to the LP project network (so caddy-prod
+# reaches it as `docassemble:80`) and mounts the conf.d block into caddy, which
+# routes /interview/* to docassemble under the existing LP hostname. Base-compose
+# -only deploys (prod) see none of this.
+#
+# Prereqs: DA_DOMAIN in .env = the existing LP host (e.g. qa.litigantportal.com) —
+# NO new DNS record, the interview lives at <host>/interview/. QA at >=4GB RAM
+# (docassemble idles ~2GB). NOT the local authoring bench — that's still
+# docker-compose.docassemble.yml (localhost:8100). See docs/docassemble-qa-hosting.md.
+
+services:
+  docassemble:
+    image: jhpyle/docassemble
+    container_name: docassemble-qa
+    profiles: ['prod']
+    restart: unless-stopped
+    environment:
+      # Served under the LP hostname at /interview/ — DA_DOMAIN is the existing
+      # LP host (e.g. qa.litigantportal.com), NOT a new subdomain, so no extra
+      # DNS. POSTURLROOT mounts docassemble at the /interview/ prefix (it
+      # regenerates its nginx for it). TLS is terminated by Caddy; docassemble
+      # serves plain HTTP and trusts the proxy (BEHINDHTTPSLOADBALANCER) so it
+      # builds https URLs + secure cookies. Env names verified against
+      # jhpyle/docassemble Docker/initialize.sh.
+      DAHOSTNAME: ${DA_DOMAIN}
+      POSTURLROOT: '/interview/'
+      USEHTTPS: 'false'
+      BEHINDHTTPSLOADBALANCER: 'true'
+      TIMEZONE: 'America/New_York'
+    # Internal only — Caddy reaches it on the project network. No public port,
+    # so there's no unencrypted docassemble exposed (unlike the :8100 bench).
+    expose:
+      - '80'
+    stop_grace_period: 600s
+    volumes:
+      - docassemble_qa_backup:/usr/share/docassemble/backup
+      - docassemble_qa_files:/usr/share/docassemble/files
+
+  # Additive: mount the optional site-block dir into the existing caddy-prod so
+  # its `import conf.d/*.caddy` picks up the docassemble subdomain. Base volumes
+  # are preserved (compose merges volume lists).
+  caddy-prod:
+    volumes:
+      - ./docker/caddy/conf.d:/etc/caddy/conf.d:ro
+
+volumes:
+  docassemble_qa_backup:
+  docassemble_qa_files:

--- a/docker/caddy/Caddyfile.prod
+++ b/docker/caddy/Caddyfile.prod
@@ -1,5 +1,18 @@
 {$DOMAIN} {
-	reverse_proxy django-prod:8000
+	# Add-on services route UNDER this one hostname (e.g. the docassemble
+	# interview at /interview/*) rather than on their own subdomains — so a court
+	# partner needs just one CNAME for their whole portal, and it's portable +
+	# self-hostable. See ARCHITECTURE.md → Open Contracts. The conf.d dir is
+	# mounted into caddy only by the docassemble override, so prod loads nothing
+	# here; an empty glob is a no-op. Imported first so its path matchers win
+	# over the catch-all below.
+	import /etc/caddy/conf.d/*.caddy
+
+	# Everything else is the Litigant Portal app.
+	handle {
+		reverse_proxy django-prod:8000
+	}
+
 	log {
 		output stdout
 	}

--- a/docker/caddy/conf.d/docassemble.caddy
+++ b/docker/caddy/conf.d/docassemble.caddy
@@ -1,0 +1,13 @@
+# docassemble interview, routed UNDER the LP hostname at /interview/* (#550) —
+# not a subdomain, so a court partner needs only their existing one CNAME for the
+# whole portal (see ARCHITECTURE.md → Open Contracts / low-friction partners).
+#
+# Imported into the main {$DOMAIN} site block by the docassemble override only,
+# so prod is untouched. docassemble is told its URL root is /interview/ via
+# POSTURLROOT (it regenerates its internal nginx for the prefix), and Caddy
+# passes the prefix straight through. reverse_proxy transparently upgrades the
+# interview's WebSocket. Caddy terminates TLS; docassemble runs with
+# BEHINDHTTPSLOADBALANCER=true so it still builds https URLs + secure cookies.
+handle /interview/* {
+	reverse_proxy docassemble:80
+}

--- a/docker/caddy/conf.d/docassemble.caddy
+++ b/docker/caddy/conf.d/docassemble.caddy
@@ -8,6 +8,10 @@
 # passes the prefix straight through. reverse_proxy transparently upgrades the
 # interview's WebSocket. Caddy terminates TLS; docassemble runs with
 # BEHINDHTTPSLOADBALANCER=true so it still builds https URLs + secure cookies.
+# Bare /interview (no trailing slash) wouldn't match /interview/* and would fall
+# through to the LP app as a 404; 308 preserves method/body for any POST.
+redir /interview /interview/ 308
+
 handle /interview/* {
 	reverse_proxy docassemble:80
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@ Democratize access to justice by empowering self-represented litigants with AI-a
 - Mobile-first (users on older phones)
 - Human-centered AI (augments, not replaces)
 - Open contracts (producer-agnostic, validated at the boundary)
+- Low-friction for partners — the deploying court is a client too, and needs "easy mode" as much as the litigant does. Minimize what a partner must operate: one hostname (one CNAME), services routed by path not subdomain, portable across partners and self-hostable. A `.gov` DNS change is a ticket and a wait; design so they rarely need one.
 
 ---
 
@@ -21,6 +22,12 @@ Litigant Portal is open source, and a court partner can stand up their own hoste
 **Example — A2J Document Assembly Tool (DAT).** The DAT expects three inputs: a base PDF, a key/value answer set, and an overlay `.json` mapping each answer to coordinates on the PDF (where each value renders to "fill it in"). Those files can come from the A2J Viewer's guided-interview flow _or_ be POSTed straight to the API endpoint with Postman — either path returns an assembled PDF. The tool depends on the contract (the three file formats), never on how they were produced.
 
 **In LP today.** The Topic Flow corpus is exactly this: `schema.py` (`extra="forbid"`) + the loader's id cross-reference checks + the `checks.py` startup guard _are_ the partner-facing contract. A conformant corpus flows through one validated path regardless of what authored it; a non-conformant one fails loudly at the boundary.
+
+### One hostname, path-routed services
+
+A court partner gives us **one CNAME** (`portal.theircourt.gov`) and _everything_ runs under it — the LP app at `/`, add-on services by path. We do **not** put add-ons on their own subdomains, because each subdomain is another DNS record a court's IT has to create and maintain, and partner DNS friction is real (a `.gov` change is a ticket, not a self-serve edit). Path-routing keeps a partner's deployment to a single record, makes it portable across partners, and means an open-source self-hoster does nothing extra.
+
+Concretely: the docassemble document-assembly handoff is served at `<host>/interview/` (not `interview.<host>`), reverse-proxied by Caddy to the docassemble container, with docassemble told its URL root via `POSTURLROOT` (#550). We pay the sub-path complexity once, at our layer; every partner and self-hoster gets the simple deployment. New add-on services should follow the same rule — claim a path, never require a new hostname.
 
 ### Topic Flow → docassemble handoff contract
 

--- a/docs/docassemble-qa-hosting.md
+++ b/docs/docassemble-qa-hosting.md
@@ -1,0 +1,105 @@
+# docassemble on QA over HTTPS
+
+How to host the docassemble interview at `https://<lp-host>/interview/` (e.g.
+`https://qa.litigantportal.com/interview/`) so the Topic Flow link-out is clean
+for court-partner demos. Infra side of #531 (branding is #549).
+
+> **Path, not subdomain — on purpose.** docassemble routes _under_ the existing
+> LP hostname at `/interview/`, so a court partner needs only their one existing
+> CNAME for the whole portal — no per-service DNS, portable between partners,
+> self-hostable. Low-friction-for-partners is a guiding principle
+> (ARCHITECTURE.md → Open Contracts).
+>
+> This is **QA hosting**, not the local authoring bench. The bench
+> (`docker-compose.docassemble.yml`, `localhost:8100`) is unchanged — keep using
+> it to author/test interviews. See `docassemble/nd-name-change/README.md`.
+
+## How it works
+
+A QA-only compose override (`docker-compose.docassemble.qa.yml`) layers on the
+base compose. It adds a `docassemble` service to the LP project network so
+**caddy-prod reaches it as `docassemble:80`** — no public port (unlike the bench's
+`:8100`). docassemble is mounted at the `/interview/` prefix via `POSTURLROOT`
+(it regenerates its internal nginx for the sub-path); Caddy passes the prefix
+through. Caddy terminates TLS and forwards plain HTTP; docassemble runs with
+`BEHINDHTTPSLOADBALANCER=true` so it still builds `https://` URLs and secure
+cookies.
+
+The route lives in `docker/caddy/conf.d/docassemble.caddy` as a `handle
+/interview/*` block, pulled into the main `{$DOMAIN}` site by `import
+conf.d/*.caddy`. The override mounts `conf.d` into caddy **only on QA**, so a
+base-only (prod) deploy loads none of it — the glob matches nothing.
+
+**No new certificate.** Because `/interview/` is on the _existing_ LP hostname,
+Caddy already serves TLS for it — there's no extra ACME/DNS challenge.
+
+## Prerequisites
+
+- **QA at ≥ 4 GB RAM.** docassemble idles ~2 GB; co-tenant with the LP stack needs
+  the 4 GB tier (#534). At 2 GB it OOMs.
+- **No new DNS.** Uses the existing host record (`qa.litigantportal.com` already
+  resolves to the droplet).
+- **`DA_DOMAIN`** in the QA `.env` = the existing LP host, e.g.
+  `DA_DOMAIN=qa.litigantportal.com` (docassemble needs its own hostname for URL
+  building; same value as the Caddy site).
+
+## Deploy
+
+On `lp-qa`, from `/opt/litigant-portal`:
+
+```bash
+# Stop the local-bench container first if it's still running (frees :8100, avoids
+# two docassemble instances):
+docker rm -f docassemble-dev 2>/dev/null || true
+
+# Bring up LP + docassemble together, behind Caddy:
+docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml \
+  --profile prod up -d
+```
+
+First boot pulls the image and inits docassemble's own DB — give it **5–10 min**.
+Then verify:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml \
+  --profile prod ps                                       # docassemble + LP all up
+curl -sI https://qa.litigantportal.com/interview/ | head -1   # 200 / 302 into docassemble
+curl -sI https://qa.litigantportal.com/ | head -1             # LP root still 200
+docker stats --no-stream                                  # docassemble ~2 GB, LP healthy
+```
+
+## After it's up
+
+- **Load the interview** — upload the interviews + `petition.pdf` to this
+  instance's Playground (same steps as the bench README), or publish them as a
+  package for a clean anonymous URL.
+- **Branding** — apply the LP look + download-only + anonymous config (#549).
+- **Set the corpus `interview_url`** to `https://qa.litigantportal.com/interview/...`
+  so the Topic Flow "Fill out your forms" button goes live (#543 seam).
+
+## Reboot durability
+
+The service is `restart: unless-stopped`, so a reboot brings it back (pairs with
+#548 for the LP stack). A cold boot starts LP + docassemble together on 2 vCPUs,
+so there's a brief window where docassemble's init competes for CPU — LP recovers
+once it settles.
+
+## Troubleshooting
+
+- **The interview loads but live updates hang** → the WebSocket isn't threading
+  the `/interview/` prefix. This is the main thing to verify in path mode: confirm
+  `POSTURLROOT=/interview/` took (check docassemble's logs/nginx) and that Caddy's
+  `reverse_proxy docassemble:80` is upgrading the socket. **Test this first.**
+- **Assets/links 404 under `/interview/`** → `POSTURLROOT` not applied; recreate
+  the container so `initialize.sh` regenerates nginx with the prefix.
+- **Bare `/interview` (no trailing slash) misses** → `handle /interview/*` matches
+  the trailing-slash form; add a redirect if needed.
+- **Caddy won't start** → `DA_DOMAIN` unset while the override is active. Set it in
+  `.env`. (Base-only/prod deploys don't mount `conf.d`, so they're unaffected.)
+
+## Prod safety
+
+Production deploys (`docker compose -f docker-compose.yml --profile prod up -d`,
+no override) load **none** of this — no docassemble service, no `conf.d` mount, no
+`/interview/` route. docassemble's real production home rides the CL infra move
+(#461); this is the interim QA demo host.

--- a/docs/docassemble-qa-hosting.md
+++ b/docs/docassemble-qa-hosting.md
@@ -39,9 +39,11 @@ Caddy already serves TLS for it — there's no extra ACME/DNS challenge.
   the 4 GB tier (#534). At 2 GB it OOMs.
 - **No new DNS.** Uses the existing host record (`qa.litigantportal.com` already
   resolves to the droplet).
-- **`DA_DOMAIN`** in the QA `.env` = the existing LP host, e.g.
-  `DA_DOMAIN=qa.litigantportal.com` (docassemble needs its own hostname for URL
-  building; same value as the Caddy site).
+- **`DA_HOSTNAME`** in the QA `.env` = the existing LP host as a **bare hostname**,
+  e.g. `DA_HOSTNAME=qa.litigantportal.com`. docassemble needs its own hostname for
+  URL building. ⚠️ Unlike `DOMAIN` (which is `https://qa.litigantportal.com`),
+  `DA_HOSTNAME` has **no scheme** — a `https://` prefix makes docassemble build
+  `https://https://…` URLs and breaks secure cookies.
 
 ## Deploy
 
@@ -92,10 +94,13 @@ once it settles.
   `reverse_proxy docassemble:80` is upgrading the socket. **Test this first.**
 - **Assets/links 404 under `/interview/`** → `POSTURLROOT` not applied; recreate
   the container so `initialize.sh` regenerates nginx with the prefix.
-- **Bare `/interview` (no trailing slash) misses** → `handle /interview/*` matches
-  the trailing-slash form; add a redirect if needed.
-- **Caddy won't start** → `DA_DOMAIN` unset while the override is active. Set it in
-  `.env`. (Base-only/prod deploys don't mount `conf.d`, so they're unaffected.)
+- **Bare `/interview` (no trailing slash)** → redirected to `/interview/` with a
+  308 (in `conf.d/docassemble.caddy`), so hand-typed/trailing-slash-stripped URLs
+  still land.
+- **docassemble fails to initialize / builds wrong URLs** → `DA_HOSTNAME` unset (or
+  scheme-prefixed) while the override is active. Compose substitutes an empty
+  string with a warning — Caddy still starts (it uses `DOMAIN`, not `DA_HOSTNAME`),
+  but docassemble runs with no hostname. Set a bare host in `.env`.
 
 ## Prod safety
 


### PR DESCRIPTION
Serve docassemble at `https://<lp-host>/interview/` so the Topic Flow link-out is a clean, partner-friendly URL — routed **under the existing hostname** (one CNAME for the whole portal), not a subdomain.

- QA-only compose override adds docassemble to the LP network (no public port); Caddy `handle /interview/*` → docassemble; `POSTURLROOT=/interview/`; behind-proxy env (`USEHTTPS=false`, `BEHINDHTTPSLOADBALANCER=true`) verified against jhpyle/docassemble source.
- Prod untouched — override-only `conf.d` mount + empty-glob import.
- Codifies the **'low-friction for partners / one hostname, path-routed services'** guiding principle in ARCHITECTURE.md.
- Runbook: `docs/docassemble-qa-hosting.md`.

Part of #550 — closes once deployed + verified on QA (set `DA_DOMAIN`, deploy the override, test the `/interview/` WebSocket).

Test plan: compose merge verified with `docker compose config` (service + behind-proxy env + caddy `conf.d` mount); env names verified against source. End-to-end is the QA deploy.