### PR TITLE
fix(cd): keep docassemble /interview/ route across deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,8 +93,18 @@ jobs:
             # There's no build cache to reclaim here anyway (deploys pull, never
             # build). Images carry no --volumes flag, so postgres data is safe.
             docker image prune -af
+            # Pull base images only (app / caddy / postgres). The docassemble
+            # override is applied at `up` below, not here, on purpose: docassemble
+            # is the ~20 GB jhpyle/docassemble all-in-one, and its running
+            # container references the local image, so `up` reuses it — no need to
+            # re-pull it on every deploy.
             docker compose --profile prod pull
-            docker compose --profile prod up -d --no-build
+            # Bring the stack up WITH the docassemble override so caddy-prod keeps
+            # the conf.d mount that routes /interview/* to docassemble (#558). A
+            # base-only `up` recreated caddy without the mount and silently dropped
+            # the /interview/ route on every deploy — 404-ing the Topic Flow
+            # handoff button until restored by hand.
+            docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml --profile prod up -d --no-build
 
       - name: Verify deploy
         # Poll /api/health/ until 200 or timeout. Fails the workflow if the new

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,8 +93,9 @@ jobs:
             # There's no build cache to reclaim here anyway (deploys pull, never
             # build). Images carry no --volumes flag, so postgres data is safe.
             docker image prune -af
-            # Pull base images only (app / caddy / postgres). The docassemble
-            # override is applied at `up` below, not here, on purpose: docassemble
+            # Pull base prod images only (all `--profile prod` services: app,
+            # caddy, postgres, redis). The docassemble override is applied at
+            # `up` below, not here, on purpose: docassemble
             # is the ~20 GB jhpyle/docassemble all-in-one, and its running
             # container references the local image, so `up` reuses it — no need to
             # re-pull it on every deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,7 +520,7 @@ curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js" -o 
 
 QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to `main` via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
 
-Manual deploy on the QA server: `make docker-rebuild`
+Manual deploy on the QA server: `make update` (pulls code + images, recreates, health-checks — and brings up the docassemble override so the `/interview/` route survives; a base-only compose `up` drops it, #558). `make docker-rebuild` is a local from-source rebuild, not the QA deploy path.
 
 ### Production (Self-Hosted)
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ docker-prod: ## Start production environment (Caddy + Gunicorn)
 docker-prod-build: ## Build and start production environment
 	docker compose --profile prod up --build
 
-docker-rebuild: ## Rebuild and restart prod (for QA deploys)
+docker-rebuild: ## Rebuild prod from source (local). QA/partner deploys use `make update`
 	docker compose --profile prod down
 	docker compose --profile prod up -d --build
 

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -127,14 +127,17 @@ docker compose --profile prod exec django-prod python manage.py shell
 # Restart
 docker compose --profile prod restart
 
-# Manual pull + deploy (same as what CI does)
+# Manual pull + deploy (same as CI). Use `make update`: it pulls code + images,
+# recreates WITH the docassemble override, and health-checks. A base-only compose
+# `up` recreates Caddy without the conf.d mount and 404s /interview/* (#558).
 cd /opt/litigant-portal
-docker compose pull django-prod
-docker compose --profile prod up -d --no-build
+make update
 
-# Rollback to a specific SHA
+# Rollback to a specific SHA: pin the image, then recreate override-aware — NOT a
+# base-only `up`, which drops the /interview/ route (#558).
 docker pull ghcr.io/freelawproject/litigant-portal:sha-abc1234
-docker compose --profile prod up -d --no-build
+docker tag ghcr.io/freelawproject/litigant-portal:sha-abc1234 ghcr.io/freelawproject/litigant-portal:latest
+docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml --profile prod up -d --no-build
 ```
 
 ## How Deploys Work
@@ -144,6 +147,6 @@ docker compose --profile prod up -d --no-build
    - Builds Docker image
    - Pushes to GHCR with `latest` + SHA tags
    - SSHs to QA VPS
-   - Runs `docker compose pull django-prod && docker compose --profile prod up -d --no-build`
+   - Pulls base prod images, then brings the stack up **with the docassemble override** (`-f docker-compose.yml -f docker-compose.docassemble.qa.yml --profile prod up -d`) so the `/interview/` route is preserved (#558)
 3. The `web-prod` entrypoint runs `migrate` + `collectstatic` + starts Gunicorn
 4. Caddy proxies traffic with HTTPS


### PR DESCRIPTION
`cd.yml` brought the stack up with the **base** compose file only, so each deploy recreated `caddy-prod` without the `conf.d` mount from `docker-compose.docassemble.qa.yml` — silently dropping the `/interview/*` route and 404-ing the Topic Flow handoff button until restored by hand.

This applies the docassemble override at `up`, so `caddy-prod` keeps the route mount and docassemble stays part of the managed stack. `pull` stays base-only: the ~20 GB `jhpyle/docassemble` image is referenced by its running container, so `up` reuses it without a re-pull every deploy.

Closes #558

Test plan:
- Next merge to `main`: deploy completes and the "Fill out your forms" button still opens the interview — no manual two-`-f` re-up needed
- `/api/health/` still returns 200 (LP app unaffected)
