### PR TITLE
feat(docassemble): add Declaration to ND name-change packet

### DIFF
--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -111,6 +111,36 @@ publication date lands on the field auto-named `Notice choose the same checkbox
 as Paragraph 11...`). The signature-line and "additional sheets" fields that
 static parsing couldn't settle were confirmed by a full-packet bench fill (#560).
 
+## Verifying a fill
+
+The packet is filled by **pikepdf inside the docassemble container** — that is the
+only PDF dependency the project has. The tools below are **local analysis aids**
+for checking a bench fill by hand; nothing in the repo or CI requires them.
+
+Dump every AcroForm field name and value from a filled (or blank) form with
+[qpdf](https://github.com/qpdf/qpdf) (actively maintained, Apache-2.0):
+
+```bash
+qpdf --json --json-key=acroform nd_declaration_in_support.pdf \
+  | jq -r '.acroform.fields[] | "\(.fullname) = \(.value)"'
+```
+
+To see _where_ a value lands on the page, render with [poppler](https://poppler.freedesktop.org/):
+
+```bash
+pdftotext -layout -f 5 -l 5 nd_declaration_in_support.pdf -   # page 5 as text
+pdftoppm -png -f 5 -l 5 nd_declaration_in_support.pdf page    # page 5 as image
+```
+
+**Standing gotcha — the one-row field-name shift.** These ND forms auto-name each
+fillable field after the label that _follows_ the blank, so a field's name sits
+one row above where it actually prints. It has now bitten three forms — the
+Petition §3 address block, the Confidential Information signature block, and the
+Declaration §13 signature block — each needing values shifted up one field name
+(e.g. on the Declaration the printed name goes in `Text15`, not `Printed Name of
+Petitioner`). Assume any new ND form has it, and dump the fields after a bench
+fill to confirm before trusting the mapping.
+
 ## Related
 
 - Handoff epic: #531 (under document-assembly #123)

--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -108,8 +108,8 @@ resolved by parsing each page top-to-bottom and matching fields to the visible
 labels. The 93-field **Declaration** is the heaviest: its sections were mapped by
 position (e.g. §2 citizenship is `Check Box1`/`Check Box2` left-to-right; §11
 publication date lands on the field auto-named `Notice choose the same checkbox
-as Paragraph 11...`). A few signature-line and "additional sheets" fields carry
-`VERIFY` comments in the interview pending a bench fill-and-check.
+as Paragraph 11...`). The signature-line and "additional sheets" fields that
+static parsing couldn't settle were confirmed by a full-packet bench fill (#560).
 
 ## Related
 

--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -33,18 +33,17 @@ Prereq: the bench is up. See [`docs/docassemble-local-dev.md`](../../docs/docass
 - Start the bench: `make docassemble-up`
 - Open `http://localhost:8100` and log in (fresh box default: `admin@example.com` / `password`)
 - Top-right menu → **Playground**
-- Upload the template: in the Playground, open the **Templates** folder → upload `petition.pdf`
-  (the `pdf template file: petition.pdf` line resolves against this folder)
+- Upload the templates: in the Playground, open the **Templates** folder → upload
+  `petition.pdf`, `declaration.pdf`, `notice.pdf`, `confidential-info.pdf`, and `order.pdf`
+  (each attachment block's `pdf template file:` line resolves against this folder)
 - Upload the interview: in the **Sources** folder (the interview file list at the top of the
   editor) → upload `petition-standard.yml`, then select it so it loads in the editor
 - Run it: click **Save and Run**
-- Upload the **other form templates** too (`declaration.pdf`, `notice.pdf`,
-  `confidential-info.pdf`, `order.pdf`) into the **Templates** folder — the
-  packet's attachment blocks resolve each `pdf template file:` against it
 - Walk the screens with the sample data below, then **download the combined
   packet** (and spot-check each form) at the end
 - Verify on each PDF: every text field populated, and the right checkboxes ticked
-  (§2 citizenship, §9 criminal history, §11 publication/waiver, §12 objections)
+  (citizenship — Petition §5, Declaration §2 — plus §9 criminal history, §11
+  publication/waiver, §12 objections)
 - Repeat with `petition-waiver.yml` to exercise the waiver track
 
 Sample data:

--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -9,16 +9,22 @@ README together), not split by file type.
 
 ## Contents
 
-| File                    | What it is                                                                 |
-| ----------------------- | -------------------------------------------------------------------------- |
-| `petition.pdf`          | ND Petition for Name Change (NC Pet/Rev. May 2024) — the fillable template |
-| `petition-standard.yml` | Interview for the standard **publish** track                               |
-| `petition-waiver.yml`   | Interview for the **publication-waived** track                             |
+| File                    | What it is                                                                |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `petition.pdf`          | ND Petition for Name Change (NC Pet/Rev. May 2024) — fillable template    |
+| `declaration.pdf`       | Declaration in Support of Petition (NC Dec/Rev. May 2024) — 93-field form |
+| `notice.pdf`            | Notice of Petition for Name Change (standard track only)                  |
+| `confidential-info.pdf` | Confidential Information Form                                             |
+| `order.pdf`             | Proposed Order for Name Change                                            |
+| `petition-standard.yml` | Interview for the standard **publish** track                              |
+| `petition-waiver.yml`   | Interview for the **publication-waived** track                            |
 
-Both interviews fill the **same** `petition.pdf`; they differ only at the
-Petition's §11 (publish vs. waive + reason) and §12 (objections). The tracks fork
-at entry, matching the Topic Flow corpus's standard/waiver split — no in-interview
-branching.
+Each interview gathers the shared facts once and emits the **full filing packet**
+as one combined PDF plus the individual forms — the standard track assembles 5
+forms (Petition, Declaration, Notice, Confidential, Order), the waiver track 4
+(no Notice). The two tracks differ only at §11 (publish vs. waive + reason) and
+§12 (objections); they fork at entry, matching the Topic Flow corpus's
+standard/waiver split — no in-interview branching.
 
 ## Test it locally
 
@@ -32,9 +38,13 @@ Prereq: the bench is up. See [`docs/docassemble-local-dev.md`](../../docs/docass
 - Upload the interview: in the **Sources** folder (the interview file list at the top of the
   editor) → upload `petition-standard.yml`, then select it so it loads in the editor
 - Run it: click **Save and Run**
-- Walk the 5 screens with the sample data below, then **download the filled Petition** at the end
-- Verify on the PDF: every text field populated, and the right checkboxes ticked
-  (§5 citizenship, §9 criminal history, §11 publication, §12 objections)
+- Upload the **other form templates** too (`declaration.pdf`, `notice.pdf`,
+  `confidential-info.pdf`, `order.pdf`) into the **Templates** folder — the
+  packet's attachment blocks resolve each `pdf template file:` against it
+- Walk the screens with the sample data below, then **download the combined
+  packet** (and spot-check each form) at the end
+- Verify on each PDF: every text field populated, and the right checkboxes ticked
+  (§2 citizenship, §9 criminal history, §11 publication/waiver, §12 objections)
 - Repeat with `petition-waiver.yml` to exercise the waiver track
 
 Sample data:
@@ -44,6 +54,9 @@ Current name:     Jane Marie Doe
 Requested name:   Jane Marie Smith
 Residence:        123 Main St, Bismarck, Burleigh County, ND 58501
 Resident since:   January 2025
+Place of birth:   Fargo, North Dakota
+ND residency:     1 year, 5 months
+Date of birth:    1990-03-12
 Citizenship:      U.S. citizen
 Criminal history: never convicted
 Standard track — published: 2026-05-01, The Bismarck Tribune, Burleigh County
@@ -90,6 +103,14 @@ re-verify whenever the court revises the form. Concrete gotcha: in §3 the
 parenthetical labels trail the blank they describe, so the field names are
 shifted one slot — `Petitioner currently resides at`/`address`/`city`/`North
 Dakota` actually hold address/city/county/zip.
+
+Every form in the packet is mapped the same way — auto-generated AcroForm names
+resolved by parsing each page top-to-bottom and matching fields to the visible
+labels. The 93-field **Declaration** is the heaviest: its sections were mapped by
+position (e.g. §2 citizenship is `Check Box1`/`Check Box2` left-to-right; §11
+publication date lands on the field auto-named `Notice choose the same checkbox
+as Paragraph 11...`). A few signature-line and "additional sheets" fields carry
+`VERIFY` comments in the interview pending a bench fill-and-check.
 
 ## Related
 

--- a/docassemble/nd-name-change/petition-standard.yml
+++ b/docassemble/nd-name-change/petition-standard.yml
@@ -86,6 +86,13 @@ subquestion: |
 fields:
   - Date of birth: date_of_birth
     datatype: date
+  - Place of birth: place_of_birth
+    hint: e.g. Fargo, North Dakota
+  - Years you have lived in North Dakota: residency_years
+    datatype: integer
+  - Additional months: residency_months
+    datatype: integer
+    default: 0
   - Your phone number: phone_number
     required: False
 ---
@@ -247,20 +254,85 @@ attachment:
     - 'Middle names if any_4': ${ requested_middle }
     - 'Last name_4': ${ requested_last }
 ---
-# === Declaration in Support of Petition (next, #560) ====================
-# TODO(#560): the 93-field heavy one — mirrors the Petition (birth year, place
-# of birth, residency duration, 6-row criminal-history table, publication,
-# objections, signature). Build + bench-verify next. When added: a 5th standalone
-# attachment with `variable name: declaration_doc`, then add it to the merge and
-# the link list below.
+# === Declaration in Support of Petition =================================
+# The 93-field form; mirrors the Petition. Field names are the PDF's real
+# AcroForm names, mapped against page/position (parsed page-by-page, top-to-
+# bottom — same method as the Petition). Auto-generated names are not name-
+# obvious, so each section notes what the field actually fills. Checkbox "on"
+# state is "Yes" (parity with the other forms in this packet). The VERIFY tags
+# below still need a bench fill-and-check pass (#560 DoD).
+attachment:
+  name: Declaration in Support of Petition
+  filename: nd_declaration_in_support
+  variable name: declaration_doc
+  pdf template file: declaration.pdf
+  fields:
+    # Caption
+    - 'In District Court': ${ residence_county }
+    - 'Case No': ''
+    - 'Petitioners current first middle if any and last legal name': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    # Preamble "I, ____ (current legal name), the undersigned, states..."
+    - 'I': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    # 1. Current legal name
+    - 'First name': ${ current_first }
+    - 'Middle names if any': ${ current_middle }
+    - 'Last name': ${ current_last }
+    # 2. Citizenship (same line: Check Box1 = citizen [left], Check Box2 = resident alien [right])
+    - 'Check Box1': ${ citizenship == "citizen" }
+    - 'Check Box2': ${ citizenship == "resident_alien" }
+    # 3. "resident of North Dakota for ___ years and ___ months"
+    - 'I have been a resident of North Dakota for': ${ residency_years }
+    - 'years and': ${ residency_months }
+    # 4. "resident of ___ County ... since ___ (month and year)"
+    - 'I have been a resident of': ${ residence_county }
+    - 'month and year more than six months immediately before the': ${ residence_since }
+    # 5. Place of birth
+    - 'My place of birth is': ${ place_of_birth }
+    # 6. Year of birth
+    - 'My year of birth is': ${ date_of_birth.year }
+    # 7. Requested name
+    - 'First name_2': ${ requested_first }
+    - 'Middle names if any_2': ${ requested_middle }
+    - 'Last name_2': ${ requested_last }
+    # 8. Reasons for the change — a free narrative the litigant writes by hand,
+    #    left unmapped for parity with the Petition (which also collects no
+    #    reason). The ruled overflow lines are fields 'on Page 3 1'..'on Page 3
+    #    16' (p2) and '1'/'2'/'3'/'4'/'undefined' (p3).
+    # 9. Criminal history (Check Box3 = never [top], Check Box4 = convicted [below])
+    - 'Check Box3': ${ criminal_history == "none" }
+    - 'Check Box4': ${ criminal_history == "convicted" }
+    # 9. Conviction table (ChargeRow/ClassRow/Name of CourtRow/YearRow 1-6):
+    #    blank for the demo persona (never convicted); filled by hand otherwise.
+    # 11. Notice — standard track: published (mirrors Petition §11)
+    - 'Check Box7': True
+    - 'Notice choose the same checkbox as Paragraph 11 of your Petition': ${ publication_date }
+    - 'newspaper the official': ${ publication_newspaper }
+    - 'newspaper in': ${ publication_county }
+    # 11. Waiver sub-checkboxes (unused on the standard path)
+    - 'Check Box8': False
+    - 'Check Box9': False
+    - 'Check Box10': False
+    # 12. Objections — standard track: none (Check Box12 = no objections)
+    - 'Check Box12': True
+    - 'Check Box13': False
+    - 'Check Box14': False
+    # 13. Signature block — printed name + address; the litigant signs and dates
+    #     by hand. 'Address' spans the single ruled line (address, city, ZIP).
+    - 'Printed Name of Petitioner': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    - 'Address': ${ residence_street }, ${ residence_city }, ND ${ residence_zip }
+    # VERIFY: 'Text15' sits in the §13 signing line ("Signed on ___ (date) in ___
+    # (city)...") — left blank for the litigant to complete at signing.
+    # VERIFY: additional-sheets toggles ('Check Box5'/'Check Box6', ¶8/¶9) default
+    # off; confirm which is which on the bench (both stay off for the demo).
 ---
 # Merge into one mobile-friendly PDF. pdf_concatenate (verified in docassemble's
 # util.py) accepts the attachment DAFileCollection variables directly and returns
 # a DAFile. It lives in its own block so the docs resolve before the screen
-# below renders — NOT on that screen, which would loop.
+# below renders — NOT on that screen, which would loop. Filing order: Petition,
+# its Declaration, Notice, Confidential, Order.
 code: |
   packet_pdf = pdf_concatenate(
-      petition_doc, notice_doc, confidential_doc, order_doc,
+      petition_doc, declaration_doc, notice_doc, confidential_doc, order_doc,
       filename="nd-name-change-packet-standard.pdf")
 ---
 mandatory: True
@@ -275,6 +347,7 @@ subquestion: |
   clerk (or mail them in, depending on your court's process):
 
   - [Petition for Name Change](${ petition_doc.pdf.url_for(attachment=True) })
+  - [Declaration in Support of Petition](${ declaration_doc.pdf.url_for(attachment=True) })
   - [Notice of Petition for Name Change](${ notice_doc.pdf.url_for(attachment=True) })
   - [Confidential Information Form](${ confidential_doc.pdf.url_for(attachment=True) })
   - [Proposed Order for Name Change](${ order_doc.pdf.url_for(attachment=True) })

--- a/docassemble/nd-name-change/petition-standard.yml
+++ b/docassemble/nd-name-change/petition-standard.yml
@@ -107,7 +107,7 @@ fields:
 # makes docassemble loop ("petition_doc already looked for"), because the screen
 # seeks a variable it is itself mid-assembling. So: standalone blocks define each
 # doc, a code block merges them, the final screen only links. Fields map answers
-# to AcroForm names (#560); VERIFY tags still need a bench fill.
+# to AcroForm names (#560); bench-confirmed by a full-packet fill.
 
 # === Petition for Name Change ===========================================
 attachment:
@@ -176,13 +176,13 @@ attachment:
   variable name: notice_doc
   pdf template file: notice.pdf
   fields:
-    # VERIFY: header field — county vs judicial-district number.
+    # Bench-confirmed: header holds the county name.
     - 'In District Court': ${ residence_county }
     - 'In The Matter Of The Petition For Name Change Of': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
     - 'an Order changing the Petitioners name of': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
     - 'to': ${ " ".join(p for p in [requested_first, requested_middle, requested_last] if p) }
-    # VERIFY: sits above the printed-name/address signature block — likely a
-    # date or signature line; left blank for the litigant to sign by hand.
+    # Bench-confirmed: signing/date line above the printed-name/address block —
+    # left blank for the litigant to sign by hand.
     - 'Text1': ''
     - 'Printed Name': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
     - 'Address': ${ residence_street }, ${ residence_city }, ND ${ residence_zip }
@@ -217,21 +217,19 @@ attachment:
     - 'Telephone Number': '' # -> (Email Address); no email collected
 ---
 # === Proposed Order for Name Change =====================================
-# VERIFY (whole form): four name-sets (base / _2 / _3 / _4). _3 is the caption
-# (current legal name) with confidence; the body from/to ordering below is a
-# best guess pending a bench fill — the filled PDF shows which set lands on
-# "from" vs "to". The judge signs the Order, so no signature mapping.
+# Four name-sets (base / _2 / _3 / _4), bench-confirmed by page position (see the
+# per-field notes below). The judge signs the Order, so no signature mapping.
 attachment:
   name: Proposed Order for Name Change
   filename: nd_proposed_order
   variable name: order_doc
   pdf template file: order.pdf
   fields:
-    # VERIFY: header field — county vs judicial-district number.
+    # Bench-confirmed: header holds the county name.
     - 'In District Court': ${ residence_county }
     - 'Case No': ''
     - 'County of': ${ residence_county }
-    # VERIFY: stray single-char field on the residence/"County of" line.
+    # Bench-confirmed: stray single-char field on the "County of" line — blank.
     - '1': ''
     - 'The Petitioners birth year is': ${ date_of_birth.year }
     - 'Petitioners Current First Middle If Any And Last Legal Name': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
@@ -262,8 +260,8 @@ attachment:
 # AcroForm names, mapped against page/position (parsed page-by-page, top-to-
 # bottom — same method as the Petition). Auto-generated names are not name-
 # obvious, so each section notes what the field actually fills. Checkbox "on"
-# state is "Yes" (parity with the other forms in this packet). The VERIFY tags
-# below still need a bench fill-and-check pass (#560 DoD).
+# state is "Yes" (parity with the other forms in this packet). Bench-confirmed by
+# a full-packet fill (#560 DoD).
 attachment:
   name: Declaration in Support of Petition
   filename: nd_declaration_in_support
@@ -319,14 +317,17 @@ attachment:
     - 'Check Box12': True
     - 'Check Box13': False
     - 'Check Box14': False
-    # 13. Signature block — printed name + address; the litigant signs and dates
-    #     by hand. 'Address' spans the single ruled line (address, city, ZIP).
-    - 'Printed Name of Petitioner': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
-    - 'Address': ${ residence_street }, ${ residence_city }, ND ${ residence_zip }
-    # VERIFY: 'Text15' sits in the §13 signing line ("Signed on ___ (date) in ___
-    # (city)...") — left blank for the litigant to complete at signing.
-    # VERIFY: additional-sheets toggles ('Check Box5'/'Check Box6', ¶8/¶9) default
-    # off; confirm which is which on the bench (both stay off for the demo).
+    # 13. Signature block. Bench fill (#560) showed the field names trail their
+    #     visual labels by one row (same gotcha as Petition §3 / the Confidential
+    #     form): 'Text15' sits on the (Printed Name) line, 'Printed Name of
+    #     Petitioner' on the (Address / City, State, Zip) line, 'Address' on the
+    #     (Telephone / Email) line. The (Signature) line and the "Signed on ___"
+    #     date/city blanks have no fields — the litigant signs and dates by hand.
+    - 'Text15': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) } # -> (Printed Name of Petitioner)
+    - 'Printed Name of Petitioner': ${ residence_street }, ${ residence_city }, ND ${ residence_zip } # -> (Address / City, State, Zip)
+    - 'Address': ${ phone_number } # -> (Telephone Number / Email); no email collected
+    # Bench-confirmed: additional-sheets toggles ('Check Box5'/'Check Box6', ¶8/¶9)
+    # stay off for the demo.
 ---
 # Merge into one mobile-friendly PDF. pdf_concatenate (verified in docassemble's
 # util.py) accepts the attachment DAFileCollection variables directly and returns

--- a/docassemble/nd-name-change/petition-standard.yml
+++ b/docassemble/nd-name-change/petition-standard.yml
@@ -90,8 +90,11 @@ fields:
     hint: e.g. Fargo, North Dakota
   - Years you have lived in North Dakota: residency_years
     datatype: integer
+    min: 0
   - Additional months: residency_months
     datatype: integer
+    min: 0
+    max: 11
     default: 0
   - Your phone number: phone_number
     required: False

--- a/docassemble/nd-name-change/petition-waiver.yml
+++ b/docassemble/nd-name-change/petition-waiver.yml
@@ -218,7 +218,7 @@ attachment:
 # === Declaration in Support of Petition (waiver track) ==================
 # Identical to the standard Declaration except §11 (waive instead of publish)
 # and §12 (requesting waiver). Field mapping is position-verified the same way
-# (#560); VERIFY tags still need a bench fill-and-check pass.
+# (#560); the shared Declaration fields were bench-confirmed on the standard track.
 attachment:
   name: Declaration in Support of Petition
   filename: nd_declaration_in_support_waiver
@@ -270,11 +270,14 @@ attachment:
     - 'Check Box12': False
     - 'Check Box13': False
     - 'Check Box14': True
-    # 13. Signature block — printed name + address; litigant signs/dates by hand.
-    - 'Printed Name of Petitioner': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
-    - 'Address': ${ residence_street }, ${ residence_city }, ND ${ residence_zip }
-    # VERIFY: 'Text15' (§13 signing line) left blank for hand-completion;
-    # additional-sheets 'Check Box5'/'Check Box6' (¶8/¶9) default off.
+    # 13. Signature block — same one-row label shift as the standard track (shared
+    #     declaration.pdf): 'Text15' = (Printed Name) line, 'Printed Name of
+    #     Petitioner' = (Address / City, State, Zip) line, 'Address' = (Telephone /
+    #     Email) line. The signature + "Signed on ___" blanks are handwritten.
+    - 'Text15': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) } # -> (Printed Name of Petitioner)
+    - 'Printed Name of Petitioner': ${ residence_street }, ${ residence_city }, ND ${ residence_zip } # -> (Address / City, State, Zip)
+    - 'Address': ${ phone_number } # -> (Telephone Number / Email); no email collected
+    # additional-sheets 'Check Box5'/'Check Box6' (¶8/¶9) stay off (Off on the bench).
 ---
 # Merge into one mobile-friendly PDF (waiver track). pdf_concatenate takes the
 # attachment DAFileCollection vars directly; in its own block so the docs resolve

--- a/docassemble/nd-name-change/petition-waiver.yml
+++ b/docassemble/nd-name-change/petition-waiver.yml
@@ -86,8 +86,11 @@ fields:
     hint: e.g. Fargo, North Dakota
   - Years you have lived in North Dakota: residency_years
     datatype: integer
+    min: 0
   - Additional months: residency_months
     datatype: integer
+    min: 0
+    max: 11
     default: 0
   - Your phone number: phone_number
     required: False

--- a/docassemble/nd-name-change/petition-waiver.yml
+++ b/docassemble/nd-name-change/petition-waiver.yml
@@ -78,10 +78,17 @@ mandatory: True
 question: |
   A few more details for the rest of your packet
 subquestion: |
-  These appear on the Order and Confidential Information form.
+  These appear on the Order, Declaration, and Confidential Information form.
 fields:
   - Date of birth: date_of_birth
     datatype: date
+  - Place of birth: place_of_birth
+    hint: e.g. Fargo, North Dakota
+  - Years you have lived in North Dakota: residency_years
+    datatype: integer
+  - Additional months: residency_months
+    datatype: integer
+    default: 0
   - Your phone number: phone_number
     required: False
 ---
@@ -205,18 +212,74 @@ attachment:
     - 'Middle names if any_4': ${ requested_middle }
     - 'Last name_4': ${ requested_last }
 ---
-# === Declaration in Support of Petition (next, #560) ====================
-# TODO(#560): the 93-field heavy one. Build + bench-verify, then add here as a 4th
-# standalone attachment with `variable name: declaration_doc` and fold it into the
-# merge + the link list below. Waiver packet = Petition + Declaration +
-# Confidential + Order (no Notice).
+# === Declaration in Support of Petition (waiver track) ==================
+# Identical to the standard Declaration except §11 (waive instead of publish)
+# and §12 (requesting waiver). Field mapping is position-verified the same way
+# (#560); VERIFY tags still need a bench fill-and-check pass.
+attachment:
+  name: Declaration in Support of Petition
+  filename: nd_declaration_in_support_waiver
+  variable name: declaration_doc
+  pdf template file: declaration.pdf
+  fields:
+    # Caption
+    - 'In District Court': ${ residence_county }
+    - 'Case No': ''
+    - 'Petitioners current first middle if any and last legal name': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    # Preamble "I, ____ (current legal name)"
+    - 'I': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    # 1. Current legal name
+    - 'First name': ${ current_first }
+    - 'Middle names if any': ${ current_middle }
+    - 'Last name': ${ current_last }
+    # 2. Citizenship (Check Box1 = citizen, Check Box2 = resident alien)
+    - 'Check Box1': ${ citizenship == "citizen" }
+    - 'Check Box2': ${ citizenship == "resident_alien" }
+    # 3. "resident of North Dakota for ___ years and ___ months"
+    - 'I have been a resident of North Dakota for': ${ residency_years }
+    - 'years and': ${ residency_months }
+    # 4. "resident of ___ County ... since ___ (month and year)"
+    - 'I have been a resident of': ${ residence_county }
+    - 'month and year more than six months immediately before the': ${ residence_since }
+    # 5. Place of birth
+    - 'My place of birth is': ${ place_of_birth }
+    # 6. Year of birth
+    - 'My year of birth is': ${ date_of_birth.year }
+    # 7. Requested name
+    - 'First name_2': ${ requested_first }
+    - 'Middle names if any_2': ${ requested_middle }
+    - 'Last name_2': ${ requested_last }
+    # 8. Reasons — litigant-handwritten narrative, left unmapped (parity w/ Petition).
+    # 9. Criminal history (Check Box3 = never, Check Box4 = convicted)
+    - 'Check Box3': ${ criminal_history == "none" }
+    - 'Check Box4': ${ criminal_history == "convicted" }
+    # 9. Conviction table: blank for the demo persona (never convicted).
+    # 11. Notice — WAIVER track: not published, blanks empty
+    - 'Check Box7': False
+    - 'Notice choose the same checkbox as Paragraph 11 of your Petition': ''
+    - 'newspaper the official': ''
+    - 'newspaper in': ''
+    # 11. Waiver of publication + reason(s)
+    - 'Check Box8': True
+    - 'Check Box9': ${ waiver_reasons["first_or_middle"] }
+    - 'Check Box10': ${ waiver_reasons["domestic_violence"] }
+    # 12. Objections — WAIVER track: requesting waiver (Check Box14)
+    - 'Check Box12': False
+    - 'Check Box13': False
+    - 'Check Box14': True
+    # 13. Signature block — printed name + address; litigant signs/dates by hand.
+    - 'Printed Name of Petitioner': ${ " ".join(p for p in [current_first, current_middle, current_last] if p) }
+    - 'Address': ${ residence_street }, ${ residence_city }, ND ${ residence_zip }
+    # VERIFY: 'Text15' (§13 signing line) left blank for hand-completion;
+    # additional-sheets 'Check Box5'/'Check Box6' (¶8/¶9) default off.
 ---
 # Merge into one mobile-friendly PDF (waiver track). pdf_concatenate takes the
 # attachment DAFileCollection vars directly; in its own block so the docs resolve
-# before the screen below renders (avoids the assembly loop).
+# before the screen below renders (avoids the assembly loop). Filing order:
+# Petition, its Declaration, Confidential, Order (no Notice on the waiver track).
 code: |
   packet_pdf = pdf_concatenate(
-      petition_doc, confidential_doc, order_doc,
+      petition_doc, declaration_doc, confidential_doc, order_doc,
       filename="nd-name-change-packet-waiver.pdf")
 ---
 mandatory: True
@@ -231,5 +294,6 @@ subquestion: |
   clerk (or mail them in, depending on your court's process):
 
   - [Petition for Name Change](${ petition_doc.pdf.url_for(attachment=True) })
+  - [Declaration in Support of Petition](${ declaration_doc.pdf.url_for(attachment=True) })
   - [Confidential Information Form](${ confidential_doc.pdf.url_for(attachment=True) })
   - [Proposed Order for Name Change](${ order_doc.pdf.url_for(attachment=True) })

--- a/docassemble/nd-name-change/test-personas.md
+++ b/docassemble/nd-name-change/test-personas.md
@@ -31,6 +31,12 @@ the publication waiver.
   - Published on: `2026-06-01` \*
   - Newspaper: `The Bismarck Tribune`
   - County: `Burleigh` (defaults from residence)
+- **Screen 6 — A few more details** (Order, Declaration, Confidential)
+  - Date of birth: `1979-04-22` \*
+  - Place of birth: `Minot, North Dakota` \*
+  - Years in North Dakota: `18` \* (resident since June 2008)
+  - Additional months: `0` \*
+  - Phone: `701-555-0142` \*
 
 Expected page-4 block: "from Sandra Marie Larson / to Sandra Marie Eriksen."
 Because Sandra has a middle name, this run also confirms the caption renders with


### PR DESCRIPTION
Completes the ND name-change filing packet. The standard track now assembles all 5 forms (Petition, Declaration, Notice, Confidential, Order) and the waiver track all 4 (no Notice), so the litigant fills once and downloads the full set.

The 93-field Declaration is mapped against the PDF's auto-generated AcroForm names by parsing each page top-to-bottom — §2 citizenship (`Check Box1`/`Check Box2` left-to-right), §9 criminal history, §11 publish-vs-waive, §12 objections, and the §11 publication date (which lands on the field auto-named `Notice choose the same checkbox as Paragraph 11...`). The §8 reason narrative, conviction-table rows, and DV-detail lines stay litigant-handwritten, matching the Petition. The gather flow gains two Declaration-only facts — place of birth and ND residency duration (years + months); birth year reuses the existing date of birth.

Closes #560

## Bench-verified (both tracks)

Full-packet fill on `localhost:8100`, confirmed three ways (rendered page, `pdftotext -layout`, and qpdf AcroForm dump). The bench surfaced and fixed one real defect:

- **Declaration §13 signature block had the one-row field-name shift** (same gotcha as Petition §3 and the Confidential form) — the petitioner's name landed on the (Address) line and the address on the (Telephone) line, leaving the (Printed Name) line blank. Remapped to the true positions: `Text15` → printed name, `Printed Name of Petitioner` → address, `Address` → phone. Without the bench pass this would have shipped a misfiled name/address on a sworn declaration.
- All `VERIFY`-tagged fields confirmed and cleared: `Text15` (now the printed-name line), additional-sheets `Check Box5`/`Check Box6` (`/Off`), Notice/Order header fields, §11 publication date.

The README gains a **"Verifying a fill"** note (qpdf field-dump + poppler render workflow, framed as local analysis aids — the packet is filled by pikepdf in the container) and generalizes the field-shift gotcha into a standing warning for any new ND form.

## Verification checklist

- [x] Standard track — all 5 forms fill correctly in the combined packet
- [x] Waiver track — 4-form packet (no Notice); §11 waive + §12 requesting-waiver tick right
- [x] Declaration checkboxes: §2 citizenship, §9 never/convicted, §11 publish/waive, §12 objections
- [x] Inferred field: §11 publication date lands on the `Notice choose the same checkbox...` field
- [x] §13 signature block: name / address / phone land on the correct lines; signature + "Signed on ___" blanks stay handwritten

Sample data and a per-screen persona walkthrough are in `docassemble/nd-name-change/README.md` and `test-personas.md`.
