### PR TITLE
chore(ci): Adds Docker Hub build-and-push workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,70 @@
+name: Build and Push to Docker Hub
+
+# v1: build the portal image and publish it to Docker Hub on every merge to main.
+# The EKS deploy job is intentionally NOT wired up yet — that comes in a
+# follow-up once AWS auth is ready.
+# Runs alongside cd.yml (which builds to GHCR and deploys QA); the two are
+# independent, so they use separate concurrency groups.
+
+on:
+  push:
+    branches:
+      - main
+
+# github-script lists the PR associated with the merge commit; that needs
+# pull-requests: read. contents: read is for checkout.
+permissions:
+  contents: read
+  pull-requests: read
+
+# Serialize publishes so back-to-back merges push image tags in order.
+concurrency:
+  group: dockerhub-publish
+  cancel-in-progress: false
+
+jobs:
+  get-pr-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.find_pr.outputs.labels }}
+    steps:
+      - name: Find merged PR for this commit
+        id: find_pr
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commitSha = context.sha;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+              sort: "updated",
+              direction: "desc",
+              per_page: 1
+            });
+
+            const pr = prs.find(p => p.merge_commit_sha === commitSha);
+            if (!pr) {
+              core.setOutput("labels", "");
+              core.warning("No merged PR found for this commit.");
+              return;
+            }
+
+            const labels = pr.labels.map(l => l.name);
+            core.setOutput("labels", labels.join(","));
+            console.log(`PR #${pr.number} labels: ${labels.join(", ")}`);
+
+  build:
+    needs: get-pr-labels
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        run: make push-image -e VERSION=$(git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build css clean install migrate test test-v collectstatic lint fmt-check fmt \
        file-issue messages compilemessages docker-build docker-dev docker-prod docker-rebuild \
 	   docker-down docker-logs docker-shell docker-migrate docker-clean \
-	   docassemble-up docassemble-down update health
+	   docassemble-up docassemble-down update health build-image push-image
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -119,3 +119,20 @@ update: ## Update a hosted box: pull code+images, recreate, health (ARGS=... e.g
 
 health: ## Health/validation summary for a hosted box (no changes)
 	./scripts/update.sh health $(ARGS)
+
+# Image build & push — used by .github/workflows/deploy.yml to publish the
+# portal image for the EKS deploy. Requires VERSION (the short git SHA in CI):
+#   make push-image -e VERSION=$(git rev-parse --short HEAD)
+# Override the registry/namespace with -e REPO=... if needed.
+REPO ?= freelawproject/litigant-portal
+DOCKER_TAG_PROD = $(VERSION)-prod
+
+build-image: ## Build the prod portal image (requires VERSION=...)
+	docker build -t $(REPO):$(DOCKER_TAG_PROD) --file docker/django/Dockerfile .
+
+push-image: build-image ## Build then push the prod portal image (amd64 only)
+	@if [ "$$(uname -m)" != "x86_64" ]; then \
+		echo "Refusing to push: only amd64 builds may be pushed (the server/EKS runs amd64; an arm64 image would crash-loop there)."; \
+		exit 1; \
+	fi
+	docker push $(REPO):$(DOCKER_TAG_PROD)


### PR DESCRIPTION
### Summary

Adds a CI workflow that builds the litigant-portal Docker image and publishes it to Docker Hub on every merge to main, along with the required Makefile targets.

This is the initial version and only handles publishing the Docker image.

### Runs alongside cd.yml

This workflow is independent of cd.yml (GHCR build + QA deployment). Each uses its own concurrency group, so they can run in parallel without blocking one another.

One consequence is that every merge to main now builds the image twice: once for Docker Hub and once for GHCR.