### PR TITLE
fix(topic-flow): fail loud on duplicate corpus keys

### DIFF
--- a/litigant_portal/app/tests/test_topic_flow_registry.py
+++ b/litigant_portal/app/tests/test_topic_flow_registry.py
@@ -53,3 +53,33 @@ def test_check_reports_invalid_corpus(tmp_path, monkeypatch):
     errors = checks.check_corpora(None)
     assert len(errors) == 1
     assert errors[0].id == "topic_flow.E001"
+
+
+def test_check_reports_duplicate_corpus_keys(tmp_path, monkeypatch):
+    # Two files declaring the same (court, topic, role) — the later one
+    # silently overwrites the earlier in the registry, so the check must
+    # fail loud and name both colliding files.
+    first = tmp_path / "first.yml"
+    second = tmp_path / "second.yml"
+    first.write_text(VALID)
+    second.write_text(VALID)
+    monkeypatch.setattr(
+        checks, "iter_corpus_paths", lambda _dir: [first, second]
+    )
+    errors = checks.check_corpora(None)
+    assert len(errors) == 1
+    assert errors[0].id == "topic_flow.E002"
+    assert "first.yml" in errors[0].msg
+    assert "second.yml" in errors[0].msg
+
+
+def test_check_passes_for_distinct_keys(tmp_path, monkeypatch):
+    # Same content but different (court, topic, role) must NOT collide.
+    first = tmp_path / "first.yml"
+    second = tmp_path / "second.yml"
+    first.write_text(VALID)
+    second.write_text(VALID.replace("test-court", "other-court"))
+    monkeypatch.setattr(
+        checks, "iter_corpus_paths", lambda _dir: [first, second]
+    )
+    assert checks.check_corpora(None) == []

--- a/litigant_portal/app/topic_flow/checks.py
+++ b/litigant_portal/app/topic_flow/checks.py
@@ -5,6 +5,8 @@ counterpart — a malformed ``content/*.yml`` surfaces as a deploy-time error
 (``manage.py check``) rather than a silently missing flow.
 """
 
+from pathlib import Path
+
 from django.core.checks import Error, Tags, register
 
 from litigant_portal.app.topic_flow.loader import (
@@ -20,9 +22,10 @@ from litigant_portal.app.topic_flow.registry import (
 @register(Tags.compatibility)
 def check_corpora(app_configs, **kwargs):
     errors = []
+    seen: dict[tuple[str, str, str], Path] = {}
     for path in iter_corpus_paths(CONTENT_DIR):
         try:
-            CorpusLoader.load(path)
+            corpus = CorpusLoader.load(path)
         except CorpusValidationError as exc:
             errors.append(
                 Error(
@@ -33,4 +36,24 @@ def check_corpora(app_configs, **kwargs):
                     obj=str(path),
                 )
             )
+            continue
+        meta = corpus.metadata
+        key = (meta.court, meta.topic, meta.role)
+        if key in seen:
+            errors.append(
+                Error(
+                    f"Duplicate corpus key (court={meta.court!r}, "
+                    f"topic={meta.topic!r}, role={meta.role!r}): both "
+                    f"{seen[key].name} and {path.name} declare it; the "
+                    "later file would silently overwrite the earlier in "
+                    "the registry.",
+                    hint="Each content/*.yml must declare a unique "
+                    "(court, topic, role). Rename, merge, or underscore-"
+                    "prefix one of the files to exclude it.",
+                    id="topic_flow.E002",
+                    obj=str(path),
+                )
+            )
+        else:
+            seen[key] = path
     return errors


### PR DESCRIPTION
`CorpusRegistry.load` silently overwrote on a `(court, topic, role)` collision, so a duplicated key dropped a whole flow from the site with no signal — the one corpus error that failed silently while every other (pydantic `extra="forbid"`, loader id cross-refs, `topic_flow.E001`) fails loud at the boundary.

This extends the `manage.py check` startup guard (`checks.py`) to track seen keys and raise `topic_flow.E002` naming both colliding files, with a fix hint. The registry stays graceful at runtime; the startup check is the loud gate — matching the existing E001 pattern.

Closes #527

## Test plan
- [ ] `make lint && make test`
- New `test_check_reports_duplicate_corpus_keys` — two files, same key → one `E002` error naming both files
- New `test_check_passes_for_distinct_keys` — same content, different court → no error (guards against false positives)
- Existing E001 / valid-corpus checks unaffected