### PR TITLE
feat(topic-flow): enforce fact_gather validation on POST

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
@@ -14,6 +14,7 @@
     id="{{ q.id }}"
     help_text="{{ q.help_text|default:'' }}"
     :required="q.required"
+    :errors="q.errors"
   >
     <option value="">{{ choice_placeholder }}</option>
     {% for choice in q.choices %}
@@ -29,6 +30,7 @@
     value="{{ q.value }}"
     help_text="{{ q.help_text|default:'' }}"
     :required="q.required"
+    :errors="q.errors"
   />
   {% endif %}
   {% endfor %}

--- a/litigant_portal/app/tests/test_topic_flow_validation.py
+++ b/litigant_portal/app/tests/test_topic_flow_validation.py
@@ -1,0 +1,81 @@
+"""Unit tests for fact_gather answer validation (#525).
+
+``validate_answers`` is pure and DB-free: given a corpus and a submitted
+``{qid: value}`` map, it returns ``{qid: [error]}`` for empty ``required``
+fields and ``choice`` answers outside the declared list. An empty dict means
+the submission is valid. These run in the fast suite.
+"""
+
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    FactGatherSection,
+    Metadata,
+    Question,
+)
+from litigant_portal.app.topic_flow.validation import validate_answers
+
+
+def _corpus():
+    return Corpus(
+        metadata=Metadata(court="c", topic="t", role="petitioner", title="T"),
+        sections=[
+            FactGatherSection(
+                kind="fact_gather",
+                id="facts",
+                questions=[
+                    Question(
+                        id="pub_date",
+                        label="Publication date",
+                        type="date",
+                        required=True,
+                    ),
+                    Question(
+                        id="county",
+                        label="County",
+                        type="choice",
+                        choices=["Cass", "Burleigh"],
+                    ),
+                    Question(id="note", label="Note", type="text"),
+                ],
+            )
+        ],
+    )
+
+
+def test_empty_required_field_is_flagged():
+    assert "pub_date" in validate_answers(_corpus(), {"pub_date": ""})
+
+
+def test_whitespace_only_required_field_is_flagged():
+    # A space-bar answer is no answer — must not satisfy `required`.
+    assert "pub_date" in validate_answers(_corpus(), {"pub_date": "   "})
+
+
+def test_filled_required_field_passes():
+    assert validate_answers(_corpus(), {"pub_date": "2026-02-01"}) == {}
+
+
+def test_choice_outside_declared_list_is_flagged():
+    assert "county" in validate_answers(_corpus(), {"county": "Stark"})
+
+
+def test_choice_within_declared_list_passes():
+    assert validate_answers(_corpus(), {"county": "Cass"}) == {}
+
+
+def test_empty_optional_choice_passes():
+    # Not required + left blank → fine; the litigant may skip it.
+    assert validate_answers(_corpus(), {"county": ""}) == {}
+
+
+def test_absent_question_is_not_validated():
+    # A required field missing from the submission belongs to a section that
+    # wasn't posted — skipped, so no upfront error on an unreached section.
+    assert validate_answers(_corpus(), {"note": "hi"}) == {}
+
+
+def test_each_invalid_answer_is_keyed_by_its_question_id():
+    errors = validate_answers(
+        _corpus(), {"pub_date": "", "county": "Stark", "note": "fine"}
+    )
+    assert set(errors) == {"pub_date", "county"}

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -328,6 +328,87 @@ def test_post_stores_only_known_question_ids(client, monkeypatch):
     assert "not_a_question" not in flow
 
 
+# --- fact_gather POST validation (#525, needs DB) ---------------------------
+# The handler now validates against the corpus question defs before persisting:
+# empty `required` fields and `choice` answers outside the list are soft-gated
+# with inline errors (re-render, not PRG) and never stored. JS-off-safe.
+
+
+def _flow_answers(client):
+    return client.session.get("topic_flow", {}).get(
+        f"{COURT}/{TOPIC}/{ROLE}", {}
+    )
+
+
+@pytest.mark.django_db
+def test_post_empty_required_rerenders_in_place(client, monkeypatch):
+    # Invalid submit soft-gates: re-render 200 (so the inline error shows),
+    # not a PRG 302. A 302 would bounce the litigant forward past the gap.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(URL, {"publication_date": "", "filing_county": ""})
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_post_empty_required_is_not_persisted(client, monkeypatch):
+    # The blank required answer must not land in the store — otherwise the
+    # litigant could advance toward filing with a missing answer.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    client.post(URL, {"publication_date": "", "filing_county": ""})
+    assert "publication_date" not in _flow_answers(client)
+
+
+@pytest.mark.django_db
+def test_post_empty_required_marks_the_field_invalid(client, monkeypatch):
+    # The offending field carries aria-invalid="true" — the JS-off-safe a11y
+    # signal the form-field error pattern renders. Functional, not copy.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.post(
+        URL, {"publication_date": "", "filing_county": ""}
+    ).content.decode()
+    flat = re.sub(r"\s+", " ", html)
+    assert re.search(r'name="publication_date"[^>]*aria-invalid="true"', flat)
+
+
+@pytest.mark.django_db
+def test_post_choice_outside_list_is_rejected_not_stored(client, monkeypatch):
+    # A choice answer outside the declared options is dropped, never persisted
+    # (the silent-accept hole this issue closes).
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Stark"}
+    )
+    assert response.status_code == 200
+    assert "filing_county" not in _flow_answers(client)
+
+
+@pytest.mark.django_db
+def test_post_saves_valid_fields_even_when_a_sibling_is_invalid(
+    client, monkeypatch
+):
+    # Partial-invalid submit: the valid field still persists so the litigant
+    # doesn't lose good input on every fix-and-resubmit; only the bad one is
+    # flagged. (publication_date valid, filing_county out-of-list.)
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Stark"}
+    )
+    answers = _flow_answers(client)
+    assert answers.get("publication_date") == "2026-02-01"
+    assert "filing_county" not in answers
+
+
+@pytest.mark.django_db
+def test_post_all_valid_still_redirects_prg(client, monkeypatch):
+    # The happy path is unchanged: a fully valid submit persists and 302s (PRG).
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
+    )
+    assert response.status_code == 302
+    assert _flow_answers(client).get("filing_county") == "Cass"
+
+
 # --- ics deadline rendering (#494, needs DB) --------------------------------
 # The ics output renders a personalized deadline computed from the stored
 # answer — fact_gather → AnswerStore → compute_deadline → on-page date, JS off.

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -409,6 +409,31 @@ def test_post_all_valid_still_redirects_prg(client, monkeypatch):
     assert _flow_answers(client).get("filing_county") == "Cass"
 
 
+@pytest.mark.django_db
+def test_error_rerender_does_not_leak_rejected_value(client, monkeypatch):
+    # The soft-gate re-renders from the stored answers, not the raw submission,
+    # so a rejected choice ("Stark") appears nowhere — the fact_gather form
+    # flags it, but the summary section can't echo it as a saved answer. Guards
+    # against the page contradicting itself (form says "fix", summary says "ok").
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Stark"}
+    ).content.decode()
+    assert "Stark" not in html
+
+
+@pytest.mark.django_db
+def test_post_persists_stripped_value(client, monkeypatch):
+    # validate_answers checks the stripped value, so storage must strip too —
+    # else a padded choice validates but fails the strict option-selected match
+    # on re-render, and a padded date breaks date.fromisoformat downstream.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    client.post(
+        URL, {"publication_date": "2026-02-01", "filing_county": "Cass  "}
+    )
+    assert _flow_answers(client).get("filing_county") == "Cass"
+
+
 # --- ics deadline rendering (#494, needs DB) --------------------------------
 # The ics output renders a personalized deadline computed from the stored
 # answer — fact_gather → AnswerStore → compute_deadline → on-page date, JS off.

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -56,13 +56,23 @@ def _dispatch_key(section):
     return getattr(section, "output_type", None) or section.kind
 
 
-def render_section(section, corpus, answers):
-    """Render one section to a ``RenderedSection``, or raise if unhandled."""
+def render_section(section, corpus, answers, errors=None):
+    """Render one section to a ``RenderedSection``, or raise if unhandled.
+
+    ``errors`` is the optional ``{question_id: [message]}`` map from a failed
+    fact_gather POST. When present, each matching question dict gets its inline
+    errors so the form re-renders with them — injected here so the individual
+    renderers stay error-agnostic.
+    """
     key = _dispatch_key(section)
     handler = SECTION_RENDERERS.get(key)
     if handler is None:
         raise ValueError(f"No SectionRenderer handler registered for {key!r}")
-    return handler(section, corpus, answers)
+    rendered = handler(section, corpus, answers)
+    if errors and key == "fact_gather":
+        for question in rendered.context["questions"]:
+            question["errors"] = errors.get(question["id"], [])
+    return rendered
 
 
 @renderer("info")
@@ -86,6 +96,7 @@ def _render_fact_gather(section, corpus, answers):
             "choices": q.choices,
             "help_text": q.help_text,
             "value": answers.get(q.id, ""),
+            "errors": [],
         }
         for q in section.questions
     ]

--- a/litigant_portal/app/topic_flow/validation.py
+++ b/litigant_portal/app/topic_flow/validation.py
@@ -1,0 +1,42 @@
+"""Validate submitted fact_gather answers against the corpus question defs.
+
+Pure and DB-free, mirroring ``deadlines.py`` / ``contacts.py``. The Topic Flow
+POST handler calls this before persisting so a litigant can't advance past a
+fact_gather section with a missing ``required`` answer or a ``choice`` outside
+the declared list — the two holes the schema models and the renderer surfaces
+but the handler used to ignore. Returns ``{question_id: [message]}``; an empty
+dict means the submission is valid.
+
+Scoped to what was submitted: a fact_gather section POSTs only its own fields,
+so a question id absent from ``submitted`` belongs to a section that wasn't
+posted and is skipped — no upfront errors on sections the litigant hasn't
+reached yet.
+"""
+
+from django.utils.translation import gettext_lazy as _
+
+from litigant_portal.app.topic_flow.schema import FactGatherSection
+
+REQUIRED_ERROR = _("Please answer this before continuing.")
+INVALID_CHOICE_ERROR = _("Choose one of the listed options.")
+
+
+def validate_answers(corpus, submitted):
+    """Return ``{question_id: [error]}`` for invalid submitted answers."""
+    errors: dict[str, list] = {}
+    for section in corpus.sections:
+        if not isinstance(section, FactGatherSection):
+            continue
+        for question in section.questions:
+            if question.id not in submitted:
+                continue
+            value = (submitted.get(question.id) or "").strip()
+            if question.required and not value:
+                errors[question.id] = [REQUIRED_ERROR]
+            elif (
+                question.type == "choice"
+                and value
+                and value not in (question.choices or [])
+            ):
+                errors[question.id] = [INVALID_CHOICE_ERROR]
+    return errors

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -263,18 +263,26 @@ def topic_flow(request, court, topic, role):
             if qid in request.POST
         }
         errors = validate_answers(corpus, submitted)
-        # Persist only what passes — a blank required field or an out-of-list
-        # choice never lands in the store. Valid siblings still save, so a
-        # fix-and-resubmit doesn't discard good input alongside the bad.
-        valid = {qid: v for qid, v in submitted.items() if qid not in errors}
+        # Persist only what passes, canonicalized (stripped) to match what
+        # validate_answers checked — otherwise a padded-but-valid answer
+        # ("Cass  ") stores raw and fails the strict option-selected match on
+        # re-render, and a padded date breaks date.fromisoformat in the
+        # deadline compute. A blank required field or an out-of-list choice
+        # never lands in the store; valid siblings still save.
+        valid = {
+            qid: submitted[qid].strip()
+            for qid in submitted
+            if qid not in errors
+        }
         if valid:
             store.update(valid)
         if errors:
-            # Soft-gate: re-render in place (no PRG) with the submitted values
-            # overlaid and inline errors, so the litigant can fix and resubmit.
-            # Other sections still render — not a forward-only wizard.
-            answers = {**store.all(), **submitted}
-            return _render_topic_flow(request, corpus, answers, errors)
+            # Soft-gate: re-render in place (no PRG) with inline errors so the
+            # litigant can fix and resubmit. Render from the stored answers
+            # (not the raw submission), so a rejected value can't leak into the
+            # summary while the form flags it. Other sections still render —
+            # not a forward-only wizard.
+            return _render_topic_flow(request, corpus, store.all(), errors)
         # PRG back to the section just saved (#anchor) so the litigant keeps
         # their place and sees the recomputed deadlines, instead of the browser
         # jumping to the top of the page on the redirected GET.

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -22,6 +22,7 @@ from litigant_portal.app.topic_flow.renderer import (
     render_section,
     submitted_section_anchor,
 )
+from litigant_portal.app.topic_flow.validation import validate_answers
 
 TOPICS = {
     "eviction": {
@@ -261,7 +262,19 @@ def topic_flow(request, court, topic, role):
             for qid in question_ids(corpus)
             if qid in request.POST
         }
-        store.update(submitted)
+        errors = validate_answers(corpus, submitted)
+        # Persist only what passes — a blank required field or an out-of-list
+        # choice never lands in the store. Valid siblings still save, so a
+        # fix-and-resubmit doesn't discard good input alongside the bad.
+        valid = {qid: v for qid, v in submitted.items() if qid not in errors}
+        if valid:
+            store.update(valid)
+        if errors:
+            # Soft-gate: re-render in place (no PRG) with the submitted values
+            # overlaid and inline errors, so the litigant can fix and resubmit.
+            # Other sections still render — not a forward-only wizard.
+            answers = {**store.all(), **submitted}
+            return _render_topic_flow(request, corpus, answers, errors)
         # PRG back to the section just saved (#anchor) so the litigant keeps
         # their place and sees the recomputed deadlines, instead of the browser
         # jumping to the top of the page on the redirected GET.
@@ -274,9 +287,19 @@ def topic_flow(request, court, topic, role):
             url = f"{url}#{anchor}"
         return redirect(url)
 
-    answers = store.all()
+    return _render_topic_flow(request, corpus, store.all())
+
+
+def _render_topic_flow(request, corpus, answers, errors=None):
+    """Render the full Topic Flow page from resolved answers.
+
+    Shared by the GET path and the POST error re-render. ``errors`` (a
+    ``{question_id: [message]}`` map) threads into ``render_section`` so a
+    failed fact_gather submit shows inline errors; ``None`` on a clean render.
+    """
     rendered_sections = [
-        render_section(section, corpus, answers) for section in corpus.sections
+        render_section(section, corpus, answers, errors)
+        for section in corpus.sections
     ]
     # Table of contents for the in-header wayfinding menu — one entry per
     # headed section, so a litigant can jump back to re-read or revise.


### PR DESCRIPTION
The corpus schema models `required` and `choices` per question, but the Topic Flow POST handler stored whatever was submitted — empty `required` fields persisted blank and `choice` answers outside the declared list were accepted silently. For an a2j flow that lets a litigant advance toward filing with missing or invalid answers (a wrong computed deadline, an incomplete packet). It's also a prerequisite for the docassemble handoff — we can't responsibly hand off empty/invalid required answers.

## What changed
- New pure `validate_answers(corpus, submitted)` → `{qid: [msg]}` for empty `required` and out-of-list `choice`. Scoped to submitted qids, so unreached sections don't error.
- POST handler persists only the **valid subset** (valid siblings still save), and on errors **soft-gates**: re-renders in place (no PRG) with submitted values overlaid + inline errors via the existing `form-field` pattern. JS-off-safe, not a forward-only wizard.
- `render_section` gained an optional `errors` map, injected into the fact_gather context only (other renderers untouched).
- Template surfaces `:errors` on both field components (atoms already emit `aria-invalid` + the red message).

Closes #525

## Test plan
- [ ] `make lint && make test`
- 8 unit tests (`test_topic_flow_validation.py`, fast suite): empty/whitespace required, valid required, choice in/out of list, empty optional choice, absent-question skip, multi-error keying
- 6 view tests: empty-required → 200 + not persisted + `aria-invalid`; invalid choice → dropped; partial → valid sibling saved; all-valid → 302 (PRG unchanged)