### PR TITLE
feat(topic-flow): add ND name-change contact phone/email

### DIFF
--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -23,11 +23,14 @@ contacts:
     note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge. This is the one call to make first."
   - id: self_help
     name: 'North Dakota Legal Self Help Center'
+    phone: '(701) 328-1852'
+    email: 'ndselfhelp@ndcourts.gov'
     url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'Court-provided guidance and the official name-change forms for self-represented filers.'
+    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers — not legal advice, and not criminal matters.'
   - id: legal_aid
     name: 'Legal Services of North Dakota'
-    note: 'Free legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter.'
+    phone: '(800) 634-5263'
+    note: 'Free civil legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter. This line is for filers under 60; if you are 60 or older, call (866) 621-9886.'
 
 deadlines:
   - id: publication_wait

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -27,11 +27,14 @@ contacts:
     note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge, and the waiver track does not remove this. This is the one call to make first."
   - id: self_help
     name: 'North Dakota Legal Self Help Center'
+    phone: '(701) 328-1852'
+    email: 'ndselfhelp@ndcourts.gov'
     url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'Court-provided guidance and the official name-change forms for self-represented filers.'
+    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers — not legal advice, and not criminal matters.'
   - id: legal_aid
     name: 'Legal Services of North Dakota'
-    note: 'Free legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter.'
+    phone: '(800) 634-5263'
+    note: 'Free civil legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter. This line is for filers under 60; if you are 60 or older, call (866) 621-9886.'
 
 sections:
   - kind: info


### PR DESCRIPTION
The `self_help` and `legal_aid` corpus contacts had no phone/email, so no `tel:`/`mailto:` affordances rendered. Adds verified ndcourts.gov numbers — North Dakota Legal Self Help Center ((701) 328-1852 / ndselfhelp@ndcourts.gov) and Legal Services of North Dakota ((800) 634-5263; the 60+ intake line noted) — on both the standard and waiver tracks. Also tightens the `self_help` note to its accurate scope: the Center provides civil-process *information* (not legal advice, not the forms, not criminal matters), correcting the prior "official name-change forms" wording.

Part of #495

## Test plan
- [ ] `make lint && make test`
- Content-only change to the two corpus YAMLs; contacts render through the existing vcf/contact path, with `tel:`/`mailto:` now populated.