### PR TITLE
feat(topic-flow): link packet forms to their official PDFs

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
@@ -6,7 +6,13 @@
 {# => plain form list, so existing corpora are unaffected. #}
 <ul class="list-disc space-y-1 pl-5 text-greyscale-700">
   {% for form in ctx.forms %}
-  <li>{{ form }}</li>
+  <li>
+    {% if form.url %}
+    <c-atoms.link href="{{ form.url }}" target="_blank" external_icon="true">{{ form.name }}</c-atoms.link>
+    {% else %}
+    {{ form.name }}
+    {% endif %}
+  </li>
   {% endfor %}
 </ul>
 

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -169,7 +169,29 @@ def test_packet_renders_form_list():
     )
     rendered = render_section(section, _corpus(section), {})
     assert rendered.heading == "Your packet"
-    assert rendered.context["forms"] == ["Petition for Name Change", "Order"]
+    # Bare-string forms surface as unlinked {name, url: None} entries.
+    assert rendered.context["forms"] == [
+        {"name": "Petition for Name Change", "url": None},
+        {"name": "Order", "url": None},
+    ]
+
+
+def test_packet_form_url_reaches_the_template_context():
+    # A linked form carries its official-PDF url through to the template, which
+    # renders the name as a link to it.
+    pdf = "https://www.ndcourts.gov/.../Petition-Name-Change-Adult.pdf"
+    section = PacketOutput(
+        kind="output",
+        output_type="packet",
+        id="forms",
+        heading="Your packet",
+        forms=[{"name": "Petition for Name Change", "url": pdf}],
+    )
+    rendered = render_section(section, _corpus(section), {})
+    assert rendered.context["forms"][0] == {
+        "name": "Petition for Name Change",
+        "url": pdf,
+    }
 
 
 def test_packet_without_interview_url_exposes_none():

--- a/litigant_portal/app/tests/test_topic_flow_schema.py
+++ b/litigant_portal/app/tests/test_topic_flow_schema.py
@@ -10,7 +10,11 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from litigant_portal.app.topic_flow.schema import Corpus, PacketOutput
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    PacketForm,
+    PacketOutput,
+)
 
 FIXTURE = Path(__file__).resolve().parents[2] / "content" / "_test_fixture.yml"
 
@@ -112,3 +116,65 @@ def test_packet_interview_url_optional_and_accepted():
         ).interview_url
         == url
     )
+
+
+def test_packet_form_bare_string_coerces_to_unlinked_form():
+    # Authoring shorthand: a plain string is the form name with no link, so
+    # existing string-only corpora keep validating unchanged.
+    packet = PacketOutput.model_validate(
+        {
+            "kind": "output",
+            "output_type": "packet",
+            "id": "p",
+            "heading": "Your packet",
+            "forms": ["Petition for Name Change"],
+        }
+    )
+    assert packet.forms == [
+        PacketForm(name="Petition for Name Change", url=None)
+    ]
+
+
+def test_packet_form_object_carries_its_url():
+    pdf = "https://www.ndcourts.gov/.../Petition-Name-Change-Adult.pdf"
+    packet = PacketOutput.model_validate(
+        {
+            "kind": "output",
+            "output_type": "packet",
+            "id": "p",
+            "heading": "Your packet",
+            "forms": [{"name": "Petition for Name Change", "url": pdf}],
+        }
+    )
+    assert packet.forms[0].url == pdf
+
+
+def test_packet_forms_may_mix_linked_and_unlinked():
+    packet = PacketOutput.model_validate(
+        {
+            "kind": "output",
+            "output_type": "packet",
+            "id": "p",
+            "heading": "Your packet",
+            "forms": [
+                "Notice",
+                {"name": "Petition", "url": "https://ex/p.pdf"},
+            ],
+        }
+    )
+    assert packet.forms[0].url is None
+    assert packet.forms[1].url == "https://ex/p.pdf"
+
+
+def test_packet_form_rejects_unknown_key():
+    # extra="forbid" — a typo'd form key fails loud instead of silently dropping.
+    with pytest.raises(ValidationError):
+        PacketOutput.model_validate(
+            {
+                "kind": "output",
+                "output_type": "packet",
+                "id": "p",
+                "heading": "Your packet",
+                "forms": [{"name": "Petition", "ulr": "https://typo"}],
+            }
+        )

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -200,6 +200,36 @@ def test_packet_section_lists_each_form(client, monkeypatch):
     assert "Petition for Name Change" in html
 
 
+@pytest.mark.django_db
+def test_packet_form_with_url_renders_as_link(client, monkeypatch):
+    # A form that carries a url renders its name as a link to the official PDF
+    # (#495); a name-only form stays plain text. Functional target, not markup.
+    pdf = "https://www.ndcourts.gov/petition.pdf"
+    corpus = Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        sections=[
+            PacketOutput(
+                kind="output",
+                output_type="packet",
+                id="filing_packet",
+                heading="Your filing packet",
+                forms=[
+                    {"name": "Petition for Name Change", "url": pdf},
+                    "Confidential Information Form",
+                ],
+            ),
+        ],
+    )
+    monkeypatch.setattr(pages.registry, "get", lambda *a: corpus)
+    flat = re.sub(r"\s+", " ", client.get(URL).content.decode())
+    # Linked form → anchor to its PDF; name-only form → present, unlinked.
+    assert re.search(
+        rf'<a[^>]*href="{re.escape(pdf)}"[^>]*>[^<]*Petition for Name Change',
+        flat,
+    )
+    assert "Confidential Information Form" in flat
+
+
 def _field_tag(html, name):
     """The <input>/<select> element whose name == ``name``, whitespace flattened.
 

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -171,7 +171,9 @@ def _render_packet(section, corpus, answers):
         heading=section.heading,
         template=f"{_TEMPLATE_DIR}/flow_section_packet.html",
         context={
-            "forms": list(section.forms),
+            "forms": [
+                {"name": form.name, "url": form.url} for form in section.forms
+            ],
             "interview_url": section.interview_url,
         },
     )

--- a/litigant_portal/app/topic_flow/schema.py
+++ b/litigant_portal/app/topic_flow/schema.py
@@ -13,7 +13,7 @@ span sibling lists, so they live in ``loader.py`` rather than here.
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 # Shared slug shape for court/topic/role and every id — alphanumeric start,
 # then alphanumeric / underscore / hyphen. Mirrors the chat/prompts slug rule.
@@ -101,12 +101,31 @@ class VcfOutput(_Base):
     contact_ids: list[Slug] = Field(min_length=1)
 
 
+class PacketForm(_Base):
+    """One court form in a packet — a name, optionally linked to its official PDF.
+
+    Authoring shorthand: a bare string is the form name with no link, so
+    ``forms: ['Petition', ...]`` keeps working. An object adds the link:
+    ``- {name: 'Petition', url: 'https://…/petition.pdf'}``.
+    """
+
+    name: str = Field(min_length=1)
+    url: str | None = None
+
+
+def _as_packet_form(value):
+    return {"name": value} if isinstance(value, str) else value
+
+
+PacketFormEntry = Annotated[PacketForm, BeforeValidator(_as_packet_form)]
+
+
 class PacketOutput(_Base):
     kind: Literal["output"]
     output_type: Literal["packet"]
     id: Slug
     heading: str = Field(min_length=1)
-    forms: list[str] = Field(min_length=1)
+    forms: list[PacketFormEntry] = Field(min_length=1)
     # Optional warm handoff to a docassemble interview that fills these forms.
     # Unset (None) => the packet renders as a plain form list, so existing
     # corpora are unaffected. v1 is link-out + manual return, no prefill (#543).

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -110,11 +110,16 @@ sections:
     id: filing_packet
     heading: 'Your filing packet'
     forms:
-      - 'Notice of Petition for Name Change'
-      - 'Petition for Name Change'
-      - 'Declaration in Support of Petition'
-      - 'Confidential Information Form'
-      - 'Proposed Order for Name Change'
+      - name: 'Notice of Petition for Name Change'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Notice-of-name-change-adult.pdf'
+      - name: 'Petition for Name Change'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Petition-Name-Change-Adult.pdf'
+      - name: 'Declaration in Support of Petition'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Declaration-name-change-adult.pdf'
+      - name: 'Confidential Information Form'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Confidential-info-form-adult.pdf'
+      - name: 'Proposed Order for Name Change'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Order-name-change-adult.pdf'
     # Warm link-out to the docassemble interview that fills these forms (#547,
     # #531). Standard (publish) track. docassemble is hosted under the /interview/
     # prefix on QA, so the launch path is /interview/interview?i=... (the prefix

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -100,10 +100,14 @@ sections:
     id: filing_packet
     heading: 'Your filing packet'
     forms:
-      - 'Petition for Name Change'
-      - 'Declaration in Support of Petition'
-      - 'Confidential Information Form'
-      - 'Proposed Order for Name Change'
+      - name: 'Petition for Name Change'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Petition-Name-Change-Adult.pdf'
+      - name: 'Declaration in Support of Petition'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Declaration-name-change-adult.pdf'
+      - name: 'Confidential Information Form'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Confidential-info-form-adult.pdf'
+      - name: 'Proposed Order for Name Change'
+        url: 'https://www.ndcourts.gov/Media/Default/Legal%20Resources/Legal%20Self%20Help/Name%20Change/Order-name-change-adult.pdf'
     # Warm link-out to the docassemble interview that fills these forms (#547,
     # #531). Waiver (publication-waived) track — a separate interview from the
     # standard track. Hosted under the /interview/ prefix on QA, so the launch


### PR DESCRIPTION
`PacketOutput.forms` accepted only names (`list[str]`), so the filing packet listed forms as plain text with no path to the official documents — and the engine had no way to surface form links (info-body links #518 and resource links #519 are unbuilt). The packet is the natural home for them.

Each form may now optionally carry a `url`: a bare string stays an unlinked name (back-compat via a `BeforeValidator`, so the test fixture, the waiver track, and existing corpora are unaffected), while `{name, url}` renders the name as a link to its PDF (new tab + external-link affordance through `c-atoms.link`). Wires the verified ndcourts.gov name-change form PDFs into both ND tracks (5 standard, 4 waiver).

Part of #495. Relates to #519 (first-class resource links).

## Test plan
- [ ] `make lint && make test`
- Schema: bare-string coercion, `{name, url}`, mixed list, unknown-key fails
- Renderer: context updated to `{name, url}` shape + url-in-context
- View: packet form renders as a link when `url` is present, plain text when not