### PR TITLE
feat(chat): implement hidden messages

### DIFF
--- a/docs/AGENT_DEV_GUIDE.md
+++ b/docs/AGENT_DEV_GUIDE.md
@@ -375,44 +375,62 @@ engine then derives two views explicitly:
 ## Conversation history: hidden & compaction messages
 
 Two message capabilities extend the history model without changing how agents
-are authored. Both are pure engine behavior driven by per-message flags — agents
-and tools opt in, the engine does the rest.
+are authored. Both are engine behavior driven by per-message flags — agents and
+tools opt in, the engine does the rest.
 
 ### Hidden messages
 
-A **hidden message** exists in the conversation history that the model sees, but
-is **never returned to the frontend**. It's flagged `hidden=True` on the message.
+A **hidden message** lives in the history the model sees but is **never returned
+to the frontend**. It's the `hidden` boolean on `ChatMessage`, and it's the
+practical face of the engine's "one store, two projections" split:
 
-- **LLM view** (`_to_llm_message` / history sent to litellm): hidden messages
-  are **included** — the model reads them like any other turn.
-- **Render view** (`thread_render_items` + the live stream): hidden messages are
-  **excluded** — no card, no bubble, no SSE content for them.
+- **LLM view** — `chat_message_list(thread=…)` returns _all_ messages, hidden
+  included, and `chat_stream` feeds that to litellm. The model reads a hidden
+  message like any other turn.
+- **Render view** — `chat_message_list_visible(thread=…)` is just
+  `chat_message_list(...).filter(hidden=False)`. Both frontend projections use
+  it: `thread_render_items` (thread reload) and the `thread_list` sidebar
+  snippet. A hidden message gets no bubble, no card, and never seeds a snippet.
 
 Use it for context the model should have but the user shouldn't see as a chat
-turn: injected retrieval results, scaffolding/setup instructions, a tool that
-records a note for later reasoning, or developer guidance mid-conversation. A
-tool can emit one by writing a hidden message to the thread; the engine simply
-skips it when projecting for the frontend.
+turn: injected retrieval results, scaffolding/setup instructions, a note a tool
+records for later reasoning, or developer guidance mid-conversation.
 
-### Compaction messages
+**Injecting one** — `chat_message_inject_hidden` (in `services/chat_v2.py`):
+
+```python
+from litigant_portal.app.services.chat_v2 import chat_message_inject_hidden
+
+chat_message_inject_hidden(
+    thread_id=thread_id,
+    content="<retrieved statute text the model should ground on>",
+    role="user",  # default; "assistant" / "system" also valid
+)
+```
+
+It's keyed by `thread_id`, so a tool can call it straight from `__call__`. The
+message is stored with `hidden=True` and deliberately does **not** bump the
+thread's `updated_at` — injecting context never reorders the sidebar or changes
+the snippet.
+
+### Compaction messages _(designed; not yet implemented)_
 
 A **compaction message** is an engine-generated summary that lets a thread grow
-indefinitely while keeping per-request token cost bounded. It's flagged
-`is_compacted=True` and its content is a condensed summary of everything before
-it.
+indefinitely while keeping per-request token cost bounded. It would be flagged
+`is_compacted=True`, with content that condenses everything before it.
 
-- When a thread crosses a **token threshold**, the engine generates a summary of
-  the conversation so far and stores it as a compaction message.
-- On history retrieval **for the model**, the engine reads **only from the most
-  recent compaction message onward** — the summary stands in for all prior
+- When a thread crosses a **token threshold**, the engine would generate a
+  summary of the conversation so far and store it as a compaction message.
+- On history retrieval **for the model**, it would read **only from the most
+  recent compaction message onward** — the summary standing in for all prior
   turns. Older messages stay in the database but cost nothing per request.
-- The **frontend still shows the full history** (with a subtle "summarized
+- The **frontend would still show the full history** (with a subtle "summarized
   earlier" divider), so the user experiences one continuous, effectively
   infinite chat.
 
-Together with hidden messages, this keeps the LLM view lean and intentional
-while the render view stays complete — the same "one store, two projections"
-principle the engine already uses for tool data.
+Like hidden messages, this keeps the LLM view lean and intentional while the
+render view stays complete — the same "one store, two projections" principle the
+engine already uses for tool data and hidden messages.
 
 ---
 

--- a/litigant_portal/app/selectors/chat_v2.py
+++ b/litigant_portal/app/selectors/chat_v2.py
@@ -14,5 +14,10 @@ def chat_thread_get(*, identity: UserIdentity, thread_id) -> ChatThread:
 
 
 def chat_message_list(*, thread: ChatThread) -> QuerySet[ChatMessage]:
-    """Messages in a thread, oldest first."""
+    """All messages in a thread, oldest first (includes hidden)."""
     return thread.messages.order_by("created_at")
+
+
+def chat_message_list_visible(*, thread: ChatThread) -> QuerySet[ChatMessage]:
+    """Frontend-safe messages: the thread's messages minus hidden ones."""
+    return chat_message_list(thread=thread).filter(hidden=False)

--- a/litigant_portal/app/services/chat_v2.py
+++ b/litigant_portal/app/services/chat_v2.py
@@ -11,6 +11,7 @@ from litigant_portal.agents_v2.base import Agent, ToolOutput
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
 from litigant_portal.app.selectors.chat_v2 import (
     chat_message_list,
+    chat_message_list_visible,
     chat_thread_get,
 )
 
@@ -22,6 +23,17 @@ MAX_STEPS = 30
 def chat_thread_delete(*, identity: UserIdentity, thread_id: str) -> None:
     """Delete a thread (and its messages, via cascade) owned by the identity."""
     chat_thread_get(identity=identity, thread_id=thread_id).delete()
+
+
+def chat_message_inject_hidden(
+    *, thread_id, content: str, role: str = "user"
+) -> ChatMessage:
+    """Append a hidden message to a thread's history."""
+    return ChatMessage.objects.create(
+        thread_id=thread_id,
+        data={"role": role, "content": content},
+        hidden=True,
+    )
 
 
 def _resolve_thread(
@@ -122,7 +134,7 @@ def thread_render_items(
     """Project a thread's stored messages into frontend render items."""
     agent = agent_class()
     tools = agent.tools_by_name
-    messages = [dict(m.data) for m in chat_message_list(thread=thread)]
+    messages = [dict(m.data) for m in chat_message_list_visible(thread=thread)]
     results = {
         m.get("tool_call_id"): m for m in messages if m.get("role") == "tool"
     }

--- a/litigant_portal/app/tests/test_chat_v2_hidden.py
+++ b/litigant_portal/app/tests/test_chat_v2_hidden.py
@@ -1,0 +1,121 @@
+"""Tests for hidden-message behavior in the chat_v2 engine.
+
+These pin the behavioral contract: hidden messages stay in the LLM history but
+are excluded from every frontend projection, and injecting one doesn't disturb
+the thread's ordering.
+"""
+
+import json
+
+import pytest
+from django.test import Client, TestCase
+
+from litigant_portal.agents_v2 import WeatherAgent
+from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+from litigant_portal.app.selectors.chat_v2 import (
+    chat_message_list,
+    chat_message_list_visible,
+)
+from litigant_portal.app.services.chat_v2 import (
+    _messages_for_llm,
+    chat_message_inject_hidden,
+    thread_render_items,
+)
+
+
+@pytest.mark.postgres
+class InjectHiddenMessageTests(TestCase):
+    """chat_message_inject_hidden stores hidden=True without bumping the thread."""
+
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="inject")
+        self.thread = ChatThread.objects.create(identity=self.identity)
+
+    def test_stores_hidden_message(self):
+        message = chat_message_inject_hidden(
+            thread_id=self.thread.id, content="context"
+        )
+        self.assertTrue(message.hidden)
+        self.assertEqual(message.data["role"], "user")
+        self.assertEqual(message.data["content"], "context")
+
+    def test_does_not_bump_thread_updated_at(self):
+        before = ChatThread.objects.get(pk=self.thread.pk).updated_at
+        chat_message_inject_hidden(thread_id=self.thread.id, content="context")
+        after = ChatThread.objects.get(pk=self.thread.pk).updated_at
+        self.assertEqual(after, before)
+
+
+@pytest.mark.postgres
+class ChatMessageListVisibilityTests(TestCase):
+    """chat_message_list includes hidden; chat_message_list_visible excludes it."""
+
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="visibility")
+        self.thread = ChatThread.objects.create(identity=self.identity)
+        self.visible = ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "shown"},
+        )
+        self.hidden = ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "secret"},
+            hidden=True,
+        )
+
+    def test_full_list_includes_hidden(self):
+        ids = set(
+            chat_message_list(thread=self.thread).values_list("id", flat=True)
+        )
+        self.assertEqual(ids, {self.visible.id, self.hidden.id})
+
+    def test_visible_list_excludes_hidden(self):
+        ids = set(
+            chat_message_list_visible(thread=self.thread).values_list(
+                "id", flat=True
+            )
+        )
+        self.assertEqual(ids, {self.visible.id})
+
+
+@pytest.mark.postgres
+class HiddenMessageProjectionTests(TestCase):
+    """A hidden message reaches the LLM but not the frontend projections."""
+
+    def setUp(self):
+        self.client = Client()
+        # First request establishes a session + identity for the client.
+        self.client.get("/api/chat/threads/")
+        self.identity = UserIdentity.objects.get(
+            session_key=self.client.session.session_key
+        )
+        self.thread = ChatThread.objects.create(identity=self.identity)
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "visible question"},
+        )
+        chat_message_inject_hidden(
+            thread_id=self.thread.id, content="HIDDEN CONTEXT"
+        )
+
+    def test_hidden_reaches_llm_history(self):
+        history = [dict(m.data) for m in chat_message_list(thread=self.thread)]
+        contents = [m["content"] for m in _messages_for_llm("sys", history)]
+        self.assertIn("HIDDEN CONTEXT", contents)
+
+    def test_hidden_excluded_from_render_items(self):
+        items = thread_render_items(
+            thread=self.thread, agent_class=WeatherAgent
+        )
+        contents = [item.get("content") for item in items]
+        self.assertIn("visible question", contents)
+        self.assertNotIn("HIDDEN CONTEXT", contents)
+
+    def test_hidden_excluded_from_sidebar_snippet(self):
+        data = json.loads(self.client.get("/api/chat/threads/").content)
+        snippet = next(
+            t["snippet"]
+            for t in data["threads"]
+            if t["id"] == str(self.thread.id)
+        )
+        self.assertEqual(snippet, "visible question")

--- a/litigant_portal/app/views/chat_v2.py
+++ b/litigant_portal/app/views/chat_v2.py
@@ -6,7 +6,7 @@ from django_ratelimit.decorators import ratelimit
 from litigant_portal.agents_v2 import WeatherAgent
 from litigant_portal.app.models import ChatThread
 from litigant_portal.app.selectors.chat_v2 import (
-    chat_message_list,
+    chat_message_list_visible,
     chat_thread_get,
     chat_thread_list,
 )
@@ -25,7 +25,7 @@ def thread_list(request: HttpRequest) -> JsonResponse:
     """List the current identity's chat threads."""
     threads = []
     for thread in chat_thread_list(identity=request.identity):
-        messages = list(chat_message_list(thread=thread))
+        messages = list(chat_message_list_visible(thread=thread))
         last = messages[-1] if messages else None
         snippet = next(
             (


### PR DESCRIPTION
Fixes #577

Adds hidden-message support to the chat_v2 engine: messages flagged hidden remain in the history sent to the LLM but are excluded from everything sent to the frontend (thread reloads and sidebar snippets) via a new chat_message_list_visible selector. Includes a chat_message_inject_hidden service helper for seeding hidden context into a thread, and updates AGENT_DEV_GUIDE.md to document the feature.