### PR TITLE
feat(topic-flow): first-class official resource links

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_section_resources.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_resources.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+{# resources output body: official/jurisdictional links for the flow (court #}
+{# self-help center, statutes, forms index), supplied by the corpus as data #}
+{# (#519). Server-rendered and JS-off — real <a> links, external-link icon + #}
+{# rel="noopener noreferrer" via the link atom. Replaces smuggling official #}
+{# URLs into contact cards or unclickable info-body text. #}
+<ul class="space-y-3">
+  {% for resource in ctx.resources %}
+  <li>
+    <c-atoms.link href="{{ resource.url }}" target="_blank" external_icon="true">{{ resource.label }}</c-atoms.link>
+    {% if resource.note %}
+    <p class="text-sm text-greyscale-500">{{ resource.note }}</p>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>

--- a/litigant_portal/app/tests/test_topic_flow_loader.py
+++ b/litigant_portal/app/tests/test_topic_flow_loader.py
@@ -10,8 +10,10 @@ from litigant_portal.app.topic_flow.loader import (
     CorpusLoader,
     CorpusValidationError,
 )
+from litigant_portal.app.topic_flow.schema import ResourcesOutput
 
-FIXTURE = Path(__file__).resolve().parents[2] / "content" / "_test_fixture.yml"
+CONTENT = Path(__file__).resolve().parents[2] / "content"
+FIXTURE = CONTENT / "_test_fixture.yml"
 
 # A minimal schema-valid corpus: one fact_gather question, no deadlines or
 # outputs. Tests deep-copy and mutate this to introduce specific problems.
@@ -177,3 +179,20 @@ def test_problems_aggregate_into_one_error(tmp_path):
     assert any("ghostq" in p for p in problems)
     assert any("ghostd" in p for p in problems)
     assert len(problems) >= 2
+
+
+# The cross-reference and schema tests above run against tmp_path fixtures; this
+# one loads the real shipped ND corpora so a typo'd resource_id (or any dangling
+# reference) in the live YAML fails CI, not just at runtime. Loading succeeds
+# only if every id-reference resolves, so a clean load is itself the assertion.
+@pytest.mark.parametrize(
+    "name",
+    ["adult-name-change-standard.yml", "adult-name-change-waiver.yml"],
+)
+def test_real_nd_corpus_loads_and_wires_its_resources(name):
+    corpus = CorpusLoader.load(CONTENT / name)
+    outputs = [s for s in corpus.sections if isinstance(s, ResourcesOutput)]
+    assert outputs, f"{name} has no resources output section"
+    declared = {r.id for r in corpus.resources}
+    for out in outputs:
+        assert set(out.resource_ids) <= declared

--- a/litigant_portal/app/tests/test_topic_flow_loader.py
+++ b/litigant_portal/app/tests/test_topic_flow_loader.py
@@ -42,7 +42,7 @@ def _write_text(tmp_path, text):
 def test_load_valid_fixture():
     corpus = CorpusLoader.load(FIXTURE)
     assert corpus.metadata.topic == "test_topic"
-    assert len(corpus.sections) == 6
+    assert len(corpus.sections) == 7
 
 
 def test_missing_file_raises_with_path(tmp_path):
@@ -125,6 +125,35 @@ def test_duplicate_contact_id_detected(tmp_path):
     with pytest.raises(CorpusValidationError) as exc:
         CorpusLoader.load(path)
     assert any("duplicate contact id: 'dup'" in p for p in exc.value.problems)
+
+
+def test_resources_output_unknown_resource(tmp_path):
+    data = copy.deepcopy(VALID)
+    data["sections"].append(
+        {
+            "kind": "output",
+            "output_type": "resources",
+            "id": "o",
+            "heading": "H",
+            "resource_ids": ["ghost"],
+        }
+    )
+    path = _write(tmp_path, data)
+    with pytest.raises(CorpusValidationError) as exc:
+        CorpusLoader.load(path)
+    assert any("unknown resource 'ghost'" in p for p in exc.value.problems)
+
+
+def test_duplicate_resource_id_detected(tmp_path):
+    data = copy.deepcopy(VALID)
+    data["resources"] = [
+        {"id": "dup", "label": "A", "url": "https://ex/a"},
+        {"id": "dup", "label": "B", "url": "https://ex/b"},
+    ]
+    path = _write(tmp_path, data)
+    with pytest.raises(CorpusValidationError) as exc:
+        CorpusLoader.load(path)
+    assert any("duplicate resource id: 'dup'" in p for p in exc.value.problems)
 
 
 def test_problems_aggregate_into_one_error(tmp_path):

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -29,16 +29,19 @@ from litigant_portal.app.topic_flow.schema import (
     Metadata,
     PacketOutput,
     Question,
+    Resource,
+    ResourcesOutput,
     SummaryOutput,
     VcfOutput,
 )
 
 
-def _corpus(*sections, deadlines=None, contacts=None):
+def _corpus(*sections, deadlines=None, contacts=None, resources=None):
     return Corpus(
         metadata=Metadata(court="c", topic="t", role="r", title="T"),
         deadlines=deadlines or [],
         contacts=contacts or [],
+        resources=resources or [],
         sections=list(sections),
     )
 
@@ -236,12 +239,26 @@ def test_each_kind_dispatches_to_a_distinct_template():
     packet = PacketOutput(
         kind="output", output_type="packet", id="p", heading="P", forms=["F"]
     )
-    corpus = _corpus(info, fg, summ, packet)
+    resources = ResourcesOutput(
+        kind="output",
+        output_type="resources",
+        id="r",
+        heading="R",
+        resource_ids=["help"],
+    )
+    corpus = _corpus(
+        info,
+        fg,
+        summ,
+        packet,
+        resources,
+        resources=[Resource(id="help", label="Help", url="https://ex/help")],
+    )
     templates = {
         render_section(s, corpus, {}).template
-        for s in (info, fg, summ, packet)
+        for s in (info, fg, summ, packet, resources)
     }
-    assert len(templates) == 4  # four kinds → four distinct templates
+    assert len(templates) == 5  # five kinds → five distinct templates
     assert all(t for t in templates)  # all non-empty
 
 
@@ -443,6 +460,60 @@ def test_vcf_uses_the_vcf_template():
     corpus, vcf = _vcf_corpus()
     rendered = render_section(vcf, corpus, {})
     assert rendered.template.endswith("flow_section_vcf.html")
+
+
+# --- resources (official link rendering, #519) ------------------------------
+# The resources output resolves corpus-level Resource entries by id, in the
+# section's declared order, to flat dicts the template binds as <a> links.
+# Page-only — no download artifact — so the resolve is inline in the renderer.
+
+_GUIDANCE = Resource(
+    id="guidance",
+    label="Name-change guidance",
+    url="https://ex/help/name-change",
+    note="Official process page.",
+)
+
+
+def _resources_corpus(resource_ids=("guidance",), resources=(_GUIDANCE,)):
+    section = ResourcesOutput(
+        kind="output",
+        output_type="resources",
+        id="official",
+        heading="Official resources",
+        resource_ids=list(resource_ids),
+    )
+    corpus = _corpus(section, resources=list(resources))
+    return corpus, section
+
+
+def test_resources_renders_referenced_resource():
+    corpus, section = _resources_corpus()
+    (r,) = render_section(section, corpus, {}).context["resources"]
+    assert r["label"] == "Name-change guidance"
+    assert r["url"] == "https://ex/help/name-change"
+    assert r["note"] == "Official process page."
+
+
+def test_resources_listed_in_resource_ids_order():
+    center = Resource(
+        id="center", label="Self-help center", url="https://ex/c"
+    )
+    corpus, section = _resources_corpus(
+        resource_ids=("center", "guidance"),
+        resources=(_GUIDANCE, center),
+    )
+    resources = render_section(section, corpus, {}).context["resources"]
+    assert [r["label"] for r in resources] == [
+        "Self-help center",
+        "Name-change guidance",
+    ]
+
+
+def test_resources_uses_the_resources_template():
+    corpus, section = _resources_corpus()
+    rendered = render_section(section, corpus, {})
+    assert rendered.template.endswith("flow_section_resources.html")
 
 
 # --- submitted_section_anchor (PRG scroll restore, #510) --------------------

--- a/litigant_portal/app/tests/test_topic_flow_schema.py
+++ b/litigant_portal/app/tests/test_topic_flow_schema.py
@@ -14,6 +14,7 @@ from litigant_portal.app.topic_flow.schema import (
     Corpus,
     PacketForm,
     PacketOutput,
+    Resource,
 )
 
 FIXTURE = Path(__file__).resolve().parents[2] / "content" / "_test_fixture.yml"
@@ -31,6 +32,7 @@ def test_fixture_routes_to_concrete_section_types():
         "IcsOutput",
         "VcfOutput",
         "PacketOutput",
+        "ResourcesOutput",
         "SummaryOutput",
     ]
 
@@ -178,3 +180,44 @@ def test_packet_form_rejects_unknown_key():
                 "forms": [{"name": "Petition", "ulr": "https://typo"}],
             }
         )
+
+
+def test_resource_requires_a_url():
+    # A resource *is* a link — unlike Contact.url, the url is mandatory, so a
+    # resource that would render as an unclickable label fails loud.
+    with pytest.raises(ValidationError):
+        Resource(id="r", label="Self-help page")
+
+
+def test_resource_carries_label_url_and_optional_note():
+    bare = Resource(id="r", label="Self-help", url="https://ex/help")
+    assert bare.note is None
+    noted = Resource(
+        id="r", label="Self-help", url="https://ex/help", note="Official page."
+    )
+    assert noted.note == "Official page."
+
+
+def test_resource_rejects_unknown_key():
+    # extra="forbid" — a typo'd key fails loud instead of silently dropping.
+    with pytest.raises(ValidationError):
+        Resource.model_validate(
+            {"id": "r", "label": "L", "url": "https://ex", "lable": "typo"}
+        )
+
+
+def test_resources_output_requires_at_least_one_reference():
+    # min_length=1 — an empty resources section is an authoring mistake, not a
+    # silently-empty list.
+    data = _fixture()
+    data["sections"] = [
+        {
+            "kind": "output",
+            "output_type": "resources",
+            "id": "official",
+            "heading": "Official resources",
+            "resource_ids": [],
+        }
+    ]
+    with pytest.raises(ValidationError):
+        Corpus.model_validate(data)

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -27,6 +27,8 @@ from litigant_portal.app.topic_flow.schema import (
     Metadata,
     PacketOutput,
     Question,
+    Resource,
+    ResourcesOutput,
     SummaryOutput,
     VcfOutput,
 )
@@ -228,6 +230,35 @@ def test_packet_form_with_url_renders_as_link(client, monkeypatch):
         flat,
     )
     assert "Confidential Information Form" in flat
+
+
+@pytest.mark.django_db
+def test_resources_section_renders_links(client, monkeypatch):
+    # A resources output renders each official link as an anchor to its url
+    # (#519) — the cleanup that retires plain-text URLs in info bodies.
+    # Functional target (the link is clickable), not markup.
+    url = "https://www.ndcourts.gov/legal-self-help/name-change-adult"
+    corpus = Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        resources=[
+            Resource(id="guidance", label="Name-change guidance", url=url),
+        ],
+        sections=[
+            ResourcesOutput(
+                kind="output",
+                output_type="resources",
+                id="official_resources",
+                heading="Official resources",
+                resource_ids=["guidance"],
+            ),
+        ],
+    )
+    monkeypatch.setattr(pages.registry, "get", lambda *a: corpus)
+    flat = re.sub(r"\s+", " ", client.get(URL).content.decode())
+    assert re.search(
+        rf'<a[^>]*href="{re.escape(url)}"[^>]*>[^<]*Name-change guidance',
+        flat,
+    )
 
 
 def _field_tag(html, name):

--- a/litigant_portal/app/topic_flow/loader.py
+++ b/litigant_portal/app/topic_flow/loader.py
@@ -17,6 +17,7 @@ from litigant_portal.app.topic_flow.schema import (
     Corpus,
     FactGatherSection,
     IcsOutput,
+    ResourcesOutput,
     VcfOutput,
 )
 
@@ -82,6 +83,7 @@ def _cross_reference_problems(corpus: Corpus) -> list[str]:
 
     contact_ids = _collect([c.id for c in corpus.contacts], "contact")
     deadline_ids = _collect([d.id for d in corpus.deadlines], "deadline")
+    resource_ids = _collect([r.id for r in corpus.resources], "resource")
     _collect([s.id for s in corpus.sections], "section")
 
     question_ids = _collect(
@@ -118,5 +120,12 @@ def _cross_reference_problems(corpus: Corpus) -> list[str]:
                     problems.append(
                         f"output {section.id!r} references unknown "
                         f"contact {ref!r}"
+                    )
+        elif isinstance(section, ResourcesOutput):
+            for ref in section.resource_ids:
+                if ref not in resource_ids:
+                    problems.append(
+                        f"output {section.id!r} references unknown "
+                        f"resource {ref!r}"
                     )
     return problems

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -171,15 +171,17 @@ def _render_resources(section, corpus, answers):
     # the resolve is inline here rather than in a shared module (contrast
     # ics/vcf, whose resolvers are shared with their download handlers).
     by_id = {resource.id: resource for resource in corpus.resources}
-    resources = [
-        {
-            "id": by_id[ref].id,
-            "label": by_id[ref].label,
-            "url": by_id[ref].url,
-            "note": by_id[ref].note,
-        }
-        for ref in section.resource_ids
-    ]
+    resources = []
+    for ref in section.resource_ids:
+        resource = by_id[ref]
+        resources.append(
+            {
+                "id": resource.id,
+                "label": resource.label,
+                "url": resource.url,
+                "note": resource.note,
+            }
+        )
     return RenderedSection(
         anchor_id=section.id,
         heading=section.heading,

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -164,6 +164,30 @@ def _render_summary(section, corpus, answers):
     )
 
 
+@renderer("resources")
+def _render_resources(section, corpus, answers):
+    # Official/jurisdictional links (self-help center, statutes), referenced by
+    # id and resolved in declared order. Page-only — no download artifact — so
+    # the resolve is inline here rather than in a shared module (contrast
+    # ics/vcf, whose resolvers are shared with their download handlers).
+    by_id = {resource.id: resource for resource in corpus.resources}
+    resources = [
+        {
+            "id": by_id[ref].id,
+            "label": by_id[ref].label,
+            "url": by_id[ref].url,
+            "note": by_id[ref].note,
+        }
+        for ref in section.resource_ids
+    ]
+    return RenderedSection(
+        anchor_id=section.id,
+        heading=section.heading,
+        template=f"{_TEMPLATE_DIR}/flow_section_resources.html",
+        context={"resources": resources},
+    )
+
+
 @renderer("packet")
 def _render_packet(section, corpus, answers):
     return RenderedSection(

--- a/litigant_portal/app/topic_flow/schema.py
+++ b/litigant_portal/app/topic_flow/schema.py
@@ -46,6 +46,21 @@ class Contact(_Base):
     note: str | None = None
 
 
+class Resource(_Base):
+    """An official/jurisdictional link for a flow (self-help center, statute).
+
+    Unlike ``Contact``, whose ``url`` is one of several optional affordances, a
+    resource *is* a link — ``url`` is required. Courts supply these as data, so
+    the engine renders trustworthy official links without authors hand-coding
+    HTML or smuggling URLs into contact cards / info-body prose.
+    """
+
+    id: Slug
+    label: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+    note: str | None = None
+
+
 class Deadline(_Base):
     """A date computed as ``offset_days`` from a gathered date.
 
@@ -132,6 +147,14 @@ class PacketOutput(_Base):
     interview_url: str | None = None
 
 
+class ResourcesOutput(_Base):
+    kind: Literal["output"]
+    output_type: Literal["resources"]
+    id: Slug
+    heading: str = Field(min_length=1)
+    resource_ids: list[Slug] = Field(min_length=1)
+
+
 class SummaryOutput(_Base):
     kind: Literal["output"]
     output_type: Literal["summary"]
@@ -141,7 +164,7 @@ class SummaryOutput(_Base):
 
 # output sections discriminate on output_type ...
 OutputSection = Annotated[
-    IcsOutput | VcfOutput | PacketOutput | SummaryOutput,
+    IcsOutput | VcfOutput | PacketOutput | ResourcesOutput | SummaryOutput,
     Field(discriminator="output_type"),
 ]
 
@@ -157,4 +180,5 @@ class Corpus(_Base):
     metadata: Metadata
     contacts: list[Contact] = Field(default_factory=list)
     deadlines: list[Deadline] = Field(default_factory=list)
+    resources: list[Resource] = Field(default_factory=list)
     sections: list[Section] = Field(min_length=1)

--- a/litigant_portal/content/_test_fixture.yml
+++ b/litigant_portal/content/_test_fixture.yml
@@ -2,10 +2,10 @@
 #
 # The leading underscore excludes this file from the registry (registry.py
 # skips `_`-prefixed files), so it never renders as a real Topic Flow. It
-# exercises every part of the v1 schema: all three section kinds, all four
-# output types, and both id-reference cross-checks (a deadline offset_from a
-# fact_gather question; ics/vcf outputs referencing corpus-level deadlines and
-# contacts).
+# exercises every part of the v1 schema: all three section kinds, all five
+# output types, and every id-reference cross-check (a deadline offset_from a
+# fact_gather question; ics/vcf/resources outputs referencing corpus-level
+# deadlines, contacts, and resources).
 
 metadata:
   court: test-court
@@ -29,6 +29,12 @@ deadlines:
     offset_days: 30
     offset_from: publication_date
     description: 'The judge can review the petition 30 days after the notice is published.'
+
+resources:
+  - id: self_help_page
+    label: 'Name-change guidance and forms'
+    url: 'https://example.gov/legal-self-help/name-change'
+    note: 'The official process page and form source.'
 
 sections:
   - kind: info
@@ -73,6 +79,13 @@ sections:
     forms:
       - 'Petition for Name Change'
       - 'Confidential Information Form'
+
+  - kind: output
+    output_type: resources
+    id: official_resources
+    heading: 'Official resources'
+    resource_ids:
+      - self_help_page
 
   - kind: output
     output_type: summary

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -39,6 +39,16 @@ deadlines:
     offset_from: publication_date
     description: 'Under North Dakota law the judge may not consider your petition until 30 days after the notice is published. After this date, check with the clerk about judge review.'
 
+resources:
+  - id: nd_name_change_guidance
+    label: 'North Dakota name-change guidance and forms'
+    url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
+    note: "The court's official adult name-change page — process overview and the source for every form in your packet."
+  - id: nd_self_help_center
+    label: 'North Dakota Legal Self Help Center'
+    url: 'https://www.ndcourts.gov/legal-self-help'
+    note: 'General help for self-represented filers navigating the civil court process.'
+
 sections:
   - kind: info
     id: overview
@@ -57,8 +67,6 @@ sections:
       that has to be requested inside the divorce case — it is not handled here.
       If your divorce is final and didn't change your name, this standalone
       petition is the way.
-
-      Official guidance and forms: ndcourts.gov/legal-self-help/name-change-adult
 
   - kind: info
     id: eligibility
@@ -167,6 +175,14 @@ sections:
       - clerk
       - self_help
       - legal_aid
+
+  - kind: output
+    output_type: resources
+    id: official_resources
+    heading: 'Official North Dakota resources'
+    resource_ids:
+      - nd_name_change_guidance
+      - nd_self_help_center
 
   - kind: info
     id: after_order

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -44,10 +44,6 @@ resources:
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
     note: "The court's official adult name-change page — process overview and the source for every form in your packet."
-  - id: nd_self_help_center
-    label: 'North Dakota Legal Self Help Center'
-    url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'General help for self-represented filers navigating the civil court process.'
 
 sections:
   - kind: info
@@ -182,7 +178,6 @@ sections:
     heading: 'Official North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
-      - nd_self_help_center
 
   - kind: info
     id: after_order

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -41,10 +41,6 @@ resources:
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
     note: "The court's official adult name-change page — process overview and the source for every form in your packet."
-  - id: nd_self_help_center
-    label: 'North Dakota Legal Self Help Center'
-    url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'General help for self-represented filers navigating the civil court process.'
 
 sections:
   - kind: info
@@ -176,7 +172,6 @@ sections:
     heading: 'Official North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
-      - nd_self_help_center
 
   - kind: info
     id: after_order

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -36,6 +36,16 @@ contacts:
     phone: '(800) 634-5263'
     note: 'Free civil legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter. This line is for filers under 60; if you are 60 or older, call (866) 621-9886.'
 
+resources:
+  - id: nd_name_change_guidance
+    label: 'North Dakota name-change guidance and forms'
+    url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
+    note: "The court's official adult name-change page — process overview and the source for every form in your packet."
+  - id: nd_self_help_center
+    label: 'North Dakota Legal Self Help Center'
+    url: 'https://www.ndcourts.gov/legal-self-help'
+    note: 'General help for self-represented filers navigating the civil court process.'
+
 sections:
   - kind: info
     id: overview
@@ -55,8 +65,6 @@ sections:
 
       One common mix-up: if you wanted your name changed as part of a divorce,
       that has to be requested inside the divorce case — it is not handled here.
-
-      Official guidance and forms: ndcourts.gov/legal-self-help/name-change-adult
 
   - kind: info
     id: eligibility
@@ -161,6 +169,14 @@ sections:
       - clerk
       - self_help
       - legal_aid
+
+  - kind: output
+    output_type: resources
+    id: official_resources
+    heading: 'Official North Dakota resources'
+    resource_ids:
+      - nd_name_change_guidance
+      - nd_self_help_center
 
   - kind: info
     id: after_order


### PR DESCRIPTION
Adds a corpus-level `resources` list (id + label + required url + optional note) and a `resources` output section that references them by id — mirroring the contacts/deadlines validated-contract pattern. The renderer resolves refs in declared order into a labeled link list (real `<a>`, external-link affordance, server-rendered, JS-off); the loader cross-checks every reference resolves and flags duplicate ids.

Both ND name-change tracks migrate to it: the official self-help and name-change guidance pages move from unclickable plain text in an info body into structured, clickable links — retiring the dead-text-URL workaround.

Resolve is inline in the renderer (no download artifact, unlike vcf/ics), and `url` is required on `Resource` (a resource *is* a link). #518 (inline links within info-body prose) stays open as the complementary follow-up.

Closes #519

## Test plan

- schema: `url` required, label/url/note carried, unknown-key rejected, empty `resource_ids` rejected
- loader: unknown-ref fails loud, duplicate-id detected
- renderer: resolves referenced resource, declared-order preserved, distinct template
- view: resources section renders a clickable `<a href=url>`
- `make lint` + `make test` green locally
