### PR TITLE
Track llm usage

### DIFF
--- a/docs/AGENT_DEV_GUIDE.md
+++ b/docs/AGENT_DEV_GUIDE.md
@@ -74,15 +74,16 @@ execution are the engine's job, not the agent's.**
 
 ### 1. The LLM config — `completion_args`
 
-A plain dict of litellm completion kwargs (model, temperature, `max_tokens`,
-`reasoning_effort`, …). This is the only place the model is chosen.
+A plain dict of litellm completion kwargs for tuning the call — `temperature`,
+`max_tokens`, `reasoning_effort`, and so on.
 
 ```python
-completion_args = {"temperature": 0.7, "max_tokens": 1000}
+completion_args = {"max_tokens": 1000}
 ```
 
-The engine spreads these into `litellm.completion(**completion_args, messages=…,
-tools=…, stream=True)`. Anything litellm accepts, you can put here.
+These are spread into `litellm.completion(...)`. **Don't put `model` here** — you'll get an error if you try.
+The model is supplied to the engine by the endpoint (eventually from a site
+config model), not the agent, and setting it in `completion_args` raises.
 
 ### 2. The state — `state_schema`
 
@@ -262,7 +263,7 @@ class WeatherState(AgentState):
 class WeatherAgent(Agent):
     """A demo agent that can check the weather."""
 
-    completion_args = {"model": "gpt-5-mini"}   # INGREDIENT 1: LLM config
+    completion_args = {"max_tokens": 1000}       # INGREDIENT 1: LLM config
     state_schema = WeatherState                  # INGREDIENT 2
     tools = [CheckWeather]                        # INGREDIENT 4 (from .tools)
 
@@ -404,14 +405,15 @@ from litigant_portal.app.services.chat_v2 import chat_message_inject_hidden
 chat_message_inject_hidden(
     thread_id=thread_id,
     content="<retrieved statute text the model should ground on>",
+    model=model,
     role="user",  # default; "assistant" / "system" also valid
 )
 ```
 
-It's keyed by `thread_id`, so a tool can call it straight from `__call__`. The
-message is stored with `hidden=True` and deliberately does **not** bump the
-thread's `updated_at` — injecting context never reorders the sidebar or changes
-the snippet.
+It takes the `model` (to count tokens, like every message) and is keyed by
+`thread_id`. The message is stored with `hidden=True` and deliberately does
+**not** bump the thread's `updated_at` — injecting context never reorders the
+sidebar or changes the snippet.
 
 ### Compaction messages _(designed; not yet implemented)_
 

--- a/litigant_portal/agents_v2/weather.py
+++ b/litigant_portal/agents_v2/weather.py
@@ -13,7 +13,7 @@ class WeatherState(AgentState):
 class WeatherAgent(Agent):
     """A demo agent that can check the weather."""
 
-    completion_args = {"model": "gpt-5-mini"}
+    completion_args = {"max_tokens": 1000}
     state_schema = WeatherState
     tools = [CheckWeather]
 

--- a/litigant_portal/app/migrations/0006_chatmessage_num_tokens_cost.py
+++ b/litigant_portal/app/migrations/0006_chatmessage_num_tokens_cost.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("app", "0005_chatmessage_hidden"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="chatmessage",
+            name="num_tokens",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="chatmessage",
+            name="cost",
+            field=models.FloatField(default=0.0),
+        ),
+    ]

--- a/litigant_portal/app/models/chat_v2.py
+++ b/litigant_portal/app/models/chat_v2.py
@@ -33,3 +33,5 @@ class ChatMessage(BaseModel):
         schema=MessageSchema, default={"role": "system", "content": ""}
     )
     hidden = models.BooleanField(default=False)
+    num_tokens = models.PositiveIntegerField(default=0)
+    cost = models.FloatField(default=0.0)

--- a/litigant_portal/app/selectors/chat_v2.py
+++ b/litigant_portal/app/selectors/chat_v2.py
@@ -1,4 +1,4 @@
-from django.db.models import QuerySet
+from django.db.models import QuerySet, Sum
 
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
 
@@ -21,3 +21,14 @@ def chat_message_list(*, thread: ChatThread) -> QuerySet[ChatMessage]:
 def chat_message_list_visible(*, thread: ChatThread) -> QuerySet[ChatMessage]:
     """Frontend-safe messages: the thread's messages minus hidden ones."""
     return chat_message_list(thread=thread).filter(hidden=False)
+
+
+def chat_thread_usage(*, thread: ChatThread) -> dict:
+    """Total tokens and cost across all of a thread's messages (incl. hidden)."""
+    totals = chat_message_list(thread=thread).aggregate(
+        total_tokens=Sum("num_tokens"), total_cost=Sum("cost")
+    )
+    return {
+        "total_tokens": totals["total_tokens"] or 0,
+        "total_cost": totals["total_cost"] or 0.0,
+    }

--- a/litigant_portal/app/services/chat_v2.py
+++ b/litigant_portal/app/services/chat_v2.py
@@ -243,10 +243,17 @@ def chat_stream(
                 for chunk in litellm.completion(**call_args):
                     usage = getattr(chunk, "usage", None)
                     if usage:
-                        cost = litellm.completion_cost(
-                            completion_response=chunk, model=model
-                        )
-                        completion_tokens = usage.completion_tokens
+                        try:
+                            cost = litellm.completion_cost(
+                                completion_response=chunk, model=model
+                            )
+                            completion_tokens = usage.completion_tokens
+                        except Exception:
+                            logger.exception(
+                                "Chat cost/usage extraction failed "
+                                "(model=%s)",
+                                model,
+                            )
                     if not chunk.choices:
                         continue
                     delta = chunk.choices[0].delta

--- a/litigant_portal/app/services/chat_v2.py
+++ b/litigant_portal/app/services/chat_v2.py
@@ -250,8 +250,7 @@ def chat_stream(
                             completion_tokens = usage.completion_tokens
                         except Exception:
                             logger.exception(
-                                "Chat cost/usage extraction failed "
-                                "(model=%s)",
+                                "Chat cost/usage extraction failed (model=%s)",
                                 model,
                             )
                     if not chunk.choices:

--- a/litigant_portal/app/services/chat_v2.py
+++ b/litigant_portal/app/services/chat_v2.py
@@ -20,18 +20,42 @@ logger = logging.getLogger(__name__)
 MAX_STEPS = 30
 
 
+def chat_message_create(
+    *,
+    thread_id,
+    data: dict,
+    model: str,
+    num_tokens: int | None = None,
+    hidden: bool = False,
+    cost: float = 0.0,
+) -> ChatMessage:
+    """Add a message to a thread."""
+    if num_tokens is None:
+        num_tokens = litellm.token_counter(
+            model=model, text=data.get("content", "")
+        )
+    return ChatMessage.objects.create(
+        thread_id=thread_id,
+        data=data,
+        hidden=hidden,
+        num_tokens=num_tokens,
+        cost=cost,
+    )
+
+
 def chat_thread_delete(*, identity: UserIdentity, thread_id: str) -> None:
     """Delete a thread (and its messages, via cascade) owned by the identity."""
     chat_thread_get(identity=identity, thread_id=thread_id).delete()
 
 
 def chat_message_inject_hidden(
-    *, thread_id, content: str, role: str = "user"
+    *, thread_id, content: str, model: str, role: str = "user"
 ) -> ChatMessage:
     """Append a hidden message to a thread's history."""
-    return ChatMessage.objects.create(
+    return chat_message_create(
         thread_id=thread_id,
         data={"role": role, "content": content},
+        model=model,
         hidden=True,
     )
 
@@ -171,14 +195,23 @@ def chat_stream(
     identity: UserIdentity,
     message: str,
     agent_class: type[Agent],
+    model: str,
     thread_id: str | None = None,
 ) -> StreamingHttpResponse:
     """Stream an agent's reply for ``message``, running the tool loop."""
     thread = _resolve_thread(identity=identity, thread_id=thread_id)
     agent = agent_class()
 
-    ChatMessage.objects.create(
-        thread=thread, data={"role": "user", "content": message}
+    if "model" in agent.completion_args:
+        raise ValueError(
+            f"{agent_class.__name__}.completion_args must not set 'model' — "
+            "the model is passed to chat_stream by the caller."
+        )
+
+    chat_message_create(
+        thread_id=thread.id,
+        data={"role": "user", "content": message},
+        model=model,
     )
 
     history: list[dict[str, Any]] = [
@@ -194,16 +227,28 @@ def chat_stream(
             for _ in range(MAX_STEPS):
                 call_args: dict[str, Any] = {
                     **agent.completion_args,
+                    "model": model,
                     "messages": _messages_for_llm(system_prompt, history),
                     "stream": True,
+                    "stream_options": {"include_usage": True},
                 }
                 if agent.tool_schemas:
                     call_args["tools"] = agent.tool_schemas
 
                 content_parts: list[str] = []
                 tool_calls: list[dict[str, Any]] = []
+                cost = 0.0
+                completion_tokens = None
 
                 for chunk in litellm.completion(**call_args):
+                    usage = getattr(chunk, "usage", None)
+                    if usage:
+                        cost = litellm.completion_cost(
+                            completion_response=chunk, model=model
+                        )
+                        completion_tokens = usage.completion_tokens
+                    if not chunk.choices:
+                        continue
                     delta = chunk.choices[0].delta
 
                     if delta.content:
@@ -241,7 +286,13 @@ def chat_stream(
                 if tool_calls:
                     assistant_msg["tool_calls"] = tool_calls
                 history.append(assistant_msg)
-                ChatMessage.objects.create(thread=thread, data=assistant_msg)
+                chat_message_create(
+                    thread_id=thread.id,
+                    data=assistant_msg,
+                    model=model,
+                    num_tokens=completion_tokens,
+                    cost=cost,
+                )
 
                 if not tool_calls:
                     break
@@ -291,7 +342,11 @@ def chat_stream(
                     if output.render_data is not None:
                         tool_msg["data"] = output.render_data
                     history.append(tool_msg)
-                    ChatMessage.objects.create(thread=thread, data=tool_msg)
+                    chat_message_create(
+                        thread_id=thread.id,
+                        data=tool_msg,
+                        model=model,
+                    )
 
                     yield _sse(
                         {

--- a/litigant_portal/app/static/js/chat_v2.js
+++ b/litigant_portal/app/static/js/chat_v2.js
@@ -189,12 +189,39 @@ function threadRowClass(threadId, activeId) {
     : 'border-transparent hover:bg-greyscale-100'
 }
 
+function blankMessage() {
+  return {
+    id: 0,
+    content: '',
+    html: '',
+    isUser: false,
+    isAssistant: false,
+    isTool: false,
+    notTool: true,
+    copied: false,
+    notCopied: true,
+    rowClass: '',
+    bubbleClass: '',
+    name: '',
+    pending: false,
+    argsJson: '',
+    callHtml: '',
+    renderDataJson: '',
+    resultHtml: '',
+    showCallCustom: false,
+    showCallDefault: false,
+    showResultCustom: false,
+    showResultDefault: false,
+  }
+}
+
 // Build a message with precomputed style classes + rendered markdown (CSP-safe
 // — the template binds dot-paths only, no expressions).
 let messageSeq = 0
 function makeMessage(role, content) {
   const isUser = role === 'user'
   return {
+    ...blankMessage(),
     id: ++messageSeq,
     role,
     content,
@@ -244,6 +271,7 @@ function computeToolFlags(t) {
 // A tool part from a live `tool_call` event (result fills in later).
 function makeToolFromCall(event) {
   return computeToolFlags({
+    ...blankMessage(),
     id: ++messageSeq,
     toolId: event.id,
     name: event.name,
@@ -261,6 +289,7 @@ function makeToolFromCall(event) {
 // A completed tool part from a reloaded thread's render item.
 function makeToolFromItem(item) {
   return computeToolFlags({
+    ...blankMessage(),
     id: ++messageSeq,
     toolId: item.id,
     name: item.name,
@@ -621,6 +650,45 @@ document.addEventListener('alpine:init', () => {
         const el = this.$refs.messagesArea
         if (el) el.scrollTop = el.scrollHeight
       })
+    },
+  }))
+
+  // Superuser-only token/cost readout for the active thread. Rendered only for
+  // superusers (so non-superusers never instantiate it or hit the endpoint).
+  // Assumes it lives inside a chatApp component — it reads the thread id from
+  // the parent and refreshes when the thread changes or a turn finishes.
+  Alpine.data('chatUsage', () => ({
+    totalTokens: '0',
+    totalCost: '$0.00',
+    app: null,
+
+    init() {
+      this.app = this.$root.closest('[x-data="chatApp"]')._x_dataStack[0]
+      this.$watch('app.threadId', () => this.refresh())
+      this.$watch('app.streaming', (streaming) => {
+        if (!streaming) this.refresh()
+      })
+      this.refresh()
+    },
+
+    async refresh() {
+      const threadId = this.app && this.app.threadId
+      if (!threadId) {
+        this.totalTokens = '0'
+        this.totalCost = '$0.00'
+        return
+      }
+      try {
+        const res = await fetch('/api/chat/threads/' + threadId + '/usage/', {
+          headers: { Accept: 'application/json' },
+        })
+        if (!res.ok) return
+        const data = await res.json()
+        this.totalTokens = (data.total_tokens || 0).toLocaleString()
+        this.totalCost = '$' + (data.total_cost || 0).toFixed(4)
+      } catch (e) {
+        console.error('Failed to load chat usage:', e)
+      }
     },
   }))
 })

--- a/litigant_portal/app/static/js/chat_v2.js
+++ b/litigant_portal/app/static/js/chat_v2.js
@@ -663,7 +663,7 @@ document.addEventListener('alpine:init', () => {
     app: null,
 
     init() {
-      this.app = this.$root.closest('[x-data="chatApp"]')._x_dataStack[0]
+      this.app = Alpine.$data(this.$root.closest('[x-data="chatApp"]'))
       this.$watch('app.threadId', () => this.refresh())
       this.$watch('app.streaming', (streaming) => {
         if (!streaming) this.refresh()

--- a/litigant_portal/app/templates/chat_v2/index.html
+++ b/litigant_portal/app/templates/chat_v2/index.html
@@ -182,6 +182,17 @@
       </div>
       {# Input #}
       <div class="border-t border-greyscale-200 p-3 flex-shrink-0">
+        {% if request.user.is_superuser %}
+          {# Dev-only token/cost readout for the active thread #}
+          <div x-data="chatUsage"
+               x-cloak
+               class="flex items-center gap-1.5 mb-2 text-xs text-greyscale-400 select-none">
+            <span x-text="totalTokens"></span>
+            <span>{% trans "tokens" %}</span>
+            <span class="text-greyscale-300">·</span>
+            <span x-text="totalCost"></span>
+          </div>
+        {% endif %}
         <form x-on:submit.prevent="send">
           {% csrf_token %}
           <div class="relative">

--- a/litigant_portal/app/tests/test_chat_v2_hidden.py
+++ b/litigant_portal/app/tests/test_chat_v2_hidden.py
@@ -33,7 +33,7 @@ class InjectHiddenMessageTests(TestCase):
 
     def test_stores_hidden_message(self):
         message = chat_message_inject_hidden(
-            thread_id=self.thread.id, content="context"
+            thread_id=self.thread.id, content="context", model="gpt-5-mini"
         )
         self.assertTrue(message.hidden)
         self.assertEqual(message.data["role"], "user")
@@ -41,7 +41,9 @@ class InjectHiddenMessageTests(TestCase):
 
     def test_does_not_bump_thread_updated_at(self):
         before = ChatThread.objects.get(pk=self.thread.pk).updated_at
-        chat_message_inject_hidden(thread_id=self.thread.id, content="context")
+        chat_message_inject_hidden(
+            thread_id=self.thread.id, content="context", model="gpt-5-mini"
+        )
         after = ChatThread.objects.get(pk=self.thread.pk).updated_at
         self.assertEqual(after, before)
 
@@ -95,7 +97,9 @@ class HiddenMessageProjectionTests(TestCase):
             data={"role": "user", "content": "visible question"},
         )
         chat_message_inject_hidden(
-            thread_id=self.thread.id, content="HIDDEN CONTEXT"
+            thread_id=self.thread.id,
+            content="HIDDEN CONTEXT",
+            model="gpt-5-mini",
         )
 
     def test_hidden_reaches_llm_history(self):

--- a/litigant_portal/app/tests/test_chat_v2_usage.py
+++ b/litigant_portal/app/tests/test_chat_v2_usage.py
@@ -1,0 +1,110 @@
+"""Tests for token counting and cost tracking in the chat_v2 engine.
+
+These pin the bookkeeping contract: chat_message_create trusts caller-supplied
+counts (an assistant turn passes usage.completion_tokens) and otherwise counts
+the message content itself, and chat_thread_usage sums tokens and cost across the
+whole thread, hidden messages included.
+"""
+
+import pytest
+from django.test import TestCase
+
+from litigant_portal.app.models import ChatThread, UserIdentity
+from litigant_portal.app.selectors.chat_v2 import chat_thread_usage
+from litigant_portal.app.services.chat_v2 import (
+    chat_message_create,
+    chat_message_inject_hidden,
+)
+
+MODEL = "gpt-5-mini"
+
+
+@pytest.mark.postgres
+class ChatMessageCreateTests(TestCase):
+    """chat_message_create — when it counts vs. when it trusts the caller."""
+
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="usage-create")
+        self.thread = ChatThread.objects.create(identity=self.identity)
+
+    def test_uses_caller_supplied_counts_verbatim(self):
+        # Assistant turns pass exact usage values; we store them, never recount.
+        # The trivial content would count to ~1 token, proving no recount.
+        message = chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "assistant", "content": "hi"},
+            model=MODEL,
+            num_tokens=4321,
+            cost=0.0123,
+        )
+        self.assertEqual(message.num_tokens, 4321)
+        self.assertAlmostEqual(message.cost, 0.0123)
+
+    def test_counts_content_when_tokens_omitted(self):
+        # Input messages (user/tool/injected) have no usage, so we count content.
+        message = chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "user", "content": "How many tokens is this?"},
+            model=MODEL,
+        )
+        self.assertGreater(message.num_tokens, 0)
+        self.assertEqual(message.cost, 0.0)
+
+    def test_explicit_zero_is_respected_not_recounted(self):
+        # The guard is `num_tokens is None`, not a falsy check — an explicit 0
+        # must be stored as-is even though the content would count above zero.
+        message = chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "assistant", "content": "non-empty body"},
+            model=MODEL,
+            num_tokens=0,
+        )
+        self.assertEqual(message.num_tokens, 0)
+
+
+@pytest.mark.postgres
+class ChatThreadUsageTests(TestCase):
+    """chat_thread_usage — totals across the thread, hidden messages included."""
+
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="usage-sum")
+        self.thread = ChatThread.objects.create(identity=self.identity)
+
+    def test_empty_thread_totals_zero(self):
+        self.assertEqual(
+            chat_thread_usage(thread=self.thread),
+            {"total_tokens": 0, "total_cost": 0.0},
+        )
+
+    def test_sums_tokens_and_cost(self):
+        chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "user", "content": "q"},
+            model=MODEL,
+            num_tokens=10,
+            cost=0.0,
+        )
+        chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "assistant", "content": "a"},
+            model=MODEL,
+            num_tokens=25,
+            cost=0.005,
+        )
+        usage = chat_thread_usage(thread=self.thread)
+        self.assertEqual(usage["total_tokens"], 35)
+        self.assertAlmostEqual(usage["total_cost"], 0.005)
+
+    def test_includes_hidden_messages(self):
+        chat_message_create(
+            thread_id=self.thread.id,
+            data={"role": "user", "content": "visible"},
+            model=MODEL,
+            num_tokens=10,
+        )
+        hidden = chat_message_inject_hidden(
+            thread_id=self.thread.id, content="hidden context", model=MODEL
+        )
+        self.assertGreater(hidden.num_tokens, 0)
+        usage = chat_thread_usage(thread=self.thread)
+        self.assertEqual(usage["total_tokens"], 10 + hidden.num_tokens)

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -58,6 +58,11 @@ api_patterns = [
         name="message_list",
     ),
     path(
+        "threads/<uuid:thread_id>/usage/",
+        chat_v2.thread_usage,
+        name="thread_usage",
+    ),
+    path(
         "threads/<uuid:thread_id>/delete/",
         chat_v2.thread_delete,
         name="thread_delete",

--- a/litigant_portal/app/views/chat_v2.py
+++ b/litigant_portal/app/views/chat_v2.py
@@ -9,6 +9,7 @@ from litigant_portal.app.selectors.chat_v2 import (
     chat_message_list_visible,
     chat_thread_get,
     chat_thread_list,
+    chat_thread_usage,
 )
 from litigant_portal.app.services.chat_v2 import (
     chat_stream as chat_stream_service,
@@ -70,6 +71,22 @@ def message_list(request: HttpRequest, thread_id) -> JsonResponse:
     )
 
 
+@require_GET
+@ratelimit(key="ip", rate="60/m", method="GET", block=True)
+def thread_usage(request: HttpRequest, thread_id) -> JsonResponse:
+    """Total tokens and cost for a thread."""
+    if not request.user.is_superuser:
+        return JsonResponse({"error": _("Forbidden")}, status=403)
+    try:
+        thread = chat_thread_get(
+            identity=request.identity, thread_id=thread_id
+        )
+    except ChatThread.DoesNotExist:
+        return JsonResponse({"error": _("Thread not found")}, status=404)
+
+    return JsonResponse(chat_thread_usage(thread=thread))
+
+
 @require_POST
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 def thread_delete(request: HttpRequest, thread_id) -> JsonResponse:
@@ -97,6 +114,8 @@ def chat_stream(request: HttpRequest):
             message=message,
             thread_id=thread_id,
             agent_class=WeatherAgent,
+            # Hard-coded for now; will come from the site configuration model.
+            model="gpt-5-mini",
         )
     except ChatThread.DoesNotExist:
         return JsonResponse({"error": _("Thread not found")}, status=404)


### PR DESCRIPTION
This PR does a few things:

- First we tweak how the model is passed in the agent engine. This should be set at the endpoint-level (currently hardcoded, will eventually be inherited from database admin config models). As a guard, if the developer tries to set `model` in the agent's completion args we will raise an error. We update the docs and the demo agent to reflect this.
- Second, a chat_message_create helper is added. This wraps ChatMessage.objects.create, and if no num_tokens is provided it will be calculated. The reason for this is: (i) For user messages we have to calculate num tokens manually, but for (ii) assistant messages and tool calls we want to rely on the litellm response `usage` object, since this factors in tool call args and thinking tokens and is the most accurate cost tracker.
- The costs of llm messages are automatically passed, again since the litellm response object will include the most accurate cost tracking. User messages don't have an associated cost, so these default to zero.

Seeing the usage on the frontend:
- We have a chatUsage component that only gets rendered on the frontend for developers (superusers).
- We also add a corresponding endpoint that this component pulls data from

So if you are logged in with a superuser account, you'll see something like this:
<img width="220" height="96" alt="Screenshot 2026-06-30 at 4 17 58 PM" src="https://github.com/user-attachments/assets/a238a0d7-e733-481c-b6ad-73bc0093d64d" />


We also update docs, old tests with the new model pattern, and add new tests.