### PR TITLE
ci(cd): make DigitalOcean deploy manual-dispatch to freeze QA

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,16 @@
-name: CD
+name: Deploy to DigitalOcean (manual)
 
+# The DigitalOcean QA box (qa.litigantportal.com) is a manual-dispatch fallback,
+# not continuous deployment. It used to auto-deploy on every merge to main via a
+# `git reset --hard origin/main` on the box — which meant a broken main would
+# take QA down. During the v1→v2 chat migration main is expected to break, so we
+# froze QA at its last deliberate deploy: it only updates when someone runs this
+# workflow by hand (Actions → Run workflow). Image publishing for AWS continues
+# independently in deploy.yml ("Build and Push to Docker Hub") on every merge.
+# The pull_request trigger stays as the pre-merge docker-build guardrail (#592).
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,14 +34,14 @@ jobs:
           push: false
 
   # ---------------------------------------------------------------------------
-  # main: build, push to GHCR, deploy to QA
+  # manual dispatch: build, push to GHCR, deploy to the DigitalOcean QA box
   # ---------------------------------------------------------------------------
   build-and-deploy:
     name: Build, push, deploy to QA
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    # Serialize deploys so back-to-back merges don't race the SSH step.
-    # cancel-in-progress=false queues subsequent commits in order.
+    if: github.event_name == 'workflow_dispatch'
+    # Serialize deploys so back-to-back manual runs don't race the SSH step.
+    # cancel-in-progress=false queues subsequent runs in order.
     concurrency:
       group: qa-deploy
       cancel-in-progress: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Keep configuration **simple and consistent** across dev, CI/CD, and QA. Docker e
 | QA/Staging  | OpenAI        | docker-compose prod profile        |
 | Production  | OpenAI        | docker-compose.yml + `.env`        |
 
-**QA environment:** `https://qa.litigantportal.com` — auto-deploys on merge to `main` via GitHub Actions CD workflow. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
+**QA environment:** `https://qa.litigantportal.com` — deployed **manually** via the `Deploy to DigitalOcean (manual)` workflow (`cd.yml`, Actions → Run workflow), not on merge to `main`. Frozen at its last deliberate deploy so churn on `main` can't break QA. See `docs/QA-DEPLOY.md` for server setup. Uses the same docker-compose prod profile on a DigitalOcean VPS.
 
 **Local dev setup:**
 
@@ -518,7 +518,7 @@ curl -sL "https://cdn.jsdelivr.net/npm/@alpinejs/csp@3.14.9/dist/cdn.min.js" -o 
 
 ### QA/Staging
 
-QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Auto-deploys on merge to `main` via the `cd.yml` GitHub Actions workflow (build → push to GHCR → SSH deploy). Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
+QA runs at `https://qa.litigantportal.com` on a DigitalOcean VPS. Deploys are **manual** — the `Deploy to DigitalOcean (manual)` workflow (`cd.yml`) runs on demand via Actions → Run workflow (build → push to GHCR → SSH deploy), not on merge to `main`. The box is frozen at its last deliberate deploy so churn on `main` can't break QA (#592). A separate workflow, `deploy.yml` ("Build and Push to Docker Hub"), still publishes the AWS-bound image on every merge. Uses the docker-compose prod profile. See `docs/QA-DEPLOY.md` for full setup runbook and gotchas.
 
 Manual deploy on the QA server: `make update` (pulls code + images, recreates, health-checks — and brings up the docassemble override so the `/interview/` route survives; a base-only compose `up` drops it, #558). `make docker-rebuild` is a local from-source rebuild, not the QA deploy path.
 

--- a/docs/QA-DEPLOY.md
+++ b/docs/QA-DEPLOY.md
@@ -1,6 +1,6 @@
 # QA Environment Setup
 
-One-time setup for the QA/staging server at `qa.litigantportal.com`. After setup, deploys are automatic — merge to `main` triggers a new Docker image build and deploy via GitHub Actions.
+One-time setup for the QA/staging server at `qa.litigantportal.com`. Deploys to this box are **manual** — the `Deploy to DigitalOcean (manual)` workflow (`cd.yml`) runs on demand via Actions → Run workflow, not on merge to `main`. The box is intentionally frozen at its last deliberate deploy so churn on `main` (e.g. the v1→v2 chat migration) can't take QA down. See #592.
 
 ## Architecture
 


### PR DESCRIPTION
Freeze the DigitalOcean QA box (qa.litigantportal.com) so churn on `main` can't take it down. Swaps cd.yml's `push:[main]` trigger for `workflow_dispatch` and gates the deploy job on the manual event — QA now updates only when someone runs the workflow by hand (Actions → Run workflow). This keeps the ND name-change QA round (#585) on a stable target while the v1→v2 chat migration removes v1 code aggressively and breaks `main`.

`deploy.yml` ("Build and Push to Docker Hub") is untouched and keeps publishing the AWS-bound image on every merge. The `pull_request` build-validation job stays as the pre-merge guardrail. Renames the workflow to reflect its new manual role and corrects the "auto-deploys on merge" claim in the docs (broader DigitalOcean→AWS rewrite stays with #587).

Closes #592

Test plan:
- [ ] Merge to `main` no longer triggers a DO deploy
- [ ] `Deploy to DigitalOcean (manual)` appears under Actions with a Run workflow button (visible once on the default branch) and deploys on demand
- [ ] This PR triggers only the `Docker build validation` check (no deploy)
- [ ] `deploy.yml` still publishes to Docker Hub on merge