### PR TITLE
fix(a11y): Topic Flow describedby, new-tab cue, error focus

### DIFF
--- a/litigant_portal/app/templates/cotton/atoms/input.html
+++ b/litigant_portal/app/templates/cotton/atoms/input.html
@@ -1,4 +1,4 @@
-<c-vars type="text" :required="False" />
+<c-vars type="text" :required="False" :autofocus="False" />
 {# --- Base --- #}
 {% with base="w-full text-md font-normal py-3 px-4 rounded-lg border bg-white text-greyscale-900 placeholder:text-greyscale-400 transition-colors duration-200 focus:outline-none focus:ring-2 disabled:bg-greyscale-100 disabled:text-greyscale-500 disabled:cursor-not-allowed" %}
 {# --- States --- #}
@@ -11,6 +11,7 @@
        {% if disabled %}disabled{% endif %}
        {% if readonly %}readonly{% endif %}
        {% if required %}required{% endif %}
+       {% if autofocus %}autofocus{% endif %}
        {% if aria_label %}aria-label="{{ aria_label }}"{% endif %}
        {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
        {% if error %}aria-invalid="true"{% endif %}

--- a/litigant_portal/app/templates/cotton/atoms/link.html
+++ b/litigant_portal/app/templates/cotton/atoms/link.html
@@ -1,5 +1,5 @@
 <c-vars variant="default" />
-{% load heroicons %}
+{% load heroicons i18n %}
 {# --- Base --- #}
 {% with base="inline-flex items-center gap-1 cursor-pointer transition-colors duration-200 [text-underline-offset:2px]" %}
 {# --- Variants --- #}
@@ -11,6 +11,9 @@
    {{ attrs }}>{{ slot }}
   {% if external_icon and target == '_blank' %}
     <span class="shrink-0 ml-1 w-3.5 h-3.5" aria-hidden="true">{% heroicon_outline "arrow-top-right-on-square" %}</span>
+  {% endif %}
+  {% if target == '_blank' %}
+    <span class="sr-only">{% trans "(opens in a new tab)" %}</span>
   {% endif %}
 </a>
 {% endwith %}

--- a/litigant_portal/app/templates/cotton/atoms/select.html
+++ b/litigant_portal/app/templates/cotton/atoms/select.html
@@ -1,4 +1,4 @@
-<c-vars :required="False" />
+<c-vars :required="False" :autofocus="False" />
 <div class="relative inline-block w-full {{ class }}">
   {# --- Base --- #}
   {% with base="w-full text-md font-normal py-3 pl-4 pr-10 rounded-lg bg-white text-greyscale-900 transition-colors duration-200 cursor-pointer appearance-none focus:outline-none focus:ring-2 disabled:bg-greyscale-100 disabled:text-greyscale-500 disabled:cursor-not-allowed border" %}
@@ -8,6 +8,7 @@
           {% if id %}id="{{ id }}"{% endif %}
           {% if disabled %}disabled{% endif %}
           {% if required %}required{% endif %}
+          {% if autofocus %}autofocus{% endif %}
           {% if aria_label %}aria-label="{{ aria_label }}"{% endif %}
           {% if aria_describedby %}aria-describedby="{{ aria_describedby }}"{% endif %}
           {% if error %}aria-invalid="true"{% endif %}

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
@@ -14,6 +14,7 @@
     id="{{ q.id }}"
     help_text="{{ q.help_text|default:'' }}"
     :required="q.required"
+    :autofocus="q.autofocus"
     :errors="q.errors"
   >
     <option value="">{{ choice_placeholder }}</option>
@@ -30,6 +31,7 @@
     value="{{ q.value }}"
     help_text="{{ q.help_text|default:'' }}"
     :required="q.required"
+    :autofocus="q.autofocus"
     :errors="q.errors"
   />
   {% endif %}

--- a/litigant_portal/app/templates/cotton/molecules/form_field.html
+++ b/litigant_portal/app/templates/cotton/molecules/form_field.html
@@ -1,8 +1,8 @@
-<c-vars type="text" :required="False" />
+<c-vars type="text" :required="False" :autofocus="False" />
 <div class="{{ class }}">
   <label for="{{ id }}"
          class="block text-sm font-medium text-greyscale-700 mb-1.5">{{ label }}</label>
-  <c-atoms.input type="{{ type }}" name="{{ name }}" id="{{ id }}" value="{{ value }}" placeholder="{{ placeholder }}" autocomplete="{{ autocomplete }}" :required="required" error="{{ errors|yesno:'true,' }}" />
-  {% if help_text %}<p class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
-  {% if errors %}<p class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
+  <c-atoms.input type="{{ type }}" name="{{ name }}" id="{{ id }}" value="{{ value }}" placeholder="{{ placeholder }}" autocomplete="{{ autocomplete }}" :required="required" :autofocus="autofocus" error="{{ errors|yesno:'true,' }}" aria_describedby="{% if help_text %}{{ id }}-help{% endif %}{% if help_text and errors %} {% endif %}{% if errors %}{{ id }}-error{% endif %}" />
+  {% if help_text %}<p id="{{ id }}-help" class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
+  {% if errors %}<p id="{{ id }}-error" class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
 </div>

--- a/litigant_portal/app/templates/cotton/molecules/form_field_select.html
+++ b/litigant_portal/app/templates/cotton/molecules/form_field_select.html
@@ -1,8 +1,8 @@
-<c-vars :required="False" />
+<c-vars :required="False" :autofocus="False" />
 <div class="{{ class }}">
   <label for="{{ id }}"
          class="block text-sm font-medium text-greyscale-700 mb-1.5">{{ label }}</label>
-  <c-atoms.select name="{{ name }}" id="{{ id }}" :required="required" error="{{ errors|yesno:'true,' }}">{{ slot }}</c-atoms.select>
-  {% if help_text %}<p class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
-  {% if errors %}<p class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
+  <c-atoms.select name="{{ name }}" id="{{ id }}" :required="required" :autofocus="autofocus" error="{{ errors|yesno:'true,' }}" aria_describedby="{% if help_text %}{{ id }}-help{% endif %}{% if help_text and errors %} {% endif %}{% if errors %}{{ id }}-error{% endif %}">{{ slot }}</c-atoms.select>
+  {% if help_text %}<p id="{{ id }}-help" class="mt-1 text-xs text-greyscale-500">{{ help_text }}</p>{% endif %}
+  {% if errors %}<p id="{{ id }}-error" class="mt-1 text-sm text-red-600">{{ errors.0 }}</p>{% endif %}
 </div>

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -114,6 +114,33 @@ def test_fact_gather_heading_optional():
     assert rendered.heading == ""
 
 
+def test_fact_gather_no_autofocus_without_errors():
+    section = _fg([Question(id="a", label="A")])
+    rendered = render_section(section, _corpus(section), {})
+    (q,) = rendered.context["questions"]
+    assert q["autofocus"] is False
+
+
+def test_fact_gather_autofocuses_first_errored_question():
+    section = _fg(
+        [
+            Question(id="a", label="A"),
+            Question(id="b", label="B"),
+            Question(id="c", label="C"),
+        ]
+    )
+    rendered = render_section(
+        section,
+        _corpus(section),
+        {},
+        errors={"b": ["Required"], "c": ["Required"]},
+    )
+    focus = {q["id"]: q["autofocus"] for q in rendered.context["questions"]}
+    # Only the first errored field takes focus — not the unerrored one before
+    # it, and not the later errored one.
+    assert focus == {"a": False, "b": True, "c": False}
+
+
 # --- summary ----------------------------------------------------------------
 
 

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -70,8 +70,14 @@ def render_section(section, corpus, answers, errors=None):
         raise ValueError(f"No SectionRenderer handler registered for {key!r}")
     rendered = handler(section, corpus, answers)
     if errors and key == "fact_gather":
+        focused = False
         for question in rendered.context["questions"]:
             question["errors"] = errors.get(question["id"], [])
+            # Move focus to the first invalid field so keyboard/SR users land
+            # on the error instead of hunting for it (WCAG 2.4.3 / 3.3.1).
+            if question["errors"] and not focused:
+                question["autofocus"] = True
+                focused = True
     return rendered
 
 
@@ -97,6 +103,7 @@ def _render_fact_gather(section, corpus, answers):
             "help_text": q.help_text,
             "value": answers.get(q.id, ""),
             "errors": [],
+            "autofocus": False,
         }
         for q in section.questions
     ]


### PR DESCRIPTION
Fixes three WCAG 2.2 AA gaps from a spot audit of the ND name-change flow, all at the shared atom/molecule level so every form and external link benefits:

- form-field / form-field-select wire `aria-describedby` to their help + error text, so a screen reader reads the error reason, not just "invalid" (SC 1.3.1 / 3.3.1)
- the link atom emits an sr-only "(opens in a new tab)" cue for every `target="_blank"` link, matching the packet button (SC 3.2.5 / 4.1.2)
- the renderer flags the first invalid fact_gather field and it renders `autofocus`, landing focus on the error after a failed POST (SC 2.4.3 / 3.3.1)

Focus is server-driven (no JS) and unit-tested at the renderer.

Closes #594

Test plan:
- [ ] `tox -e fast` green — incl. the two new renderer tests (first-errored autofocus, no-error case)
- [ ] `make lint` clean (djlint on the touched templates)
- [ ] Manual: submit the ND fact_gather with a blank required field → focus lands on it, SR announces the error text; external links announce "opens in a new tab"