### PR TITLE
docs: sizing guide + estimation calibration record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,13 @@ Field ids are validated against the chosen template — a section that doesn't m
 
 When someone references a sprint by its web-team letter/artist name ("the Ed Sheeran sprint", "Sprint F"), translate to the matching LP Iteration on board #75 via [`docs/sprint-map.md`](docs/sprint-map.md), then pull the work from #75 + git. This crosswalk is LP-specific — other JI repos don't necessarily align with the web-team retro, so it lives here, not in org-level instructions.
 
+## Sizing & estimation
+
+How we size issues so velocity maps to reality (the org-level scale + board mechanics live in `~/flp/CLAUDE.md`; these are the LP-specific practice and calibration record):
+
+- [`docs/sizing-guide.md`](docs/sizing-guide.md) — contributor/onboarding: get your estimate in the zone (size the work not the diff, incident work = size the diagnosis, XL = split). Reference anchors from real LP issues.
+- [`docs/sizing-calibration.md`](docs/sizing-calibration.md) — living team record: the estimate → verify-L1 → verify-L2 model, how to run a calibration pass, and a dated log of lessons (first entry: the It2–It4 velocity baseline + It3 reconstruction).
+
 ## Architecture
 
 ### Front-End Principles

--- a/docs/sizing-calibration.md
+++ b/docs/sizing-calibration.md
@@ -1,0 +1,106 @@
+# Sizing & estimation calibration
+
+A living record for keeping our size → velocity mapping honest as the team
+grows, and for banking what we learn each time we check estimates against
+reality. This is the internal/tuning doc; contributors who just want to size
+well should read [`sizing-guide.md`](sizing-guide.md).
+
+## Why this exists
+
+Velocity only means something to stakeholders if sizing maps to real delivered
+work, and that mapping drifts — scopes change, the team changes, the tooling
+changes. Sizing _ceremony_ (a room debating points) is theater on a small team;
+the sizing _signal_ is worth keeping, but only if we periodically verify it and
+adjust. This doc is where that verification lives.
+
+## The three-level model
+
+Estimation and its two verification passes measure different things — keep them
+separate or the signal turns to mush:
+
+| Level         | Look at                               | Measures               | Answers                             |
+| ------------- | ------------------------------------- | ---------------------- | ----------------------------------- |
+| **Estimate**  | The issue (at grooming)               | Forecast               | "How big do we think this is?"      |
+| **Verify L1** | The PR diff **+ commit/PR narrative** | Item actuals           | "How much work was it _really_?"    |
+| **Verify L2** | The iteration at close                | Commitment reliability | "Did we deliver what we committed?" |
+
+- **Estimate vs L1** calibrates the **rubric** — are our per-item sizes accurate?
+- **Committed vs L2** calibrates **capacity** — how much should we pull into a sprint?
+
+Caveat for already-done work: you can only do **L1 cleanly** in hindsight (you
+already know the outcome, so a retroactive "estimate" is contaminated). The full
+clean loop — estimate at grooming, L1 from the PRs, L2 at close — starts on
+work sized _before_ it's built.
+
+## Scale & source of truth
+
+The scale (XS 0.5 · S 1 · M 3 · L 5 · XL = split) and its point mapping live in
+**`board-sync.py:SIZE_TO_ESTIMATE`** — the single place to re-scale (e.g. moving
+to full Fibonacci) without relabeling anything. Size is the one human input at
+grooming; Estimate auto-derives; the board sums Estimate per Iteration for
+velocity. Priority/Size labels and board fields are kept in sync by
+`board-sync.py --fix`.
+
+## How to run a calibration pass
+
+1. Pull board items (number, Iteration, Size, Estimate, Status) from board #75
+   via the GraphQL `projectV2` items query.
+2. For each done item missing a Size, bundle its **issue body + closing PR**
+   (diffstat + PR body — join on the PR's `closingIssuesReferences`).
+3. Size **L1** from the diff _and the narrative_, anchored to already-sized
+   items in the same iteration — never from LOC alone.
+4. (Optional, for learning) reconstruct an issue-only **estimate** and diff it
+   against L1 — the gap is a proxy for **issue-description quality**, not a clean
+   accuracy number.
+5. Write sizes with `board-mutate.py --issue N --size X`, then
+   `board-sync.py --fix` to derive Estimates and sync labels.
+
+## Calibration log
+
+### 2026-07-02 — It2–It4 baseline + It3 reconstruction
+
+First pass. The board's Iteration field only starts at It2, so this is the
+earliest point with real tracked data.
+
+**Velocity (delivered points):**
+
+| Iteration                  | Points                   | Merged PRs | Issues closed |
+| -------------------------- | ------------------------ | ---------- | ------------- |
+| It2 (05-26→06-08)          | 11.5                     | 18         | 24            |
+| It3 (06-09→06-22)          | **20.5** (reconstructed) | 27         | 27            |
+| It4 (06-23→07-07, partial) | 10.0                     | 14         | 19            |
+
+It3 showed 6.5 on the board because 13 of its 18 done items were never sized.
+Backfilling them (L1, +14 pts) flipped It3 from an apparent collapse to the
+**biggest** iteration — which the sizing-independent throughput (27 PRs / 27
+issues) had said all along. The points now agree with throughput; that agreement
+is the point of the exercise.
+
+**Lessons (backed by the item-level data):**
+
+1. **Incident issues systematically under-size.** They're written _after_
+   diagnosis, so the hard part sits in the "Cause" section as prose while the
+   "Fix" is one line — reads XS, was S (#521, #522, #558). _Fix:_ size incident
+   work at triage, when the diagnosis is the work.
+2. **Diff ≠ effort — the textbook case is #555.** A 12-line diff, genuinely M:
+   the work was authoring docassemble interviews, loading the Playground, and
+   verifying both tracks end-to-end — none of it in the repo. LOC-based sizing
+   would have been ~6× low. What saved it: the issue's DoD spelled out the real
+   scope. Argument for reading the issue + narrative over the diffstat.
+3. **Low resolution — almost everything lands S.** The scale is correctly
+   effort-weighted (#504's 754-line `.ics` handoff is still an S), but if ~70%
+   of items are S, points barely vary and the signal starts to feel like
+   theater. Open question below.
+4. **Issue quality is generally high** — 10 of 13 estimates matched actuals; the
+   one real gap (#510) buried its actual logic (a question-id matcher) in a
+   passing mention.
+
+## Open tuning questions
+
+- **Resolution:** split S (most work clusters there), or accept that most LP
+  work is ~1-day units and treat velocity as roughly item-count?
+- **Scale shape:** is 0.5 / 1 / 3 / 5 right, or move to full Fibonacci? (One
+  line in `SIZE_TO_ESTIMATE`.)
+- **Close the loop:** start the clean estimate → L1 → L2 cycle at It5 grooming —
+  that's the first iteration where estimates exist _before_ the work, so it's
+  the first real test of rubric accuracy rather than a reconstruction.

--- a/docs/sizing-guide.md
+++ b/docs/sizing-guide.md
@@ -1,0 +1,66 @@
+# Sizing in the zone
+
+A two-minute guide to sizing an issue so the estimate tracks reality. If you're
+tuning the scale itself or logging lessons, that's the companion doc:
+[`sizing-calibration.md`](sizing-calibration.md).
+
+## The scale
+
+T-shirt sizes, calibrated to **AI-assisted** effort (one dev + an AI pair):
+
+| Size | Points | Effort     | Feels like                                 |
+| ---- | ------ | ---------- | ------------------------------------------ |
+| XS   | 0.5    | ~1–2 hours | a focused change, one place                |
+| S    | 1      | half a day | the workhorse — most issues land here      |
+| M    | 3      | 1–2 days   | spans layers, or real novelty/coordination |
+| L    | 5      | 3–4 days   | a full capability across data + API + UI   |
+| XL   | —      | too big    | **stop and split into sub-issues**         |
+
+Points are the same scale, 1:1 with size. You set the **Size**; the board
+derives the **Estimate** number and sums it per iteration for velocity. The
+mapping lives in one place — `board-sync.py:SIZE_TO_ESTIMATE` — so re-scaling is
+a one-line change, never a relabel.
+
+## Size the work, not the diff
+
+This is the whole game. Lines changed is not effort:
+
+- A **one-line fix that took three days** of debugging is not an XS. Size the
+  diagnosis, not the patch.
+- A **600-line mechanical rename** can be an XS.
+
+So read the issue and the change, not the diffstat.
+
+## Best practices — do these
+
+1. **Size from a groomed issue.** If the issue is a one-liner, you can't
+   estimate it — add scope first. A stub gets a guess, not an estimate.
+2. **Size effort, novelty, and risk** — layers crossed (data / API / UI), how
+   new the problem is, integration/deploy blast radius. Not LOC.
+3. **Incident and debugging work: size the diagnosis.** Post-mortem issues make
+   outages look trivial (the "Cause" is prose, the "Fix" is one line). The hard
+   part already happened. Size it when the diagnosis _is_ the work.
+4. **Count off-repo work.** Content authoring, infra/hosting setup, document-
+   assembly interview design, end-to-end verification — none of it shows in the
+   diff, all of it is effort.
+5. **Size relative, not absolute.** Compare to the reference anchors below
+   rather than reasoning from scratch. Consistency beats precision.
+6. **XL is a beacon, not a size.** If it's XL, break it into sub-issues before
+   it enters a sprint. Never commit an XL.
+7. **An estimate is a forecast, not a promise.** It's not a commitment or a
+   deadline, and velocity is a trend, not a contract.
+
+## Reference anchors (real LP issues)
+
+| Size | Example                                                                                                                                                                                                         |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| XS   | Drop a raw-slug breadcrumb line (#517) · add a `restart:` policy to prod services (#548)                                                                                                                        |
+| S    | New download artifact + renderer on an existing seam — `.vcf` add-to-contacts (#473) · a CD disk-prune fix that took a live-outage diagnosis (#521)                                                             |
+| M    | A decision record + coordination across sub-issues (#441) · wiring a handoff whose real work was authoring the docassemble interviews and verifying both tracks end-to-end (#555) — a 12-line diff, genuinely M |
+| L    | A full new capability spanning data + API + UI with real novelty. (Recent iterations have skewed XS–M; when an L shows up, sanity-check it isn't a hidden XL.)                                                  |
+
+## When in doubt
+
+Pick the smaller size, note your reasoning in the issue, and let the
+end-of-iteration review (delivered vs. committed) correct the scale over time.
+The goal is a consistent yardstick, not a perfect one.


### PR DESCRIPTION
Captures the reusable lessons from the It3 sizing reconstruction (backfilling 13 unsized done items, comparing issue-only estimate vs PR-diff actuals) so the knowledge compounds as the team grows instead of living in one conversation.

Two complementary docs:

- **`docs/sizing-guide.md`** — contributor/onboarding. The whole thing reduced to "get your estimate in the zone": size the work not the diff, incident work = size the diagnosis, count off-repo work, XL = split. Plus reference anchors from real LP issues.
- **`docs/sizing-calibration.md`** — living team record. The estimate → verify-L1 (PR diff + narrative) → verify-L2 (delivered vs committed) model, how to run a calibration pass, and a dated lessons log whose first entry is the It2–It4 velocity baseline + the It3 reconstruction.

`CLAUDE.md` points to both and defers the scale/board mechanics to the org-level instructions (no duplication).

Closes #596

Test plan: docs-only — prettier-clean via `make lint`; links resolve (guide ↔ calibration ↔ CLAUDE.md).