### PR TITLE
feat(prompts): hand off name-change chat to the guided flow at track confirmation

### DIFF
--- a/litigant_portal/prompts/courts/north-dakota/prompt.md
+++ b/litigant_portal/prompts/courts/north-dakota/prompt.md
@@ -20,6 +20,12 @@ ADULT NAME CHANGE — TRACKS
 - **Publication may be waived** by the judge. No 30-day waiting period if waiver is granted.
 - The judge decides whether to grant the waiver on the facts presented; eligibility for first/middle-only is met on the facts but the waiver itself is discretionary. Do not promise the waiver will be granted.
 
+GUIDED FLOW LINKS (hand off after track confirmation)
+Once the user's track is confirmed, offer the matching guided flow as a clickable markdown link — it walks them through the ND packet step by step and hands off to the form-filling interview:
+
+- Standard track → [Start the guided standard-track name-change flow](https://qa.litigantportal.com/t/north-dakota/adult-name-change/standard/)
+- Waiver track → [Start the guided waiver-track name-change flow](https://qa.litigantportal.com/t/north-dakota/adult-name-change/waiver/)
+
 FORM GOTCHAS (ND-SPECIFIC)
 
 - **Leave the case number blank** — the clerk assigns it when you file.

--- a/litigant_portal/prompts/topics/adult_name_change/prompt.md
+++ b/litigant_portal/prompts/topics/adult_name_change/prompt.md
@@ -22,6 +22,9 @@ Exact form counts, wait periods, and waiver criteria come from the Court layer.
 
 Do not ask _why_ the user is changing their name. Reasons are not required for routing. If the user volunteers a reason, accept it and move on.
 
+HANDOFF TO THE GUIDED FLOW
+Once the track is settled, don't stop at describing the forms — offer the user the guided, step-by-step flow for their track. It walks them through the jurisdiction's packet and hands off to the tool that fills the forms. The Court layer supplies the flow link per track; share it as a clickable markdown link and frame it as the next step (they can keep asking you questions here anytime). If the Court layer provides no flow link, keep guiding in chat as usual.
+
 DISQUALIFIERS AS INFORMATION
 Most name-change statutes include eligibility conditions (citizenship, intent not to defraud, not attempting to evade legal obligations). State these as facts the user self-attests to on the forms — never as interrogation. "These conditions can prevent a name change in [jurisdiction]: [facts]." Let the user apply the rule to themselves.
 


### PR DESCRIPTION
The Adult Name Change chat described the forms once a track was chosen but dead-ended — no link to the guided Topic Flow (which itself hands off to the docassemble form-filling interview). This wires the handoff at the **prompt/content layer only** — no chat-engine code — so it can't collide with the v1→v2 chat migration.

- `topics/adult_name_change/prompt.md` — court-neutral instruction to offer the guided-flow link once the track is settled, as a clickable markdown link.
- `courts/north-dakota/prompt.md` — the ND standard/waiver flow URLs.

Linking to the flow covers docassemble for free (the flow already carries the interview handoff, #555/#557). Link-out only — not capturing the packet back to the briefcase yet (#177).

Verified live on localhost: the chat offers the link at track-confirmation exactly as intended.

Closes #599

Test plan:
- [ ] In the ND Adult Name Change chat, confirm a track (standard / waiver) → assistant offers a clickable "Start the guided … flow" link
- [ ] Link opens the matching Topic Flow, which shows the "Fill out your forms" docassemble handoff

Known follow-up (#600): the chat renderer only linkifies absolute `https://`, so the flow links are QA-absolute for now — clicking from localhost cross-navigates to QA. Same-origin on QA is unaffected; env-relative links tracked in #600.