### PR TITLE
chore: local archive for court-partner corpus source docs (gitignored)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Court-partner corpus source docs — local archive only (see corpus-sources/README.md)
+/corpus-sources/*
+!/corpus-sources/README.md

--- a/corpus-sources/README.md
+++ b/corpus-sources/README.md
@@ -1,0 +1,41 @@
+# Corpus source documents (local archive)
+
+Local archive of the **source material** court partners give us — official forms,
+instruction guides, and feedback — that backs the Topic Flow corpus in
+`litigant_portal/content/`.
+
+**These files are gitignored on purpose.** Everything under `corpus-sources/`
+except this README is excluded from version control:
+
+- The durable source of truth will be an internal wiki, not this repo.
+- They are the partner's documents (often large binaries), not our code.
+- Court partners deliver them by uploading to a shared Google Drive; this
+  directory is our local working archive of those uploads.
+
+## Structure
+
+Mirror the corpus keys — one directory per court, then per topic:
+
+```
+corpus-sources/
+  <court-slug>/            # matches metadata.court, e.g. north-dakota
+    <topic-slug>/          # matches the topic, e.g. adult-name-change
+      *.docx, *.pdf …      # the files exactly as the partner delivered them
+      SOURCE.md            # optional: Drive link, date received, who uploaded
+```
+
+Example:
+
+```
+corpus-sources/north-dakota/adult-name-change/
+  Instructions for a name change adult.docx
+  Petition name change adult.docx
+  …
+```
+
+## Using it
+
+1. Drop the partner's uploaded files under the right `<court>/<topic>/`.
+2. Author or correct the corpus in `litigant_portal/content/` against them.
+3. Note provenance (a `SOURCE.md` with the Drive link + date) so a later reader
+   knows where a batch came from and how current it is.


### PR DESCRIPTION
Court partners deliver corpus source material (official forms, instruction guides, feedback) by uploading to a shared Google Drive, and the durable source of truth will be an internal wiki — not this repo. This gives us a consistent **local** archive for that material without putting the documents under version control.

## What changed
- Added a gitignored `corpus-sources/` archive, organized `<court-slug>/<topic-slug>/` to mirror the corpus keys (e.g. `corpus-sources/north-dakota/adult-name-change/`).
- Committed only `corpus-sources/README.md` (via a `.gitignore` negation) so the convention is discoverable on a fresh clone while the actual documents stay local.

## Why gitignored
- The wiki will be the source of truth long-term.
- The files are the partner's documents (often large binaries), not our code.
- More court partners and topics are coming; every one gets a predictable local home.

The existing ND Adult Name Change upload (15 `.docx`) has been moved into the new structure locally.

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)
