### PR TITLE
feat(middleware): add middleware for temp site password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,15 +37,12 @@ services:
       - ALLOWED_HOSTS=localhost,portal.localhost,127.0.0.1,0.0.0.0
       # AI Chat configuration
       - CHAT_ENABLED=${CHAT_ENABLED:-true}
-      - CHAT_MODEL=openai/gpt-4o-mini
+      - CHAT_MODEL=${CHAT_MODEL:-openai/gpt-4o-mini}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - SITE_PASSWORD=${SITE_PASSWORD}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_S3_REGION_NAME=${AWS_S3_REGION_NAME:-us-east-1}
-      - AWS_S3_ENDPOINT_URL=${AWS_S3_ENDPOINT_URL:-}
-      - AWS_S3_CUSTOM_DOMAIN=${AWS_S3_CUSTOM_DOMAIN:-}
-      - AWS_STORAGE_PUBLIC_BUCKET_NAME=${AWS_STORAGE_PUBLIC_BUCKET_NAME}
-      - AWS_STORAGE_PRIVATE_BUCKET_NAME=${AWS_STORAGE_PRIVATE_BUCKET_NAME}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     volumes:
       - ./litigant_portal:/app/litigant_portal
     stdin_open: true

--- a/litigant_portal/app/middleware.py
+++ b/litigant_portal/app/middleware.py
@@ -19,20 +19,19 @@ class SitePasswordMiddleware:
 
     def __call__(self, request):
         password = settings.SITE_PASSWORD
+        exempt = tuple(
+            p for p in (settings.STATIC_URL, settings.MEDIA_URL, "/api/") if p
+        )
         if (
             not password
             or request.session.get(self.SESSION_KEY)
-            or request.path.startswith(
-                (settings.STATIC_URL, settings.MEDIA_URL, "/api/")
-            )
+            or request.path.startswith(exempt)
         ):
             return self.get_response(request)
-        # This runs before CsrfViewMiddleware's view check, so the POST needs
-        # no CSRF token.
         if request.method == "POST" and "site_password" in request.POST:
             if request.POST["site_password"] == password:
                 request.session[self.SESSION_KEY] = True
-                return redirect(request.path)
+                return redirect(request.get_full_path())
             return render(
                 request, "site_password.html", {"error": True}, status=401
             )

--- a/litigant_portal/app/middleware.py
+++ b/litigant_portal/app/middleware.py
@@ -1,7 +1,42 @@
+from django.conf import settings
+from django.shortcuts import redirect, render
 from django.utils.functional import SimpleLazyObject
 
 from litigant_portal.app.models import UserIdentity
 from litigant_portal.app.services.identity import identity_ensure
+
+
+class SitePasswordMiddleware:
+    """Temporary password gate on pages (not /api/), active only when
+    SITE_PASSWORD is set — it keeps visitors from mistaking the dev site
+    for a live service. To remove: delete this class, its MIDDLEWARE entry,
+    the SITE_PASSWORD setting, and templates/site_password.html."""
+
+    SESSION_KEY = "site_password_ok"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        password = settings.SITE_PASSWORD
+        if (
+            not password
+            or request.session.get(self.SESSION_KEY)
+            or request.path.startswith(
+                (settings.STATIC_URL, settings.MEDIA_URL, "/api/")
+            )
+        ):
+            return self.get_response(request)
+        # This runs before CsrfViewMiddleware's view check, so the POST needs
+        # no CSRF token.
+        if request.method == "POST" and "site_password" in request.POST:
+            if request.POST["site_password"] == password:
+                request.session[self.SESSION_KEY] = True
+                return redirect(request.path)
+            return render(
+                request, "site_password.html", {"error": True}, status=401
+            )
+        return render(request, "site_password.html", status=401)
 
 
 class AnonymousSessionKeyMiddleware:

--- a/litigant_portal/app/templates/site_password.html
+++ b/litigant_portal/app/templates/site_password.html
@@ -1,0 +1,29 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex">
+    <title>Password required</title>
+    <link rel="stylesheet" href="{% static 'css/main.built.css' %}">
+</head>
+<body class="min-h-dvh flex items-center justify-center bg-greyscale-50">
+    <form method="post" class="w-full max-w-sm p-6 bg-white border border-greyscale-200 rounded-lg shadow-sm">
+        <h1 class="text-lg font-bold mb-4">This site is under development</h1>
+        <p class="text-sm text-greyscale-600 mb-4">
+            This site is a work in progress and not yet open to the public.
+            If you're part of the project, enter the password to continue.
+        </p>
+        {% if error %}
+            <p class="text-sm text-red-700 mb-4">Incorrect password.</p>
+        {% endif %}
+        <input type="password" name="site_password" autofocus
+               class="w-full px-4 py-2 border border-greyscale-300 rounded-md mb-4">
+        <button type="submit"
+                class="w-full px-4 py-2 bg-primary-600 text-white font-semibold rounded-md">
+            Enter
+        </button>
+    </form>
+</body>
+</html>

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -29,6 +29,10 @@ APP_BUILD_TIME = datetime.now().strftime("%Y/%m/%d %H:%M")
 
 SECRET_KEY = os.environ.get("SECRET_KEY") or get_random_secret_key()
 
+# Temporary site-wide password gate; empty disables it. See
+# SitePasswordMiddleware.
+SITE_PASSWORD = os.environ.get("SITE_PASSWORD", "")
+
 ALLOWED_HOSTS = [
     h.strip()
     for h in os.environ.get("ALLOWED_HOSTS", "").split(",")
@@ -57,6 +61,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "csp.middleware.CSPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "litigant_portal.app.middleware.SitePasswordMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -338,5 +343,5 @@ DEFAULT_CHAT_AGENT = os.environ.get(
     "DEFAULT_CHAT_AGENT", "LitigantAssistantAgent"
 )
 CHAT_MODEL = os.environ.get(
-    "CHAT_MODEL", "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
+    "CHAT_MODEL", "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 )


### PR DESCRIPTION
This PR adds a temporary middleware to block the whole site unless you have a password. Affects views only, not api endpoints so that health checks will still work.

I also snuck in a few small fixes so the staging deploy goes more smoothly:
- Fixed the default chat model with a valid bedrock slug for haiku
- Added optional env vars for testing bedrock models locally with your aws session credentials
- Deleted the S3 env vars from the docker compose since dev uses filesystem storage