### PR TITLE
feat(middleware): return 200s for site password page

### DIFF
--- a/litigant_portal/app/middleware.py
+++ b/litigant_portal/app/middleware.py
@@ -32,10 +32,8 @@ class SitePasswordMiddleware:
             if request.POST["site_password"] == password:
                 request.session[self.SESSION_KEY] = True
                 return redirect(request.get_full_path())
-            return render(
-                request, "site_password.html", {"error": True}, status=401
-            )
-        return render(request, "site_password.html", status=401)
+            return render(request, "site_password.html", {"error": True})
+        return render(request, "site_password.html")
 
 
 class AnonymousSessionKeyMiddleware:

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -178,7 +178,8 @@ AWS_STORAGE_PRIVATE_BUCKET_NAME = os.environ.get(
 AWS_STORAGE_PUBLIC_BUCKET_NAME = os.environ.get(
     "AWS_STORAGE_PUBLIC_BUCKET_NAME", "litigantportal-storage"
 )
-AWS_S3_PUBLIC_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
+# Temporarily disable public domain until DNS is configured
+AWS_S3_PUBLIC_CUSTOM_DOMAIN = None#os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
 
 if DEBUG:
     STORAGES = {

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -179,7 +179,9 @@ AWS_STORAGE_PUBLIC_BUCKET_NAME = os.environ.get(
     "AWS_STORAGE_PUBLIC_BUCKET_NAME", "litigantportal-storage"
 )
 # Temporarily disable public domain until DNS is configured
-AWS_S3_PUBLIC_CUSTOM_DOMAIN = None#os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
+AWS_S3_PUBLIC_CUSTOM_DOMAIN = (
+    None  # os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
+)
 
 if DEBUG:
     STORAGES = {


### PR DESCRIPTION
The password guard is returning 401s. Changing this to 200s since the guard is just to block user's from content, not a real auth error. And the 401s are confusing our EKS probes