### PR TITLE
feat(chat): demo court context switcher (dev/QA only)

### DIFF
--- a/litigant_portal/app/context_processors.py
+++ b/litigant_portal/app/context_processors.py
@@ -1,12 +1,31 @@
 from django.conf import settings
 from django.contrib.messages import get_messages
 
+from litigant_portal.app import court_context as court_ctx
+from litigant_portal.prompts import get_court_name
+
 
 def app_meta(request):
     """App-level metadata available in every template."""
     return {
         "deployment_env": settings.DEPLOYMENT_ENV,
         "app_build_time": settings.APP_BUILD_TIME,
+    }
+
+
+def court_context(request):
+    """Active court + demo-switcher data for every template.
+
+    ``court_switcher_enabled`` gates the header switcher (dev/QA only);
+    ``active_court`` / ``active_court_name`` reflect the session choice so
+    court branding is consistent app-wide.
+    """
+    active = court_ctx.get_active_court(request)
+    return {
+        "court_switcher_enabled": court_ctx.switcher_enabled(),
+        "available_courts": court_ctx.available_courts(),
+        "active_court": active,
+        "active_court_name": get_court_name(active),
     }
 
 

--- a/litigant_portal/app/court_context.py
+++ b/litigant_portal/app/court_context.py
@@ -1,0 +1,56 @@
+"""Active-court context for the demo court switcher (#632).
+
+In dev/QA a hot-switcher lets Jessica and court partners flip the active court
+on the fly; the choice is stored in the session so it persists across
+navigation. In production the switcher is hidden and the court comes from a
+per-court config object instead (future), so the session key is simply never
+set and ``get_active_court`` returns "".
+
+All logic lives here so the view, the context processor, and future callers
+share one validated path — and so the underscore/hyphen and unknown-slug
+edge cases are handled in exactly one place.
+"""
+
+from django.conf import settings
+
+from litigant_portal.prompts import is_known_court, iter_courts
+
+SESSION_KEY = "active_court"
+
+
+def switcher_enabled() -> bool:
+    """The demo court switcher is shown only outside production."""
+    return settings.DEPLOYMENT_ENV != "prod"
+
+
+def get_active_court(request) -> str:
+    """Return the session's active court slug, or "" if none or invalid.
+
+    Validated against the court registry so a stale or tampered session value
+    can't leak an unknown court downstream — callers treat "" as "no court".
+    """
+    slug = request.session.get(SESSION_KEY, "")
+    return slug if is_known_court(slug) else ""
+
+
+def set_active_court(request, slug: str) -> str:
+    """Set (or clear) the active court in the session; return the result.
+
+    A known court slug is stored. Anything else — including "" for the
+    generic / no-court option — clears the key. Returns the resulting slug
+    ("" when cleared).
+    """
+    slug = (slug or "").strip().lower()
+    if slug and is_known_court(slug):
+        request.session[SESSION_KEY] = slug
+        return slug
+    request.session.pop(SESSION_KEY, None)
+    return ""
+
+
+def available_courts() -> list[dict]:
+    """Courts the switcher can pick from — ``[{"slug", "name"}, ...]``."""
+    return [
+        {"slug": slug, "name": meta.get("name") or slug}
+        for slug, meta in iter_courts()
+    ]

--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -60,6 +60,24 @@
                class="absolute right-0 mt-2 w-max bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
                role="menu"
                aria-orientation="vertical">
+            {% if court_switcher_enabled and available_courts %}
+              {# Demo court switcher (#632) — dev/QA only; sets the session's #}
+              {# active court. Native form so it works without the menu's JS. #}
+              <form method="post" action="{% url 'pages:set_court' %}" class="border-b border-greyscale-200 px-4 py-3" role="none">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}" />
+                <label for="court-switcher" class="block text-xs font-semibold text-greyscale-400 mb-1">{% trans "Active court" %}</label>
+                <div class="flex items-center gap-2">
+                  <select id="court-switcher" name="court" class="flex-1 text-sm border border-greyscale-300 rounded-md px-2 py-1 bg-white">
+                    <option value="">{% trans "Generic (no court)" %}</option>
+                    {% for c in available_courts %}
+                      <option value="{{ c.slug }}" {% if c.slug == active_court %}selected{% endif %}>{{ c.name }}</option>
+                    {% endfor %}
+                  </select>
+                  <button type="submit" class="text-sm font-medium text-primary-600 hover:text-primary-700 px-2 py-1">{% trans "Switch" %}</button>
+                </div>
+              </form>
+            {% endif %}
             <button type="button" x-on:click="resetDemo" class="flex items-center gap-2 w-full px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
               {% trans "Reset Demo" %}

--- a/litigant_portal/app/tests/test_court_context.py
+++ b/litigant_portal/app/tests/test_court_context.py
@@ -1,0 +1,180 @@
+"""Tests for the demo court context switcher (#632).
+
+Helper + context-processor tests are DB-free (SimpleTestCase). The view and
+chat_page tests exercise the session end-to-end via the test client.
+"""
+
+import pytest
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+)
+from django.urls import reverse
+
+from litigant_portal.app import court_context as cc
+from litigant_portal.app.context_processors import court_context
+
+
+class CourtContextHelperTests(SimpleTestCase):
+    """The single validated path for reading/writing the active court."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _req(self, session=None):
+        request = self.factory.get("/")
+        request.session = {} if session is None else session
+        return request
+
+    @override_settings(DEPLOYMENT_ENV="dev")
+    def test_switcher_enabled_in_dev(self):
+        self.assertTrue(cc.switcher_enabled())
+
+    @override_settings(DEPLOYMENT_ENV="qa")
+    def test_switcher_enabled_in_qa(self):
+        self.assertTrue(cc.switcher_enabled())
+
+    @override_settings(DEPLOYMENT_ENV="prod")
+    def test_switcher_disabled_in_prod(self):
+        self.assertFalse(cc.switcher_enabled())
+
+    def test_active_court_empty_when_unset(self):
+        self.assertEqual(cc.get_active_court(self._req()), "")
+
+    def test_active_court_returns_known_slug(self):
+        request = self._req({cc.SESSION_KEY: "north-dakota"})
+        self.assertEqual(cc.get_active_court(request), "north-dakota")
+
+    def test_active_court_rejects_unknown_slug(self):
+        # A stale/tampered session value must not leak an unknown court.
+        request = self._req({cc.SESSION_KEY: "atlantis"})
+        self.assertEqual(cc.get_active_court(request), "")
+
+    def test_set_stores_known_court(self):
+        request = self._req()
+        self.assertEqual(
+            cc.set_active_court(request, "north-dakota"), "north-dakota"
+        )
+        self.assertEqual(request.session[cc.SESSION_KEY], "north-dakota")
+
+    def test_set_blank_clears_selection(self):
+        request = self._req({cc.SESSION_KEY: "north-dakota"})
+        self.assertEqual(cc.set_active_court(request, ""), "")
+        self.assertNotIn(cc.SESSION_KEY, request.session)
+
+    def test_set_unknown_clears_selection(self):
+        request = self._req({cc.SESSION_KEY: "north-dakota"})
+        self.assertEqual(cc.set_active_court(request, "atlantis"), "")
+        self.assertNotIn(cc.SESSION_KEY, request.session)
+
+    def test_set_normalizes_case_and_whitespace(self):
+        request = self._req()
+        self.assertEqual(
+            cc.set_active_court(request, "  North-Dakota "), "north-dakota"
+        )
+
+    def test_available_courts_shape_includes_known_court(self):
+        courts = cc.available_courts()
+        self.assertTrue(all({"slug", "name"} <= set(c) for c in courts))
+        self.assertIn("north-dakota", [c["slug"] for c in courts])
+
+
+class CourtContextProcessorTests(SimpleTestCase):
+    """Exposes the switcher + active court to every template."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _req(self, session=None):
+        request = self.factory.get("/")
+        request.session = {} if session is None else session
+        return request
+
+    @override_settings(DEPLOYMENT_ENV="dev")
+    def test_exposes_switcher_and_courts(self):
+        ctx = court_context(self._req())
+        self.assertTrue(ctx["court_switcher_enabled"])
+        self.assertIn(
+            "north-dakota", [c["slug"] for c in ctx["available_courts"]]
+        )
+        self.assertEqual(ctx["active_court"], "")
+        self.assertEqual(ctx["active_court_name"], "")
+
+    @override_settings(DEPLOYMENT_ENV="prod")
+    def test_switcher_disabled_in_prod(self):
+        self.assertFalse(court_context(self._req())["court_switcher_enabled"])
+
+    def test_reflects_active_court_from_session(self):
+        ctx = court_context(self._req({cc.SESSION_KEY: "north-dakota"}))
+        self.assertEqual(ctx["active_court"], "north-dakota")
+        self.assertTrue(ctx["active_court_name"])  # resolved display name
+
+
+@pytest.mark.postgres
+class SetCourtViewTests(TestCase):
+    """POST-only view that writes the session and redirects safely."""
+
+    def test_post_sets_court_and_redirects_to_next(self):
+        resp = self.client.post(
+            reverse("pages:set_court"),
+            {
+                "court": "north-dakota",
+                "next": "/chat/?topic=adult_name_change",
+            },
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, "/chat/?topic=adult_name_change")
+        self.assertEqual(self.client.session[cc.SESSION_KEY], "north-dakota")
+
+    def test_post_blank_clears_selection(self):
+        self.client.post(reverse("pages:set_court"), {"court": "north-dakota"})
+        self.client.post(reverse("pages:set_court"), {"court": ""})
+        self.assertNotIn(cc.SESSION_KEY, self.client.session)
+
+    def test_offsite_next_falls_back_to_home(self):
+        resp = self.client.post(
+            reverse("pages:set_court"),
+            {"court": "north-dakota", "next": "https://evil.example/x"},
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("pages:home"))
+
+    def test_get_is_404(self):
+        self.assertEqual(
+            self.client.get(reverse("pages:set_court")).status_code, 404
+        )
+
+    @override_settings(DEPLOYMENT_ENV="prod")
+    def test_disabled_in_prod_is_404(self):
+        resp = self.client.post(
+            reverse("pages:set_court"), {"court": "north-dakota"}
+        )
+        self.assertEqual(resp.status_code, 404)
+
+
+@pytest.mark.postgres
+class ChatPageActiveCourtTests(TestCase):
+    """chat_page resolves court from the session, param overrides + persists."""
+
+    def test_uses_session_active_court(self):
+        session = self.client.session
+        session[cc.SESSION_KEY] = "north-dakota"
+        session.save()
+        resp = self.client.get(
+            reverse("pages:chat") + "?topic=adult_name_change"
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.context["court_slug"], "north-dakota")
+        self.assertTrue(resp.context["court_name"])
+
+    def test_explicit_court_param_overrides_and_persists(self):
+        session = self.client.session
+        session[cc.SESSION_KEY] = "north-dakota"
+        session.save()
+        resp = self.client.get(
+            reverse("pages:chat") + "?topic=eviction&court=dupage-il"
+        )
+        self.assertEqual(resp.context["court_slug"], "dupage-il")
+        self.assertEqual(self.client.session[cc.SESSION_KEY], "dupage-il")

--- a/litigant_portal/app/tests/test_portal.py
+++ b/litigant_portal/app/tests/test_portal.py
@@ -603,17 +603,25 @@ class ChatPageCourtTests(TestCase):
         self.assertEqual(response.context["court_name"], "")
 
     def test_court_name_rendered_in_subheader(self):
-        """Template renders the court-branding eyebrow when court_name is set."""
+        """Template renders the court-branding eyebrow when court_name is set.
+
+        Asserts the eyebrow element itself (``court-branding``), not the raw
+        court name — the name also appears as an option in the dev court
+        switcher, so a bare string match would pass vacuously.
+        """
         response = self.client.get(
             "/chat/?topic=adult_name_change&court=north-dakota"
         )
-        self.assertContains(response, "North Dakota Courts")
+        self.assertContains(response, "court-branding")
 
     def test_court_name_absent_when_no_court(self):
-        """Template does not render the eyebrow when no court is set."""
+        """Template does not render the eyebrow when no court is set.
+
+        Targets the ``court-branding`` eyebrow rather than the court name,
+        which the dev court switcher lists as a dropdown option regardless.
+        """
         response = self.client.get("/chat/?topic=eviction")
-        self.assertNotContains(response, "North Dakota Courts")
-        self.assertNotContains(response, "DuPage County Circuit Court")
+        self.assertNotContains(response, "court-branding")
 
 
 # =============================================================================

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -25,6 +25,7 @@ app_patterns = [
     ),
     path("chat/", pages.chat_page, name="chat"),
     path("chat-v2/", pages.chat_v2_view, name="chat_v2"),
+    path("set-court/", pages.set_court, name="set_court"),
     path("chat/action-plan/", endpoints.action_plan, name="action_plan"),
     path("style-guide/", pages.style_guide, name="style_guide"),
     # Agent testing

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -194,6 +194,10 @@ def topic_detail(request, slug):
 
 def chat_page(request):
     """Chat page - AI-powered legal assistance chat interface."""
+    from litigant_portal.app.court_context import (
+        get_active_court,
+        set_active_court,
+    )
     from litigant_portal.prompts import get_court_name, is_known_court
 
     slug = request.GET.get("topic", "").strip()
@@ -205,9 +209,17 @@ def chat_page(request):
             lines.append(f"{section['heading']}: {section['body']}")
         topic_context = "\n".join(lines)
 
-    court_slug = request.GET.get("court", "").strip().lower()
-    if court_slug and not is_known_court(court_slug):
-        court_slug = ""
+    # Active court comes from the session (demo switcher, #632). An explicit,
+    # valid ?court= (deep-link path) overrides and persists it, so the chosen
+    # court sticks across navigation instead of living only in the URL.
+    court_slug = get_active_court(request)
+    param_court = request.GET.get("court", "").strip().lower()
+    if (
+        param_court
+        and is_known_court(param_court)
+        and param_court != court_slug
+    ):
+        court_slug = set_active_court(request, param_court)
 
     return render(
         request,
@@ -220,6 +232,33 @@ def chat_page(request):
             "court_name": get_court_name(court_slug),
         },
     )
+
+
+def set_court(request):
+    """Demo court switcher: set the session's active court, then redirect back.
+
+    Dev/QA only (#632) — hidden and inert in production, where the court comes
+    from a per-court config object rather than a user switcher. POST only; a
+    blank / unknown court clears the selection (the generic, no-court option).
+    """
+    from django.utils.http import url_has_allowed_host_and_scheme
+
+    from litigant_portal.app.court_context import (
+        set_active_court,
+        switcher_enabled,
+    )
+
+    if not switcher_enabled() or request.method != "POST":
+        raise Http404()
+
+    set_active_court(request, request.POST.get("court", ""))
+
+    nxt = request.POST.get("next", "")
+    if url_has_allowed_host_and_scheme(
+        nxt, allowed_hosts={request.get_host()}
+    ):
+        return redirect(nxt)
+    return redirect("pages:home")
 
 
 def chat_v2_view(request):

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -83,6 +83,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 # "portal.context_processors.toast_messages",
                 "litigant_portal.app.context_processors.app_meta",
+                "litigant_portal.app.context_processors.court_context",
             ],
             "builtins": [
                 "django_cotton.templatetags.cotton",


### PR DESCRIPTION
Adds a session-backed active court with a hot-switcher in the dev-tools menu, so demos and court-partner testing can operate inside a court from the start. Production resolves court from a per-court config object instead (future), so the switcher is hidden and inert outside dev/QA. This is the substrate the persistent chat→flow links (#633) build on via `get_active_court`.

- `court_context` helper: one validated path for reading/writing the active court (rejects unknown/stale slugs; clears on the generic option)
- context processor exposes switcher state + active court app-wide
- `set-court` POST view: dev/QA-gated, safe same-host redirect back
- switcher `<select>` in the existing dev-tools menu (already gated `deployment_env != "prod"`)
- `chat_page` resolves court from the session; an explicit valid `?court=` (deep-link) overrides and persists it

Part of #632

## Test plan
- `make test` — new `test_court_context.py` (helper + context-processor DB-free `SimpleTestCase`; `set-court` view + `chat_page` behavioral) is green; retargeted two pre-existing `test_portal.py` court-branding tests to the `court-branding` eyebrow, which the switcher's dropdown options no longer collide with.
- Manual (dev/QA): header dev-tools menu → "Active court" → Switch → the choice persists across navigation and the sub-header branding reflects it; confirm the switcher is absent under `DEPLOYMENT_ENV=prod`.
