### PR TITLE
feat(chat): mobile drawer for case briefcase + activity timeline

### DIFF
--- a/litigant_portal/app/src/main.css
+++ b/litigant_portal/app/src/main.css
@@ -615,6 +615,26 @@
     animation: sidebar-flash 1.5s ease-out;
   }
 
+  /* Mobile case drawer — slides in from the right */
+  @keyframes drawer-slide-in {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  .drawer-panel {
+    animation: drawer-slide-in 0.2s ease-out;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .drawer-panel {
+      animation: none;
+    }
+  }
+
   /* Activity panel */
   .activity-panel {
     @apply flex flex-col h-full;

--- a/litigant_portal/app/static/js/chat.js
+++ b/litigant_portal/app/static/js/chat.js
@@ -638,10 +638,10 @@ function createHomePage() {
       return this.caseTimeline.length
     },
 
-    // --- Mobile case drawer (dialog a11y: focus in, trap, escape, focus out) ---
+    // --- Mobile case drawer (non-modal: nav stays interactive above it) ---
     openCasePanel() {
+      if (this.casePanelOpen) return
       this.casePanelOpen = true
-      document.body.classList.add('overflow-hidden')
       this.$nextTick(() => {
         if (this.$refs.casePanelClose) this.$refs.casePanelClose.focus()
       })
@@ -649,25 +649,33 @@ function createHomePage() {
     closeCasePanel() {
       if (!this.casePanelOpen) return
       this.casePanelOpen = false
-      document.body.classList.remove('overflow-hidden')
       if (this.$refs.casePanelTrigger) this.$refs.casePanelTrigger.focus()
     },
-    casePanelKeydown(event) {
-      if (event.key !== 'Tab' || !this.$refs.casePanel) return
-      const focusables = Array.from(
-        this.$refs.casePanel.querySelectorAll(
-          'button:not([disabled]), a[href], summary, input:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        )
-      ).filter((el) => el.offsetParent !== null)
-      if (!focusables.length) return
-      const first = focusables[0]
-      const last = focusables[focusables.length - 1]
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault()
-        last.focus()
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault()
-        first.focus()
+
+    // Drawer swipe gestures: left-swipe opens, right-swipe closes. Single-touch,
+    // horizontal-dominant with a distance threshold — never hijacks vertical scrolling.
+    _swipeStartX: null,
+    _swipeStartY: null,
+    chatTouchStart(event) {
+      if (event.touches.length !== 1) {
+        this._swipeStartX = null
+        return
+      }
+      this._swipeStartX = event.touches[0].clientX
+      this._swipeStartY = event.touches[0].clientY
+    },
+    chatTouchEnd(event) {
+      if (this._swipeStartX === null) return
+      const dx = event.changedTouches[0].clientX - this._swipeStartX
+      const dy = event.changedTouches[0].clientY - this._swipeStartY
+      this._swipeStartX = null
+      // The drawer only exists below lg (1024px)
+      if (window.innerWidth >= 1024) return
+      if (Math.abs(dx) < 48 || Math.abs(dx) < Math.abs(dy) * 2) return
+      if (this.casePanelOpen && dx > 0) {
+        this.closeCasePanel()
+      } else if (!this.casePanelOpen && dx < 0) {
+        this.openCasePanel()
       }
     },
 

--- a/litigant_portal/app/static/js/chat.js
+++ b/litigant_portal/app/static/js/chat.js
@@ -449,6 +449,9 @@ function createHomePage() {
     // --- Timeline state ---
     caseTimeline: [],
 
+    // --- Mobile case drawer state ---
+    casePanelOpen: false,
+
     // --- Sidebar flash state ---
     _sidebarFlash: false,
 
@@ -630,6 +633,42 @@ function createHomePage() {
     },
     get noTimeline() {
       return this.caseTimeline.length === 0
+    },
+    get timelineCount() {
+      return this.caseTimeline.length
+    },
+
+    // --- Mobile case drawer (dialog a11y: focus in, trap, escape, focus out) ---
+    openCasePanel() {
+      this.casePanelOpen = true
+      document.body.classList.add('overflow-hidden')
+      this.$nextTick(() => {
+        if (this.$refs.casePanelClose) this.$refs.casePanelClose.focus()
+      })
+    },
+    closeCasePanel() {
+      if (!this.casePanelOpen) return
+      this.casePanelOpen = false
+      document.body.classList.remove('overflow-hidden')
+      if (this.$refs.casePanelTrigger) this.$refs.casePanelTrigger.focus()
+    },
+    casePanelKeydown(event) {
+      if (event.key !== 'Tab' || !this.$refs.casePanel) return
+      const focusables = Array.from(
+        this.$refs.casePanel.querySelectorAll(
+          'button:not([disabled]), a[href], summary, input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter((el) => el.offsetParent !== null)
+      if (!focusables.length) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
     },
 
     // Case status

--- a/litigant_portal/app/templates/cotton/organisms/activity_timeline.html
+++ b/litigant_portal/app/templates/cotton/organisms/activity_timeline.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+
+{# Activity timeline content — empty state + session event cards. #}
+{# Binds to homePage Alpine state; rendered in the desktop activity-panel AND the mobile drawer. #}
+{# Empty state #}
+<div x-show="noTimeline" class="text-center py-8 px-4">
+  <c-atoms.icon name="clock" class="w-6 h-6 text-greyscale-300 mx-auto mb-3" />
+  <p class="text-sm font-medium text-greyscale-500 mb-2">{% trans "Your documents & deadlines" %}</p>
+  <p class="text-xs text-greyscale-400">
+    {% trans "I'll save important information here as we talk." %}
+  </p>
+</div>
+{# Timeline events #}
+<template x-if="hasTimeline">
+  <div class="space-y-2">
+    <template x-for="event in caseTimeline" :key="event.id">
+      <details class="timeline-event-card">
+        <summary class="timeline-event-summary">
+          <template x-if="event.isUpload">
+            <c-atoms.icon name="document-arrow-up" class="timeline-event-icon" />
+          </template>
+          <template x-if="event.isSummary">
+            <c-atoms.icon name="document-text" class="timeline-event-icon" />
+          </template>
+          <template x-if="event.isChange">
+            <c-atoms.icon name="pencil-square" class="timeline-event-icon" />
+          </template>
+          <template x-if="event.isResolution">
+            <c-atoms.icon name="check-circle" class="timeline-event-icon text-green-600" />
+          </template>
+          <span class="timeline-event-title" x-text="event.title"></span>
+          <span class="timeline-event-badge" x-text="event.typeLabel"></span>
+        </summary>
+        <div class="timeline-event-body" x-show="event.content">
+          <p class="text-xs text-greyscale-600" x-text="event.content"></p>
+          <p class="text-xs text-greyscale-400 mt-1" x-text="event.formattedTime"></p>
+        </div>
+      </details>
+    </template>
+  </div>
+</template>

--- a/litigant_portal/app/templates/cotton/organisms/case_sidebar_content.html
+++ b/litigant_portal/app/templates/cotton/organisms/case_sidebar_content.html
@@ -1,0 +1,261 @@
+{% load i18n %}
+
+{# Case briefcase content — error alert, empty state, and full case display. #}
+{# Binds to homePage Alpine state; rendered in the desktop case-sidebar AND the mobile drawer. #}
+{% trans "Deadlines" as deadlines_heading %}
+{% trans "Other Dates" as other_dates_heading %}
+{% trans "Your Rights & Defenses" as rights_heading %}
+{% trans "Possible Next Steps" as next_steps_heading %}
+{% trans "Resources" as resources_heading %}
+{# Clear-failed error — surfaced when archive request fails so case isn't silently wiped. #}
+{# c-atoms.alert hardcodes role="alert"; no extra aria-live wrapper needed. #}
+<div x-show="caseInfoError" x-cloak>
+  <c-atoms.alert variant="danger" class="text-sm">
+    <span x-text="caseInfoError"></span>
+  </c-atoms.alert>
+</div>
+{# Empty state #}
+<div x-show="noCaseInfo" class="text-center py-8 px-4">
+  <div class="w-10 h-10 rounded-lg bg-primary-50 flex items-center justify-center mx-auto mb-3">
+    <c-atoms.icon name="folder-open" class="w-5 h-5 text-primary-300" />
+  </div>
+  <p class="text-sm font-medium text-greyscale-600 mb-2">{% trans "Your case details" %}</p>
+  <p class="text-xs text-greyscale-400">
+    {% trans "Answer a few questions below and I'll fill this in as we go." %}
+  </p>
+</div>
+{# Case info display #}
+<div x-show="caseInfo" x-cloak x-bind:class="sidebarFlash" class="p-4 space-y-4">
+  {# Case type header #}
+  <div class="border-b border-greyscale-200 pb-3">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class="text-sm font-semibold text-greyscale-900" x-text="caseTitle"></h3>
+      <span
+        x-show="isCaseResolved"
+        x-cloak
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700"
+      >
+        <c-atoms.icon name="check-circle" class="w-3 h-3" />
+        {% trans "Resolved" %}
+      </span>
+    </div>
+    <p class="text-xs text-greyscale-500 mt-1"
+       x-show="hasCaseNumber"
+       x-text="caseNumber"></p>
+  </div>
+  {# Court info #}
+  <div x-show="showCourtSection" class="space-y-1">
+    <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Court" %}</h4>
+    <p class="text-sm text-greyscale-700" x-text="courtName"></p>
+    <p x-show="courtCounty"
+       class="text-xs text-greyscale-500"
+       x-text="courtCounty"></p>
+    <p x-show="courtAddress"
+       class="text-xs text-greyscale-600"
+       x-text="courtAddress"></p>
+    <p x-show="courtPhone" class="text-xs text-greyscale-600">
+      <a x-bind:href="courtPhoneHref"
+         class="text-primary-600 hover:underline"
+         x-text="courtPhone"></a>
+    </p>
+    <p x-show="courtEmail" class="text-xs text-greyscale-600">
+      <a x-bind:href="courtEmailHref"
+         class="text-primary-600 hover:underline"
+         x-text="courtEmail"></a>
+    </p>
+  </div>
+  {# Opposing Party #}
+  <div x-show="opposingParty" class="space-y-1">
+    <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Opposing Party" %}</h4>
+    <p class="text-sm text-greyscale-700" x-text="opposingParty"></p>
+    <p x-show="opposingAddress"
+       class="text-xs text-greyscale-600"
+       x-text="opposingAddress"></p>
+    <p x-show="opposingPhone" class="text-xs text-greyscale-600">
+      <a x-bind:href="opposingPhoneHref"
+         class="text-primary-600 hover:underline"
+         x-text="opposingPhone"></a>
+    </p>
+    <p x-show="opposingEmail" class="text-xs text-greyscale-600">
+      <a x-bind:href="opposingEmailHref"
+         class="text-primary-600 hover:underline"
+         x-text="opposingEmail"></a>
+    </p>
+    <p x-show="opposingWebsite" class="text-xs text-greyscale-600">
+      <a x-bind:href="opposingWebsite"
+         target="_blank"
+         rel="noopener"
+         class="text-primary-600 hover:underline"
+         x-text="opposingWebsite"></a>
+    </p>
+  </div>
+  {# Attorney (if represented) #}
+  <div x-show="attorneyName" class="space-y-1">
+    <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Their Attorney" %}</h4>
+    <p class="text-sm text-greyscale-700" x-text="attorneyName"></p>
+    <p x-show="attorneyPhone" class="text-xs text-greyscale-600">
+      <a x-bind:href="attorneyPhoneHref"
+         class="text-primary-600 hover:underline"
+         x-text="attorneyPhone"></a>
+    </p>
+    <p x-show="attorneyEmail" class="text-xs text-greyscale-600">
+      <a x-bind:href="attorneyEmailHref"
+         class="text-primary-600 hover:underline"
+         x-text="attorneyEmail"></a>
+    </p>
+  </div>
+  {# Key deadlines #}
+  <template x-if="hasDeadlines">
+    <c-molecules.sidebar-section title="{{ deadlines_heading }}">
+      <template x-for="deadline in deadlines" :key="deadline.id">
+        <c-molecules.deadline-card variant="urgent">
+          <div class="flex items-start justify-between gap-1">
+            <div class="min-w-0">
+              <p class="text-sm font-medium text-red-700" x-text="deadline.date"></p>
+              <p class="text-xs text-red-600 truncate" x-text="deadline.label"></p>
+            </div>
+            <button
+              type="button"
+              x-bind:data-deadline-id="deadline.id"
+              x-on:click="toggleDeadlineReminder"
+              x-bind:title="deadline.reminderTitle"
+              class="flex-shrink-0 p-0.5 rounded hover:bg-red-100"
+            >
+              <template x-if="deadline.hasReminder">
+                <c-atoms.icon name="bell-alert" style="solid" class="w-3.5 h-3.5 text-red-600" />
+              </template>
+              <template x-if="deadline.noReminder">
+                <c-atoms.icon name="bell" class="w-3.5 h-3.5 text-red-400" />
+              </template>
+            </button>
+          </div>
+        </c-molecules.deadline-card>
+      </template>
+    </c-molecules.sidebar-section>
+  </template>
+  {# Other dates #}
+  <template x-if="hasOtherDates">
+    <c-molecules.sidebar-section title="{{ other_dates_heading }}">
+      <template x-for="date in otherDates" :key="date.label">
+        <c-molecules.deadline-card>
+          <p class="text-sm text-greyscale-700" x-text="date.date"></p>
+          <p class="text-xs text-greyscale-500 truncate" x-text="date.label"></p>
+        </c-molecules.deadline-card>
+      </template>
+    </c-molecules.sidebar-section>
+  </template>
+  {# Action plan — spotted issues #}
+  <template x-if="hasSpottedIssues">
+    <c-molecules.sidebar-section title="{{ rights_heading }}">
+      <template x-for="issue in spottedIssues" :key="issue.title">
+        <div class="flex items-start gap-2 p-2 bg-blue-50 border border-blue-100 rounded-lg">
+          <c-atoms.icon name="shield-check" class="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-blue-800" x-text="issue.title"></p>
+            <p x-show="issue.description"
+               class="text-xs text-blue-600 mt-0.5"
+               x-text="issue.description"></p>
+            <p x-show="issue.statute"
+               class="text-xs text-blue-400 mt-0.5"
+               x-text="issue.statute"></p>
+          </div>
+        </div>
+      </template>
+    </c-molecules.sidebar-section>
+  </template>
+  {# Action plan — action items #}
+  <template x-if="hasActionItems">
+    <c-molecules.sidebar-section title="{{ next_steps_heading }}">
+      <template x-for="item in actionItems" :key="item.id">
+        <c-molecules.action-item
+          x-bind:class="item.bgClass"
+          x-bind:data-item-id="item.id"
+          x-on:click="toggleActionItem"
+          role="checkbox"
+          tabindex="0"
+          x-bind:aria-checked="item.isCompleted"
+          class="cursor-pointer"
+        >
+          <template x-if="item.isCompleted">
+            <c-atoms.icon name="check-circle" style="solid" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+          </template>
+          <template x-if="item.isUrgentOpen">
+            <span class="flex-shrink-0 mt-0.5">
+              <c-atoms.icon name="exclamation-triangle" style="solid" class="w-4 h-4 text-red-500" />
+              <span class="sr-only">{% trans "Urgent" %}</span>
+            </span>
+          </template>
+          <template x-if="item.isNormalOpen">
+            <div class="w-4 h-4 rounded-full border-2 flex-shrink-0 mt-0.5"
+                 x-bind:class="item.borderClass"></div>
+          </template>
+          <div class="min-w-0">
+            <p class="text-sm font-medium"
+               x-bind:class="item.titleClass"
+               x-text="item.title"></p>
+            <p x-show="item.description"
+               class="text-xs mt-0.5"
+               x-bind:class="item.descClass"
+               x-text="item.description"></p>
+            <p x-show="item.deadline"
+               class="text-xs mt-0.5"
+               x-bind:class="item.dateClass">
+              <c-atoms.icon name="clock" class="w-3 h-3 inline -mt-0.5 mr-0.5" />
+              <span x-text="item.deadline"></span>
+            </p>
+          </div>
+        </c-molecules.action-item>
+      </template>
+    </c-molecules.sidebar-section>
+  </template>
+  {# Action plan — resources #}
+  <template x-if="hasResources">
+    <c-molecules.sidebar-section title="{{ resources_heading }}">
+      <template x-for="resource in resources" :key="resource.title">
+        <div class="flex items-start gap-2 p-2 bg-green-50 border border-green-100 rounded-lg">
+          <c-atoms.icon name="link" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-green-800" x-text="resource.title"></p>
+            <p x-show="resource.description"
+               class="text-xs text-green-600 mt-0.5"
+               x-text="resource.description"></p>
+          </div>
+        </div>
+      </template>
+    </c-molecules.sidebar-section>
+  </template>
+  {# Sidebar footer — resolve, print, new case #}
+  <div class="pt-3 border-t border-greyscale-200 space-y-2">
+    {# Resolve button — active cases with action plan #}
+    <template x-if="showResolveButton">
+      <c-atoms.button
+        type="button"
+        variant="primary"
+        full_width
+        x-on:click="resolveCase"
+      >
+        <c-atoms.icon name="check-circle" class="w-4 h-4" />
+        {% trans "Mark resolved" %}
+      </c-atoms.button>
+    </template>
+    {# New case button — after resolution #}
+    <template x-if="isCaseResolved">
+      <c-atoms.button
+        type="button"
+        variant="outline"
+        full_width
+        x-on:click="clearCaseInfo"
+      >
+        <c-atoms.icon name="plus" class="w-4 h-4" />
+        {% trans "New case" %}
+      </c-atoms.button>
+    </template>
+    <a href="{% url 'pages:action_plan' %}"
+       target="_blank"
+       rel="noopener"
+       class="flex items-center gap-2 text-xs font-medium text-primary-600 hover:text-primary-700 hover:underline">
+      <c-atoms.icon name="printer" class="w-4 h-4" />
+      {% trans "Printable summary" %}
+    </a>
+  </div>
+</div>

--- a/litigant_portal/app/templates/pages/chat.html
+++ b/litigant_portal/app/templates/pages/chat.html
@@ -20,7 +20,9 @@
        data-agent-name="{{ agent_name|default:'' }}"
        data-topic-slug="{{ topic_slug|default:'' }}"
        data-court-slug="{{ court_slug|default:'' }}"
-       class="flex-1 flex flex-row min-h-0">
+       x-on:touchstart.passive="chatTouchStart"
+       x-on:touchend.passive="chatTouchEnd"
+       class="relative flex-1 flex flex-row min-h-0">
     {# Hidden file input for PDF upload #}
     <input type="file"
            x-ref="fileInput"
@@ -276,10 +278,11 @@
         <c-organisms.activity-timeline />
       </c-organisms.activity-panel>
     </div>
-    {# Mobile drawer — same case + activity state as the desktop columns, overlay below lg #}
+    {# Mobile drawer — same case + activity state as the desktop columns. Overlays the content #}
+    {# area only (root is relative), so the site nav stays visible and interactive: non-modal. #}
     <div x-show="casePanelOpen"
          x-cloak
-         class="lg:hidden fixed inset-0 z-50"
+         class="lg:hidden absolute inset-0 z-30 overflow-hidden"
          x-on:keydown.escape.window="closeCasePanel">
       {# Backdrop — click closes #}
       <div class="absolute inset-0 bg-greyscale-900/50"
@@ -289,11 +292,8 @@
       {% trans "Close case details" as drawer_close_label %}
       <div id="case-drawer"
            role="dialog"
-           aria-modal="true"
            aria-label="{{ drawer_label }}"
-           x-ref="casePanel"
-           x-on:keydown="casePanelKeydown"
-           class="absolute inset-y-0 right-0 w-5/6 max-w-sm bg-white shadow-xl flex flex-col">
+           class="drawer-panel absolute inset-y-0 right-0 w-5/6 max-w-sm bg-white shadow-xl flex flex-col">
         {# Drawer header — mirrors the case-sidebar shell header + close #}
         <div class="flex items-center justify-between px-4 pt-4 pb-3 border-b border-greyscale-200">
           <h2 class="text-xs font-semibold uppercase tracking-wider text-greyscale-400">{% trans "Your Case" %}</h2>

--- a/litigant_portal/app/templates/pages/chat.html
+++ b/litigant_portal/app/templates/pages/chat.html
@@ -13,11 +13,6 @@
 {% trans "Upload PDF document" as upload_pdf_label %}
 {% trans "Describe your situation — what happened?" as input_placeholder %}
 {% trans "Ask a question" as input_aria_label %}
-{% trans "Deadlines" as deadlines_heading %}
-{% trans "Other Dates" as other_dates_heading %}
-{% trans "Your Rights & Defenses" as rights_heading %}
-{% trans "Possible Next Steps" as next_steps_heading %}
-{% trans "Resources" as resources_heading %}
 
 {% block content %}
   {{ topic_context|json_script:"topic-context-data" }}
@@ -78,266 +73,15 @@
             {% trans "Clear" %}
           </c-atoms.button>
         </c-slot>
-        {# Clear-failed error — surfaced when archive request fails so case isn't silently wiped. #}
-        {# c-atoms.alert hardcodes role="alert"; no extra aria-live wrapper needed. #}
-        <div x-show="caseInfoError" x-cloak>
-          <c-atoms.alert variant="danger" class="text-sm">
-            <span x-text="caseInfoError"></span>
-          </c-atoms.alert>
-        </div>
-        {# Empty state #}
-        <div x-show="noCaseInfo" class="text-center py-8 px-4">
-          <div class="w-10 h-10 rounded-lg bg-primary-50 flex items-center justify-center mx-auto mb-3">
-            <c-atoms.icon name="folder-open" class="w-5 h-5 text-primary-300" />
-          </div>
-          <p class="text-sm font-medium text-greyscale-600 mb-2">{% trans "Your case details" %}</p>
-          <p class="text-xs text-greyscale-400">
-            {% trans "Answer a few questions below and I'll fill this in as we go." %}
-          </p>
-        </div>
-        {# Case info display #}
-        <div x-show="caseInfo" x-cloak x-bind:class="sidebarFlash" class="p-4 space-y-4">
-          {# Case type header #}
-          <div class="border-b border-greyscale-200 pb-3">
-            <div class="flex items-center justify-between gap-2">
-              <h3 class="text-sm font-semibold text-greyscale-900" x-text="caseTitle"></h3>
-              <span
-                x-show="isCaseResolved"
-                x-cloak
-                class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700"
-              >
-                <c-atoms.icon name="check-circle" class="w-3 h-3" />
-                {% trans "Resolved" %}
-              </span>
-            </div>
-            <p class="text-xs text-greyscale-500 mt-1"
-               x-show="hasCaseNumber"
-               x-text="caseNumber"></p>
-          </div>
-          {# Court info #}
-          <div x-show="showCourtSection" class="space-y-1">
-            <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Court" %}</h4>
-            <p class="text-sm text-greyscale-700" x-text="courtName"></p>
-            <p x-show="courtCounty"
-               class="text-xs text-greyscale-500"
-               x-text="courtCounty"></p>
-            <p x-show="courtAddress"
-               class="text-xs text-greyscale-600"
-               x-text="courtAddress"></p>
-            <p x-show="courtPhone" class="text-xs text-greyscale-600">
-              <a x-bind:href="courtPhoneHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="courtPhone"></a>
-            </p>
-            <p x-show="courtEmail" class="text-xs text-greyscale-600">
-              <a x-bind:href="courtEmailHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="courtEmail"></a>
-            </p>
-          </div>
-          {# Opposing Party #}
-          <div x-show="opposingParty" class="space-y-1">
-            <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Opposing Party" %}</h4>
-            <p class="text-sm text-greyscale-700" x-text="opposingParty"></p>
-            <p x-show="opposingAddress"
-               class="text-xs text-greyscale-600"
-               x-text="opposingAddress"></p>
-            <p x-show="opposingPhone" class="text-xs text-greyscale-600">
-              <a x-bind:href="opposingPhoneHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="opposingPhone"></a>
-            </p>
-            <p x-show="opposingEmail" class="text-xs text-greyscale-600">
-              <a x-bind:href="opposingEmailHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="opposingEmail"></a>
-            </p>
-            <p x-show="opposingWebsite" class="text-xs text-greyscale-600">
-              <a x-bind:href="opposingWebsite"
-                 target="_blank"
-                 rel="noopener"
-                 class="text-primary-600 hover:underline"
-                 x-text="opposingWebsite"></a>
-            </p>
-          </div>
-          {# Attorney (if represented) #}
-          <div x-show="attorneyName" class="space-y-1">
-            <h4 class="text-xs font-medium text-greyscale-500 uppercase tracking-wide">{% trans "Their Attorney" %}</h4>
-            <p class="text-sm text-greyscale-700" x-text="attorneyName"></p>
-            <p x-show="attorneyPhone" class="text-xs text-greyscale-600">
-              <a x-bind:href="attorneyPhoneHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="attorneyPhone"></a>
-            </p>
-            <p x-show="attorneyEmail" class="text-xs text-greyscale-600">
-              <a x-bind:href="attorneyEmailHref"
-                 class="text-primary-600 hover:underline"
-                 x-text="attorneyEmail"></a>
-            </p>
-          </div>
-          {# Key deadlines #}
-          <template x-if="hasDeadlines">
-            <c-molecules.sidebar-section title="{{ deadlines_heading }}">
-              <template x-for="deadline in deadlines" :key="deadline.id">
-                <c-molecules.deadline-card variant="urgent">
-                  <div class="flex items-start justify-between gap-1">
-                    <div class="min-w-0">
-                      <p class="text-sm font-medium text-red-700" x-text="deadline.date"></p>
-                      <p class="text-xs text-red-600 truncate" x-text="deadline.label"></p>
-                    </div>
-                    <button
-                      type="button"
-                      x-bind:data-deadline-id="deadline.id"
-                      x-on:click="toggleDeadlineReminder"
-                      x-bind:title="deadline.reminderTitle"
-                      class="flex-shrink-0 p-0.5 rounded hover:bg-red-100"
-                    >
-                      <template x-if="deadline.hasReminder">
-                        <c-atoms.icon name="bell-alert" style="solid" class="w-3.5 h-3.5 text-red-600" />
-                      </template>
-                      <template x-if="deadline.noReminder">
-                        <c-atoms.icon name="bell" class="w-3.5 h-3.5 text-red-400" />
-                      </template>
-                    </button>
-                  </div>
-                </c-molecules.deadline-card>
-              </template>
-            </c-molecules.sidebar-section>
-          </template>
-          {# Other dates #}
-          <template x-if="hasOtherDates">
-            <c-molecules.sidebar-section title="{{ other_dates_heading }}">
-              <template x-for="date in otherDates" :key="date.label">
-                <c-molecules.deadline-card>
-                  <p class="text-sm text-greyscale-700" x-text="date.date"></p>
-                  <p class="text-xs text-greyscale-500 truncate" x-text="date.label"></p>
-                </c-molecules.deadline-card>
-              </template>
-            </c-molecules.sidebar-section>
-          </template>
-          {# Action plan — spotted issues #}
-          <template x-if="hasSpottedIssues">
-            <c-molecules.sidebar-section title="{{ rights_heading }}">
-              <template x-for="issue in spottedIssues" :key="issue.title">
-                <div class="flex items-start gap-2 p-2 bg-blue-50 border border-blue-100 rounded-lg">
-                  <c-atoms.icon name="shield-check" class="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium text-blue-800" x-text="issue.title"></p>
-                    <p x-show="issue.description"
-                       class="text-xs text-blue-600 mt-0.5"
-                       x-text="issue.description"></p>
-                    <p x-show="issue.statute"
-                       class="text-xs text-blue-400 mt-0.5"
-                       x-text="issue.statute"></p>
-                  </div>
-                </div>
-              </template>
-            </c-molecules.sidebar-section>
-          </template>
-          {# Action plan — action items #}
-          <template x-if="hasActionItems">
-            <c-molecules.sidebar-section title="{{ next_steps_heading }}">
-              <template x-for="item in actionItems" :key="item.id">
-                <c-molecules.action-item
-                  x-bind:class="item.bgClass"
-                  x-bind:data-item-id="item.id"
-                  x-on:click="toggleActionItem"
-                  role="checkbox"
-                  tabindex="0"
-                  x-bind:aria-checked="item.isCompleted"
-                  class="cursor-pointer"
-                >
-                  <template x-if="item.isCompleted">
-                    <c-atoms.icon name="check-circle" style="solid" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
-                  </template>
-                  <template x-if="item.isUrgentOpen">
-                    <span class="flex-shrink-0 mt-0.5">
-                      <c-atoms.icon name="exclamation-triangle" style="solid" class="w-4 h-4 text-red-500" />
-                      <span class="sr-only">{% trans "Urgent" %}</span>
-                    </span>
-                  </template>
-                  <template x-if="item.isNormalOpen">
-                    <div class="w-4 h-4 rounded-full border-2 flex-shrink-0 mt-0.5"
-                         x-bind:class="item.borderClass"></div>
-                  </template>
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium"
-                       x-bind:class="item.titleClass"
-                       x-text="item.title"></p>
-                    <p x-show="item.description"
-                       class="text-xs mt-0.5"
-                       x-bind:class="item.descClass"
-                       x-text="item.description"></p>
-                    <p x-show="item.deadline"
-                       class="text-xs mt-0.5"
-                       x-bind:class="item.dateClass">
-                      <c-atoms.icon name="clock" class="w-3 h-3 inline -mt-0.5 mr-0.5" />
-                      <span x-text="item.deadline"></span>
-                    </p>
-                  </div>
-                </c-molecules.action-item>
-              </template>
-            </c-molecules.sidebar-section>
-          </template>
-          {# Action plan — resources #}
-          <template x-if="hasResources">
-            <c-molecules.sidebar-section title="{{ resources_heading }}">
-              <template x-for="resource in resources" :key="resource.title">
-                <div class="flex items-start gap-2 p-2 bg-green-50 border border-green-100 rounded-lg">
-                  <c-atoms.icon name="link" class="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
-                  <div class="min-w-0">
-                    <p class="text-sm font-medium text-green-800" x-text="resource.title"></p>
-                    <p x-show="resource.description"
-                       class="text-xs text-green-600 mt-0.5"
-                       x-text="resource.description"></p>
-                  </div>
-                </div>
-              </template>
-            </c-molecules.sidebar-section>
-          </template>
-          {# Sidebar footer — resolve, print, new case #}
-          <div class="pt-3 border-t border-greyscale-200 space-y-2">
-            {# Resolve button — active cases with action plan #}
-            <template x-if="showResolveButton">
-              <c-atoms.button
-                type="button"
-                variant="primary"
-                full_width
-                x-on:click="resolveCase"
-              >
-                <c-atoms.icon name="check-circle" class="w-4 h-4" />
-                {% trans "Mark resolved" %}
-              </c-atoms.button>
-            </template>
-            {# New case button — after resolution #}
-            <template x-if="isCaseResolved">
-              <c-atoms.button
-                type="button"
-                variant="outline"
-                full_width
-                x-on:click="clearCaseInfo"
-              >
-                <c-atoms.icon name="plus" class="w-4 h-4" />
-                {% trans "New case" %}
-              </c-atoms.button>
-            </template>
-            <a href="{% url 'pages:action_plan' %}"
-               target="_blank"
-               rel="noopener"
-               class="flex items-center gap-2 text-xs font-medium text-primary-600 hover:text-primary-700 hover:underline">
-              <c-atoms.icon name="printer" class="w-4 h-4" />
-              {% trans "Printable summary" %}
-            </a>
-          </div>
-        </div>
+        <c-organisms.case-sidebar-content />
       </c-organisms.case-sidebar>
     </div>
     {# Center column — subheader + chat, ~60% #}
     <div class="flex-1 min-w-0 flex flex-col min-h-0">
       {# Sub-header — topic context, only affects center column #}
       <div class="chat-subheader">
-        {% if topic %}
-          <div class="flex items-start justify-between gap-4">
+        <div class="flex items-start justify-between gap-4">
+          {% if topic %}
             <div class="topic-entry-header">
               <div class="topic-entry-icon">
                 <c-atoms.icon name="{{ topic.icon }}" class="w-6 h-6" />
@@ -350,17 +94,7 @@
                 <p class="topic-entry-subtitle">{{ topic.subtitle }}</p>
               </div>
             </div>
-            <c-atoms.button type="button"
-                            variant="ghost"
-                            class="text-sm text-greyscale-500 hover:text-greyscale-700 flex-shrink-0"
-                            x-show="hasMessages"
-                            x-cloak
-                            x-on:click="clearChat">
-              {% trans "New conversation" %}
-            </c-atoms.button>
-          </div>
-        {% else %}
-          <div class="flex items-start justify-between gap-4">
+          {% else %}
             <div class="topic-entry-header">
               <div class="topic-entry-icon">
                 <c-atoms.icon name="chat-bubble-left-right" class="w-6 h-6" />
@@ -370,16 +104,32 @@
                 <p class="topic-entry-subtitle">{% trans "Free legal help for self-represented litigants" %}</p>
               </div>
             </div>
+          {% endif %}
+          <div class="flex items-center gap-1 flex-shrink-0">
             <c-atoms.button type="button"
                             variant="ghost"
-                            class="text-sm text-greyscale-500 hover:text-greyscale-700 flex-shrink-0"
+                            class="text-sm text-greyscale-500 hover:text-greyscale-700"
                             x-show="hasMessages"
                             x-cloak
                             x-on:click="clearChat">
               {% trans "New conversation" %}
             </c-atoms.button>
+            {# Mobile-only: opens the case & activity drawer (panels are desktop-only columns) #}
+            {% trans "Open case details and activity" as drawer_trigger_label %}
+            <c-atoms.button type="button"
+                            variant="ghost"
+                            size="icon"
+                            class="lg:hidden"
+                            aria_label="{{ drawer_trigger_label }}"
+                            aria-haspopup="dialog"
+                            aria-controls="case-drawer"
+                            x-ref="casePanelTrigger"
+                            x-bind:aria-expanded="casePanelOpen"
+                            x-on:click="openCasePanel">
+              <c-atoms.icon name="briefcase" class="w-5 h-5" />
+            </c-atoms.button>
           </div>
-        {% endif %}
+        </div>
       </div>
       {# Chat content — scrollable, messages + input flow together #}
       <div class="chat-content" x-ref="messagesArea">
@@ -523,44 +273,67 @@
     {# Right column — activity panel, ~20% #}
     <div class="hidden lg:flex w-1/5 flex-shrink-0 flex-col border-l border-greyscale-200 overflow-y-auto">
       <c-organisms.activity-panel class="h-full">
-        {# Empty state #}
-        <div x-show="noTimeline" class="text-center py-8 px-4">
-          <c-atoms.icon name="clock" class="w-6 h-6 text-greyscale-300 mx-auto mb-3" />
-          <p class="text-sm font-medium text-greyscale-500 mb-2">{% trans "Your documents & deadlines" %}</p>
-          <p class="text-xs text-greyscale-400">
-            {% trans "I'll save important information here as we talk." %}
-          </p>
-        </div>
-        {# Timeline events #}
-        <template x-if="hasTimeline">
-          <div class="space-y-2">
-            <template x-for="event in caseTimeline" :key="event.id">
-              <details class="timeline-event-card">
-                <summary class="timeline-event-summary">
-                  <template x-if="event.isUpload">
-                    <c-atoms.icon name="document-arrow-up" class="timeline-event-icon" />
-                  </template>
-                  <template x-if="event.isSummary">
-                    <c-atoms.icon name="document-text" class="timeline-event-icon" />
-                  </template>
-                  <template x-if="event.isChange">
-                    <c-atoms.icon name="pencil-square" class="timeline-event-icon" />
-                  </template>
-                  <template x-if="event.isResolution">
-                    <c-atoms.icon name="check-circle" class="timeline-event-icon text-green-600" />
-                  </template>
-                  <span class="timeline-event-title" x-text="event.title"></span>
-                  <span class="timeline-event-badge" x-text="event.typeLabel"></span>
-                </summary>
-                <div class="timeline-event-body" x-show="event.content">
-                  <p class="text-xs text-greyscale-600" x-text="event.content"></p>
-                  <p class="text-xs text-greyscale-400 mt-1" x-text="event.formattedTime"></p>
-                </div>
-              </details>
-            </template>
-          </div>
-        </template>
+        <c-organisms.activity-timeline />
       </c-organisms.activity-panel>
+    </div>
+    {# Mobile drawer — same case + activity state as the desktop columns, overlay below lg #}
+    <div x-show="casePanelOpen"
+         x-cloak
+         class="lg:hidden fixed inset-0 z-50"
+         x-on:keydown.escape.window="closeCasePanel">
+      {# Backdrop — click closes #}
+      <div class="absolute inset-0 bg-greyscale-900/50"
+           aria-hidden="true"
+           x-on:click="closeCasePanel"></div>
+      {% trans "Your case and activity" as drawer_label %}
+      {% trans "Close case details" as drawer_close_label %}
+      <div id="case-drawer"
+           role="dialog"
+           aria-modal="true"
+           aria-label="{{ drawer_label }}"
+           x-ref="casePanel"
+           x-on:keydown="casePanelKeydown"
+           class="absolute inset-y-0 right-0 w-5/6 max-w-sm bg-white shadow-xl flex flex-col">
+        {# Drawer header — mirrors the case-sidebar shell header + close #}
+        <div class="flex items-center justify-between px-4 pt-4 pb-3 border-b border-greyscale-200">
+          <h2 class="text-xs font-semibold uppercase tracking-wider text-greyscale-400">{% trans "Your Case" %}</h2>
+          <div class="flex items-center gap-2">
+            <c-atoms.button type="button"
+                            variant="ghost"
+                            class="!p-0 text-xs text-greyscale-400 hover:text-greyscale-600"
+                            x-show="isCaseActive"
+                            x-cloak
+                            x-on:click="clearCaseInfo">
+              {% trans "Clear" %}
+            </c-atoms.button>
+            <c-atoms.button type="button"
+                            variant="ghost"
+                            size="icon"
+                            aria_label="{{ drawer_close_label }}"
+                            x-ref="casePanelClose"
+                            x-on:click="closeCasePanel">
+              <c-atoms.icon name="x-mark" class="w-5 h-5" />
+            </c-atoms.button>
+          </div>
+        </div>
+        {# Scrollable body — case content + collapsed activity section #}
+        <div class="flex-1 overflow-y-auto p-4 space-y-6">
+          <c-organisms.case-sidebar-content />
+          <details class="group border-t border-greyscale-200 pt-3">
+            <summary class="flex items-center gap-2 cursor-pointer text-xs font-semibold uppercase tracking-wider text-greyscale-400">
+              <c-atoms.icon name="chevron-right" class="w-3 h-3 transition-transform duration-200 group-open:rotate-90" />
+              <span>{% trans "Activity" %}</span>
+              <span x-show="hasTimeline"
+                    x-cloak
+                    class="inline-flex items-center justify-center px-1.5 py-0.5 rounded-full bg-greyscale-100 text-greyscale-500 normal-case"
+                    x-text="timelineCount"></span>
+            </summary>
+            <div class="pt-3">
+              <c-organisms.activity-timeline />
+            </div>
+          </details>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock content %}


### PR DESCRIPTION
The case sidebar and activity timeline were `hidden lg:flex` — unreachable below 1024px. Adds a mobile slide-in drawer (briefcase trigger in the chat sub-header) that overlays the content area only, so the site nav stays visible and the close button lands where the trigger sits. Panel bodies are extracted into `c-organisms.case-sidebar-content` / `activity-timeline` so desktop columns and drawer render the same components off the same Alpine state.

- Swipe: left-swipe opens, right-swipe closes — single-touch, 48px threshold, horizontal-dominant 2:1, passive listeners
- Slide-in keyframes with `prefers-reduced-motion` opt-out; `main.built.css` regenerates via `make css` (gitignored)
- Non-modal (nav stays interactive): focus-in on open, Escape, backdrop tap, focus-return — no aria-modal/trap, matching the header-menu pattern
- v1 chat only — v2 parity passes when v2 lands will carry this over (no standing carry-over issue)
- Found during QA: #639 (Clear → gated Start over) filed as follow-up

Closes #634

Test plan:
- [ ] Phone viewport (<1024px): briefcase button opens drawer below nav, dimmed page peeks left
- [ ] Swipe left anywhere in chat opens; swipe right closes; vertical scrolling never triggers it
- [ ] Escape / backdrop tap / ✕ close; focus returns to trigger
- [ ] Empty case vs populated case + activity count badge
- [ ] Desktop (≥1024px): three-pane layout unchanged, no trigger visible
- [ ] make lint && make test green
