### PR TITLE
feat(chat): remove briefcase Clear — Start over lives in the menu

### DIFF
--- a/litigant_portal/app/templates/cotton/organisms/header.html
+++ b/litigant_portal/app/templates/cotton/organisms/header.html
@@ -60,9 +60,11 @@
                class="absolute right-0 mt-2 w-max bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
                role="menu"
                aria-orientation="vertical">
+            {# User-language label: it erases chat + case and reloads. When a prod #}
+            {# site menu lands (#120), this item rides into it for real users. #}
             <button type="button" x-on:click="resetDemo" class="flex items-center gap-2 w-full px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="arrow-path" class="w-5 h-5 text-greyscale-500" />
-              {% trans "Reset Demo" %}
+              {% trans "Start over" %}
             </button>
             <a href="{% url 'pages:topic_flow' court='north-dakota' topic='adult-name-change' role='standard' %}" class="flex items-center gap-2 px-4 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100" role="menuitem">
               <c-atoms.icon name="beaker" class="w-5 h-5 text-greyscale-500" />

--- a/litigant_portal/app/templates/pages/chat.html
+++ b/litigant_portal/app/templates/pages/chat.html
@@ -65,16 +65,6 @@
     {# Left column — sidebar, ~20% #}
     <div class="hidden lg:flex w-1/5 flex-shrink-0 flex-col border-r border-greyscale-200 overflow-y-auto">
       <c-organisms.case-sidebar class="h-full">
-        <c-slot name="header_actions">
-          <c-atoms.button type="button"
-                          variant="ghost"
-                          class="!p-0 text-xs text-greyscale-400 hover:text-greyscale-600"
-                          x-show="isCaseActive"
-                          x-cloak
-                          x-on:click="clearCaseInfo">
-            {% trans "Clear" %}
-          </c-atoms.button>
-        </c-slot>
         <c-organisms.case-sidebar-content />
       </c-organisms.case-sidebar>
     </div>
@@ -297,24 +287,14 @@
         {# Drawer header — mirrors the case-sidebar shell header + close #}
         <div class="flex items-center justify-between px-4 pt-4 pb-3 border-b border-greyscale-200">
           <h2 class="text-xs font-semibold uppercase tracking-wider text-greyscale-400">{% trans "Your Case" %}</h2>
-          <div class="flex items-center gap-2">
-            <c-atoms.button type="button"
-                            variant="ghost"
-                            class="!p-0 text-xs text-greyscale-400 hover:text-greyscale-600"
-                            x-show="isCaseActive"
-                            x-cloak
-                            x-on:click="clearCaseInfo">
-              {% trans "Clear" %}
-            </c-atoms.button>
-            <c-atoms.button type="button"
-                            variant="ghost"
-                            size="icon"
-                            aria_label="{{ drawer_close_label }}"
-                            x-ref="casePanelClose"
-                            x-on:click="closeCasePanel">
-              <c-atoms.icon name="x-mark" class="w-5 h-5" />
-            </c-atoms.button>
-          </div>
+          <c-atoms.button type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria_label="{{ drawer_close_label }}"
+                          x-ref="casePanelClose"
+                          x-on:click="closeCasePanel">
+            <c-atoms.icon name="x-mark" class="w-5 h-5" />
+          </c-atoms.button>
         </div>
         {# Scrollable body — case content + collapsed activity section #}
         <div class="flex-1 overflow-y-auto p-4 space-y-6">


### PR DESCRIPTION
'Clear' sat next to the drawer's close button — easy to mis-tap, no gate, no undo, and only half a reset (case but not chat). Removed from both the desktop sidebar header and the drawer header. The whole-reset already exists in the hamburger menu — its Reset Demo item posts `/api/chat/case/clear/` and reloads, a full chat + case start-over — so it's relabeled **Start over** (user language; rides into the prod site menu when #120 lands). The menu is the deliberate step, so no extra confirm. One UI for demo and real users.

Stacked on #641; merge that first (GitHub retargets this to main automatically).

Closes #639

Test plan:
- [ ] Sidebar + drawer headers show no Clear (✕ only in drawer)
- [ ] Hamburger → Start over: case + chat both reset, page reloads clean
- [ ] make lint && make test green