### PR TITLE
feat(chat): persistent Topic Flow links — deterministic AI→flow handoff

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/flow_links.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_links.html
@@ -1,0 +1,24 @@
+{% load i18n %}
+
+<c-vars tracks="" />
+{# Guided-flow track links — persistent, server-rendered chat→Topic Flow handoff (#633). #}
+{# Renders nothing when the topic has no authored corpus. #}
+{% if tracks %}
+  {% trans "Guided steps" as flow_links_title %}
+  <c-molecules.sidebar-section title="{{ flow_links_title }}" icon="map">
+    {% for track in tracks %}
+      <p>
+        <c-atoms.link
+          href="{% url 'pages:topic_flow' track.court track.topic track.role %}"
+          class="text-sm"
+          title="{{ track.title }}"
+        >
+          {{ track.label }}
+        </c-atoms.link>
+      </p>
+    {% endfor %}
+    <p class="text-xs text-greyscale-400">
+      {% trans "Step-by-step guidance for your situation — no chat needed." %}
+    </p>
+  </c-molecules.sidebar-section>
+{% endif %}

--- a/litigant_portal/app/templates/pages/chat.html
+++ b/litigant_portal/app/templates/pages/chat.html
@@ -65,6 +65,7 @@
     {# Left column — sidebar, ~20% #}
     <div class="hidden lg:flex w-1/5 flex-shrink-0 flex-col border-r border-greyscale-200 overflow-y-auto">
       <c-organisms.case-sidebar class="h-full">
+        <c-molecules.flow-links :tracks="flow_tracks" />
         <c-organisms.case-sidebar-content />
       </c-organisms.case-sidebar>
     </div>
@@ -296,8 +297,9 @@
             <c-atoms.icon name="x-mark" class="w-5 h-5" />
           </c-atoms.button>
         </div>
-        {# Scrollable body — case content + collapsed activity section #}
+        {# Scrollable body — flow links + case content + collapsed activity section #}
         <div class="flex-1 overflow-y-auto p-4 space-y-6">
+          <c-molecules.flow-links :tracks="flow_tracks" />
           <c-organisms.case-sidebar-content />
           <details class="group border-t border-greyscale-200 pt-3">
             <summary class="flex items-center gap-2 cursor-pointer text-xs font-semibold uppercase tracking-wider text-greyscale-400">

--- a/litigant_portal/app/templates/pages/chat.html
+++ b/litigant_portal/app/templates/pages/chat.html
@@ -302,7 +302,7 @@
           <c-molecules.flow-links :tracks="flow_tracks" />
           <c-organisms.case-sidebar-content />
           <details class="group border-t border-greyscale-200 pt-3">
-            <summary class="flex items-center gap-2 cursor-pointer text-xs font-semibold uppercase tracking-wider text-greyscale-400">
+            <summary class="flex items-center gap-2 cursor-pointer list-none [&::-webkit-details-marker]:hidden text-xs font-semibold uppercase tracking-wider text-greyscale-400">
               <c-atoms.icon name="chevron-right" class="w-3 h-3 transition-transform duration-200 group-open:rotate-90" />
               <span>{% trans "Activity" %}</span>
               <span x-show="hasTimeline"

--- a/litigant_portal/app/tests/test_portal.py
+++ b/litigant_portal/app/tests/test_portal.py
@@ -82,6 +82,29 @@ class ChatPageTests(TestCase):
         self.assertContains(response, "isUrgentOpen")
         self.assertContains(response, "exclamation-triangle")
 
+    def test_chat_page_flow_tracks_for_topic_with_corpus(self):
+        """Topic with a real corpus gets its track links in context (#633).
+
+        Omni-court: the topic resolves the court, so adult_name_change
+        surfaces the ND standard + waiver tracks and the page renders
+        env-relative flow URLs.
+        """
+        response = self.client.get("/chat/?topic=adult_name_change")
+        tracks = response.context["flow_tracks"]
+        self.assertEqual([t["role"] for t in tracks], ["standard", "waiver"])
+        self.assertContains(
+            response, "/t/north-dakota/adult-name-change/standard/"
+        )
+
+    def test_chat_page_no_topic_has_no_flow_tracks(self):
+        response = self.client.get("/chat/")
+        self.assertEqual(response.context["flow_tracks"], [])
+
+    def test_chat_page_topic_without_corpus_has_no_flow_tracks(self):
+        """A topic with no authored corpus renders chat-only, no links."""
+        response = self.client.get("/chat/?topic=eviction")
+        self.assertEqual(response.context["flow_tracks"], [])
+
 
 # =============================================================================
 # Auth Template Tests

--- a/litigant_portal/app/tests/test_topic_flow_registry.py
+++ b/litigant_portal/app/tests/test_topic_flow_registry.py
@@ -83,3 +83,47 @@ def test_check_passes_for_distinct_keys(tmp_path, monkeypatch):
         checks, "iter_corpus_paths", lambda _dir: [first, second]
     )
     assert checks.check_corpora(None) == []
+
+
+# --- tracks_for: omni-court topic → track links (chat handoff, #633) ---
+
+
+def test_tracks_for_bridges_chat_underscore_slug(tmp_path):
+    # Chat topics use underscores (adult_name_change); corpora may use either.
+    (tmp_path / "real.yml").write_text(VALID)
+    registry = CorpusRegistry(content_dir=tmp_path)
+    tracks = registry.tracks_for("test_topic")
+    assert [(t["court"], t["topic"], t["role"]) for t in tracks] == [
+        FIXTURE_KEY
+    ]
+
+
+def test_tracks_for_normalizes_both_sides(tmp_path):
+    # Dashed chat slug must match an underscored corpus topic too.
+    (tmp_path / "real.yml").write_text(VALID)
+    registry = CorpusRegistry(content_dir=tmp_path)
+    assert registry.tracks_for("test-topic") != []
+
+
+def test_tracks_for_unknown_topic_returns_empty(tmp_path):
+    (tmp_path / "real.yml").write_text(VALID)
+    registry = CorpusRegistry(content_dir=tmp_path)
+    assert registry.tracks_for("eviction") == []
+
+
+def test_tracks_for_carries_label_and_title(tmp_path):
+    (tmp_path / "real.yml").write_text(VALID)
+    registry = CorpusRegistry(content_dir=tmp_path)
+    track = registry.tracks_for("test_topic")[0]
+    assert track["label"] == "Petitioner"
+    assert track["title"] == registry.get(*FIXTURE_KEY).metadata.title
+
+
+def test_tracks_for_returns_all_tracks_in_file_order(tmp_path):
+    (tmp_path / "a.yml").write_text(VALID)
+    (tmp_path / "b.yml").write_text(
+        VALID.replace("role: petitioner", "role: respondent")
+    )
+    registry = CorpusRegistry(content_dir=tmp_path)
+    roles = [t["role"] for t in registry.tracks_for("test_topic")]
+    assert roles == ["petitioner", "respondent"]

--- a/litigant_portal/app/topic_flow/registry.py
+++ b/litigant_portal/app/topic_flow/registry.py
@@ -66,6 +66,28 @@ class CorpusRegistry:
         self.load()
         return list(self._index)
 
+    def tracks_for(self, topic: str) -> list[dict]:
+        """Track links for a chat topic — omni-court: the topic resolves the court.
+
+        Bridges chat topic slugs (``adult_name_change``) to corpus topic slugs
+        (``adult-name-change``) by normalizing both sides to dashes. Returns one
+        entry per ``(court, role)`` with the fields templates need to render a
+        flow link; empty list when no corpus matches the topic.
+        """
+        self.load()
+        wanted = topic.strip().lower().replace("_", "-")
+        return [
+            {
+                "court": court,
+                "topic": corpus_topic,
+                "role": role,
+                "label": role.replace("-", " ").replace("_", " ").title(),
+                "title": corpus.metadata.title,
+            }
+            for (court, corpus_topic, role), corpus in self._index.items()
+            if corpus_topic.replace("_", "-") == wanted
+        ]
+
 
 # Module-level default over the repo's content/ directory.
 registry = CorpusRegistry()

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -218,6 +218,8 @@ def chat_page(request):
             "topic_context": topic_context,
             "court_slug": court_slug,
             "court_name": get_court_name(court_slug),
+            # Omni-court: the topic resolves its court's guided-flow tracks.
+            "flow_tracks": registry.tracks_for(slug) if topic else [],
         },
     )
 

--- a/litigant_portal/prompts/courts/north-dakota/prompt.md
+++ b/litigant_portal/prompts/courts/north-dakota/prompt.md
@@ -20,11 +20,8 @@ ADULT NAME CHANGE — TRACKS
 - **Publication may be waived** by the judge. No 30-day waiting period if waiver is granted.
 - The judge decides whether to grant the waiver on the facts presented; eligibility for first/middle-only is met on the facts but the waiver itself is discretionary. Do not promise the waiver will be granted.
 
-GUIDED FLOW LINKS (hand off after track confirmation)
-Once the user's track is confirmed, offer the matching guided flow as a clickable markdown link — it walks them through the ND packet step by step and hands off to the form-filling interview:
-
-- Standard track → [Start the guided standard-track name-change flow](https://qa.litigantportal.com/t/north-dakota/adult-name-change/standard/)
-- Waiver track → [Start the guided waiver-track name-change flow](https://qa.litigantportal.com/t/north-dakota/adult-name-change/waiver/)
+GUIDED FLOW HANDOFF (after track confirmation)
+The page already shows the guided-flow links for both tracks in the "Guided steps" section of the case panel (on phones, behind the briefcase button at the top of the chat). Once the user's track is confirmed, direct them to the matching link there by name — e.g. "Open **Standard** under _Guided steps_ in your case panel" — and frame it as their next step: it walks them through the ND packet step by step and hands off to the form-filling interview. Never construct or emit a flow URL yourself; the page renders the correct links.
 
 FORM GOTCHAS (ND-SPECIFIC)
 

--- a/litigant_portal/prompts/topics/adult_name_change/prompt.md
+++ b/litigant_portal/prompts/topics/adult_name_change/prompt.md
@@ -23,7 +23,7 @@ Exact form counts, wait periods, and waiver criteria come from the Court layer.
 Do not ask _why_ the user is changing their name. Reasons are not required for routing. If the user volunteers a reason, accept it and move on.
 
 HANDOFF TO THE GUIDED FLOW
-Once the track is settled, don't stop at describing the forms — offer the user the guided, step-by-step flow for their track. It walks them through the jurisdiction's packet and hands off to the tool that fills the forms. The Court layer supplies the flow link per track; share it as a clickable markdown link and frame it as the next step (they can keep asking you questions here anytime). If the Court layer provides no flow link, keep guiding in chat as usual.
+Once the track is settled, don't stop at describing the forms — point the user to the guided, step-by-step flow for their track. It walks them through the jurisdiction's packet and hands off to the tool that fills the forms. The flow links are shown persistently on the page in the "Guided steps" section of the case panel (behind the briefcase button on phones); direct the user to the right track's link there by name and frame it as the next step (they can keep asking you questions here anytime). Never emit a flow URL yourself. If the jurisdiction has no guided flow, the section isn't shown — keep guiding in chat as usual.
 
 DISQUALIFIERS AS INFORMATION
 Most name-change statutes include eligibility conditions (citizenship, intent not to defraud, not attempting to evade legal obligations). State these as facts the user self-attests to on the forms — never as interrogation. "These conditions can prevent a name change in [jurisdiction]: [facts]." Let the user apply the rule to themselves.


### PR DESCRIPTION
The chat→flow handoff depended on the LLM emitting a hardcoded QA-absolute markdown link, so it fired inconsistently (#602) and broke off-QA (#600). The track links are now server-rendered UI: `registry.tracks_for(topic)` resolves the owning court from the topic (omni-court — no session court state), `chat_page` passes `flow_tracks`, and `c-molecules.flow-links` renders env-relative `{% url %}` links under 'Guided steps' in both the desktop case sidebar and the mobile drawer. Prompts are reworded to direct users to the on-page links by name and never emit URLs.

- Slug bridge normalizes both sides (chat `adult_name_change` ↔ corpus `adult-name-change`) — the test fixture's underscored topic forced this; mutation-checked
- Topic without a corpus renders chat-only: no section, prompts fall back to chat guidance

Stacked on #642; merge order #641 → #642 → this.

Closes #633
Closes #602
Closes #600

Test plan:
- [ ] /chat/?topic=adult_name_change shows 'Guided steps' → Standard + Waiver in sidebar (desktop) and drawer (mobile); links are relative and work locally
- [ ] /chat/?topic=eviction and bare /chat/ show no section
- [ ] Chat handoff: assistant names the on-page link instead of emitting a URL
- [ ] make lint && make test green (new registry + view tests)