### PR TITLE
feat(topic-flow): ND name-change content redraft per legal review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,14 @@ Prettier adds `/>` to void HTML elements and self-closing components alike. Foll
 
 **9. Long `class` values.** Tailwind classes stay on one line inside the `class` attribute even when long — don't break a class string across lines. If the element also has many other attributes, the `class` attribute gets its own line in the multi-line format (rule 2), but the value itself stays unbroken.
 
+## Content style (user-facing copy)
+
+Rules for authoring user-facing content — corpus YAML (`litigant_portal/content/`), UI strings, and prompt layers that shape chat output:
+
+- **No em-dashes.** Use a period, comma, colon, or parentheses instead. Em-dash-heavy prose reads as AI-generated and undermines user trust (legal review, #620). Dev-facing text (code comments, docs, commit messages) is exempt.
+- **Corpus info bodies: one line per paragraph.** The renderer pipes `body` through Django's `linebreaks`, so every newline becomes a `<br>` — hard-wrapped prose breaks mid-sentence on the page. Separate paragraphs with blank lines; never wrap a paragraph across source lines.
+- **Dash-prefixed lines** (`- item`) render as visual line-broken lists (not semantic `<ul>`) until #518 adds rich text to info bodies. Links in body prose are not supported yet (#518) — route them through the corpus `resources`/`contacts` sections instead.
+
 ## Issue creation
 
 See [`docs/issue-conventions.md`](docs/issue-conventions.md) for the full label color scheme and template rationale.

--- a/docs/ai-tone-guide.md
+++ b/docs/ai-tone-guide.md
@@ -90,6 +90,14 @@ One question at a time. Build the picture incrementally.
 
 Let them tell you; don't assume.
 
+### No Em-Dashes
+
+**Bad:** "You'll file a petition — the court's main form — and wait 30 days."
+
+**Good:** "You'll file a petition (the court's main form) and wait 30 days."
+
+Em-dash-heavy prose reads as AI-generated and undermines trust. Use a period, comma, colon, or parentheses instead. This applies to all user-facing content: chat responses, corpus copy, and UI text (flagged by legal review in #620).
+
 ## UPL Compliance
 
 All information, no legal advice:

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -21,7 +21,7 @@ metadata:
   court: north-dakota
   topic: adult-name-change
   role: standard
-  title: 'Adult Name Change — North Dakota (Publication Required)'
+  title: 'Adult Name Change in North Dakota (Publication Required)'
 
 contacts:
   - id: clerk
@@ -44,7 +44,7 @@ contacts:
     url: 'https://www.dpls.org'
     note: 'Free legal assistance for low-income individuals, older Americans, veterans, and nine tribal nations across North and South Dakota.'
   - id: state_bar_referral
-    name: 'State Bar Association of North Dakota — Lawyer Referral'
+    name: 'State Bar Association of North Dakota (Lawyer Referral)'
     phone: '(866) 450-9579'
     url: 'https://www.sband.org'
     note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation: hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
@@ -190,7 +190,7 @@ sections:
     id: form_gotchas
     heading: 'Before you sign'
     body: |
-      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is:
+      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is missed:
 
       - The case number stays blank. The clerk assigns it when you file.
       - Only the judge signs the Proposed Order.

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -1,38 +1,44 @@
-# Demo corpus — Adult Name Change (North Dakota), STANDARD track.
-#
-# The standard track applies to any change that includes the last name:
-# newspaper publication + a 30-day wait before the judge may consider it.
-# The court links to this flow directly for last-name changes; the waiver
-# track (first/middle only) is a separate flow — adult-name-change-waiver.yml.
+# Demo corpus — Adult Name Change (North Dakota), STANDARD track ("publication
+# required"). Applies to any change that includes the last name: newspaper
+# publication + a 30-day wait before the judge may consider it. The court links
+# to this flow directly for last-name changes; the waiver track (first/middle
+# only) is a separate flow — adult-name-change-waiver.yml.
 #
 # Content verified against the official ND Legal Self Help Center source docs
 # (Instructions for a Name Change (Adult), Residency, Publication, Criminal
-# History) — see #614. Contact phone/email confirmed; form-PDF links not yet
-# re-verified. Publication-waiver scope (#615) and objection/declaration
-# details (#616) still pending legal review.
+# History) — see #614. Top-of-page copy redrafted by legal (Jessica) in #620,
+# including the objection section (drawn from the court's Instructions doc).
+# Contact phone/email confirmed; form-PDF links not yet re-verified.
+# Publication-waiver scope (#615) and Declaration form-set details (#616)
+# still pending legal review.
+#
+# Authoring style (per #620): no em-dashes in user-facing copy; body
+# paragraphs are ONE line each (the renderer turns every newline into <br>,
+# so hard-wrapped prose breaks mid-sentence); dash-prefixed lines render as
+# visual (non-semantic) lists until #518 adds rich text.
 
 metadata:
   court: north-dakota
   topic: adult-name-change
   role: standard
-  title: 'Adult Name Change — North Dakota (Standard Track)'
+  title: 'Adult Name Change — North Dakota (Publication Required)'
 
 contacts:
   - id: clerk
     name: 'Clerk of District Court (your county)'
     url: 'https://www.ndcourts.gov/court-locations'
-    note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge. This is the one call to make first."
+    note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal history background check before or after you file. Timing varies by judge. This is the one call to make first."
   - id: self_help
     name: 'North Dakota Legal Self Help Center'
     phone: '(701) 328-1852'
     email: 'ndselfhelp@ndcourts.gov'
     url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers — not legal advice, and not criminal matters.'
+    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers. They cannot give legal advice or help with criminal matters.'
   - id: legal_aid
     name: 'Legal Services of North Dakota'
     phone: '(800) 634-5263'
     url: 'https://lsnd.org'
-    note: 'Free civil legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter. They can also screen you for the Volunteer Lawyers low-cost program.'
+    note: 'Free civil legal help for North Dakotans who qualify by income. Useful if your name change touches a divorce or other family-law matter. They can also screen you for the Volunteer Lawyers low-cost program.'
   - id: dakota_plains
     name: 'Dakota Plains Legal Services'
     url: 'https://www.dpls.org'
@@ -41,7 +47,7 @@ contacts:
     name: 'State Bar Association of North Dakota — Lawyer Referral'
     phone: '(866) 450-9579'
     url: 'https://www.sband.org'
-    note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation — hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
+    note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation: hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
 
 deadlines:
   - id: publication_wait
@@ -54,7 +60,11 @@ resources:
   - id: nd_name_change_guidance
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
-    note: "The court's official adult name-change page — process overview and the source for every form in your packet."
+    note: "The court's official adult name-change page: process overview and the source for every form in your packet."
+  - id: nd_century_code
+    label: 'North Dakota Century Code Chapter 32-28'
+    url: 'https://ndlegis.gov/cencode/t32c28.html'
+    note: 'The state law this name-change process follows.'
   - id: fee_waiver
     label: 'Filing-fee waiver forms'
     url: 'https://www.ndcourts.gov/legal-self-help/fee-waiver'
@@ -62,7 +72,7 @@ resources:
   - id: criminal_history_check
     label: 'Criminal history record check (edo.cjis.gov)'
     url: 'https://www.edo.cjis.gov'
-    note: 'If the judge requires a background check, request it here. You pay the cost, and it can take weeks — ask the clerk early.'
+    note: 'If the judge requires a background check, request it here. You pay the cost, and it can take weeks, so ask the clerk early.'
   - id: nd_free_legal_answers
     label: 'North Dakota Free Legal Answers'
     url: 'https://nd.freelegalanswers.org'
@@ -71,63 +81,51 @@ resources:
 sections:
   - kind: info
     id: overview
-    heading: 'Changing your name in North Dakota'
+    heading: 'Changing your legal name in North Dakota'
     body: |
-      This walks you through a standalone adult name-change petition in North
-      Dakota district court, on the standard track — any change that includes
-      your last name. The standard track requires publishing a notice in a
-      newspaper and a 30-day wait before the judge can act.
+      This tool gives you the forms you need, explains what to expect, and shows you what comes next.
 
-      If you are changing only your first and/or middle name (not your last
-      name), a judge may waive publication and the wait — use the waiver-track
-      page instead.
+      You can use this tool if:
+      - You are 18 years or older.
+      - You are a U.S. citizen or a permanent resident.
+      - You have lived in a North Dakota county for the past 6 months.
+      - You are changing your last name. You can change your first and middle name at the same time, but you don't have to.
 
-      One common mix-up: if you wanted your name restored as part of a divorce,
-      that has to be requested inside the divorce case — it is not handled here.
-      If your divorce is final and didn't change your name, this standalone
-      petition is the way.
+      You should not use this tool if:
+      - You are changing only your first name, only your middle name, or both, but not your last name. Use the publication-waiver version of this tool instead.
+      - You want your former name back as part of a divorce that is still open. Ask for that inside the divorce case instead. If your divorce is final and didn't change your name, this tool is the right place.
+
+      Before you start, here is what this will involve:
+      - Cost: $160 to file. You can ask the court to waive this fee if you cannot pay it.
+      - Newspaper notice: You must publish a notice of your petition in a newspaper.
+      - Wait time: You must wait 30 days after the notice runs before a judge can decide.
+      - Background check: The judge may require a criminal history check. This can take several weeks, so it helps to ask early.
+
+      This process follows North Dakota Century Code Chapter 32-28, linked in the official resources at the end of this page.
 
   - kind: info
-    id: eligibility
-    heading: 'Who can file'
+    id: filing_fee
+    heading: 'Filing fee'
     body: |
-      To petition for a name change in North Dakota you must be a U.S. citizen
-      or a U.S. permanent resident. You attest to this on the Petition.
+      Filing this petition costs $160. If you cannot pay this fee, you can ask the court to waive it. The fee-waiver forms and instructions are linked in the official resources at the end of this page.
 
-      A name change cannot be used to defraud anyone or to evade a legal
-      obligation (for example, debts or a criminal record). These are conditions
-      you confirm on the forms — not something you have to explain to anyone here.
-
-  - kind: info
-    id: costs
-    heading: 'What it costs'
-    body: |
-      The filing fee is $160. If you cannot afford it, you can file fee-waiver
-      forms at the same time asking the judge to waive the fee — the fee-waiver
-      link is in your resources below.
-
-      Two other costs can come up later: if the judge requires a criminal-history
-      background check, you pay for it; and certified copies of your final Order
-      cost $10 for the first copy and $5 for each additional copy requested at
-      the same time.
+      File the fee-waiver request at the same time as your name-change documents, and keep a copy for your records.
 
   - kind: info
     id: criminal_history
-    heading: 'The criminal-history check'
+    heading: 'Criminal history background check'
     body: |
-      Before granting a name change, the judge has to determine whether you have
-      a criminal record. Some judges require every adult filer to get a statewide
-      or national criminal-history background check; others decide after reviewing
-      your petition. Call the clerk before you file to ask which applies in your
-      county — the check can take weeks, so it is worth starting early.
+      The judge assigned to your case must determine whether you have a criminal record before granting a name change, and may require you to complete a criminal history background check at your own cost. Some judges require this for every petitioner. Others decide after reviewing your Petition and Declaration.
 
-      If the judge requires one, you request it at edo.cjis.gov and pay the cost
-      yourself.
+      Ask the Clerk of Court whether a background check will be required before you start. If the clerk doesn't know, the judge will decide after you file. This check can take several weeks, so it is worth asking early rather than after you have already filed.
 
-      If you have a felony conviction, North Dakota law assumes a name-change
-      request is made in bad faith. A judge may still grant it, but you would need
-      to show by clear and convincing evidence that your request is made in good
-      faith and not to defraud, mislead, injure anyone, or compromise public safety.
+      If a background check is required, you can go to edo.cjis.gov to complete it. If you have a felony conviction, North Dakota law presumes your request is not made in good faith unless you show the judge clear and convincing evidence otherwise. This does not mean your petition will be denied. The Declaration form asks you to address this directly.
+
+  - kind: info
+    id: where_to_file
+    heading: 'Where to file'
+    body: |
+      File in the district court for the county where you have lived for the past 6 months. Your driver's license, lease, or a utility bill usually shows this. The court locator link in the contacts at the end of this page can also help.
 
   - kind: fact_gather
     id: your_details
@@ -160,11 +158,11 @@ sections:
       - id: filing_county
         label: 'County where you will file'
         type: text
-        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill — or look up your address with the court locator at ndcourts.gov/court-locations."
+        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill, or look up your address with the court locator at ndcourts.gov/court-locations."
       - id: publication_date
         label: 'Date your notice was published'
         type: date
-        help_text: 'Leave blank until your notice runs in the newspaper — then enter it here and your deadline updates. Found on the affidavit of publication from the paper.'
+        help_text: 'Leave blank until your notice runs in the newspaper. Then enter it here and your deadline updates. Found on the affidavit of publication from the paper.'
 
   - kind: output
     output_type: packet
@@ -192,23 +190,23 @@ sections:
     id: form_gotchas
     heading: 'Before you sign'
     body: |
-      A few North Dakota specifics that trip people up:
+      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is:
 
-      Leave the case number blank — the clerk assigns it when you file.
-
-      Do not sign the proposed Order. Only the judge signs that one.
-
-      The Confidential Information Form is sealed and stays out of the public
-      file. Keep copies — it must be attached to every certified copy of your
-      Order, or North Dakota Vital Records will reject your updates later.
+      - The case number stays blank. The clerk assigns it when you file.
+      - Only the judge signs the Proposed Order.
+      - The Confidential Information Form is sealed and stays out of the public file. A copy must be attached to every certified copy of your Order, or North Dakota Vital Records will reject your updates later. Keep copies.
 
   - kind: info
     id: hearing
     heading: 'Will there be a hearing?'
     body: |
-      North Dakota does not presumptively require a hearing for a name change,
-      but the judge may decide one is needed. If a hearing is scheduled, the
-      Clerk of District Court will send notice with the date, time, and location.
+      North Dakota does not presumptively require a hearing for a name change, but the judge may decide one is needed. If a hearing is scheduled, the Clerk of District Court will send notice with the date, time, and location.
+
+  - kind: info
+    id: objections
+    heading: 'If someone objects to your petition'
+    body: |
+      During the 30 days after publication, someone may serve a written objection to your name change on you. If that happens, keep a copy for your records and file the original along with your other documents. The clerk will tell you how the judge wants it handled from there.
 
   - kind: output
     output_type: ics
@@ -234,6 +232,7 @@ sections:
     heading: 'Official North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
+      - nd_century_code
       - fee_waiver
       - criminal_history_check
       - nd_free_legal_answers
@@ -242,13 +241,9 @@ sections:
     id: after_order
     heading: 'After the judge signs your Order'
     body: |
-      Ask the clerk for at least three certified copies of your Order — each one
-      needs the Confidential Information Form attached.
+      Ask the clerk for at least three certified copies of your Order. Certified copies cost $10 for the first and $5 for each additional copy requested at the same time, and each one needs the Confidential Information Form attached.
 
-      Then update your records in this order, because each step verifies against
-      the one before it: Social Security Administration first, then the North
-      Dakota DMV, then your passport, then financial accounts, your employer and
-      health insurance, your home title, and voter registration.
+      Then update your records in this order, because each step verifies against the one before it: Social Security Administration first, then the North Dakota DMV, then your passport, then financial accounts, your employer and health insurance, your home title, and voter registration.
 
   - kind: output
     output_type: summary

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -23,7 +23,7 @@ metadata:
   court: north-dakota
   topic: adult-name-change
   role: waiver
-  title: 'Adult Name Change — North Dakota (Publication Waiver)'
+  title: 'Adult Name Change in North Dakota (Publication Waiver)'
 
 contacts:
   - id: clerk
@@ -46,7 +46,7 @@ contacts:
     url: 'https://www.dpls.org'
     note: 'Free legal assistance for low-income individuals, older Americans, veterans, and nine tribal nations across North and South Dakota.'
   - id: state_bar_referral
-    name: 'State Bar Association of North Dakota — Lawyer Referral'
+    name: 'State Bar Association of North Dakota (Lawyer Referral)'
     phone: '(866) 450-9579'
     url: 'https://www.sband.org'
     note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation: hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
@@ -173,7 +173,7 @@ sections:
     id: form_gotchas
     heading: 'Before you sign'
     body: |
-      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is:
+      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is missed:
 
       - The case number stays blank. The clerk assigns it when you file.
       - Only the judge signs the Proposed Order.

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -1,10 +1,9 @@
-# Demo corpus — Adult Name Change (North Dakota), WAIVER track.
-#
-# The waiver track applies when changing the first and/or middle name only,
-# leaving the last name unchanged: 4 forms (no Notice of Petition), and the
-# judge MAY waive newspaper publication and the 30-day wait. The court links to
-# this flow directly for first/middle-only changes; last-name changes use the
-# standard track — adult-name-change-standard.yml.
+# Demo corpus — Adult Name Change (North Dakota), WAIVER track ("publication
+# waiver"). Applies when changing the first and/or middle name only, leaving
+# the last name unchanged: 4 forms (no Notice of Petition), and the judge MAY
+# waive newspaper publication and the 30-day wait. The court links to this flow
+# directly for first/middle-only changes; last-name changes use the
+# publication-required track — adult-name-change-standard.yml.
 #
 # Because publication and the wait can be waived, this flow has no fixed date
 # deadline (hence no calendar export) — it shows how a shorter track renders.
@@ -12,31 +11,36 @@
 # Content verified against the official ND Legal Self Help Center source docs
 # (Instructions for a Name Change (Adult), Residency, Publication, Criminal
 # History) — see #614. Contact phone/email confirmed; form-PDF links not yet
-# re-verified. Publication-waiver scope (#615) and objection/declaration
-# details (#616) still pending legal review.
+# re-verified. Publication-waiver scope (#615) and Declaration form-set
+# details (#616) still pending legal review; this track's top-of-page copy
+# gets its #620-style redraft after #615 settles the track's shape.
+#
+# Authoring style (per #620): no em-dashes in user-facing copy; body
+# paragraphs are ONE line each (the renderer turns every newline into <br>,
+# so hard-wrapped prose breaks mid-sentence).
 
 metadata:
   court: north-dakota
   topic: adult-name-change
   role: waiver
-  title: 'Adult Name Change — North Dakota (Waiver Track)'
+  title: 'Adult Name Change — North Dakota (Publication Waiver)'
 
 contacts:
   - id: clerk
     name: 'Clerk of District Court (your county)'
     url: 'https://www.ndcourts.gov/court-locations'
-    note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal-history background check before or after you file — timing varies by judge, and the waiver track does not remove this. This is the one call to make first."
+    note: "You file in the district court for the county where you have lived the past 6 months. Use the court locator to find your county's clerk, then call before filing to ask whether the judge requires the criminal history background check before or after you file. Timing varies by judge, and the waiver track does not remove this. This is the one call to make first."
   - id: self_help
     name: 'North Dakota Legal Self Help Center'
     phone: '(701) 328-1852'
     email: 'ndselfhelp@ndcourts.gov'
     url: 'https://www.ndcourts.gov/legal-self-help'
-    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers — not legal advice, and not criminal matters.'
+    note: 'A division of the ND Supreme Court Law Library. Provides information about the civil court process for self-represented filers. They cannot give legal advice or help with criminal matters.'
   - id: legal_aid
     name: 'Legal Services of North Dakota'
     phone: '(800) 634-5263'
     url: 'https://lsnd.org'
-    note: 'Free civil legal help for North Dakotans who qualify by income — useful if your name change touches a divorce or other family-law matter. They can also screen you for the Volunteer Lawyers low-cost program.'
+    note: 'Free civil legal help for North Dakotans who qualify by income. Useful if your name change touches a divorce or other family-law matter. They can also screen you for the Volunteer Lawyers low-cost program.'
   - id: dakota_plains
     name: 'Dakota Plains Legal Services'
     url: 'https://www.dpls.org'
@@ -45,13 +49,17 @@ contacts:
     name: 'State Bar Association of North Dakota — Lawyer Referral'
     phone: '(866) 450-9579'
     url: 'https://www.sband.org'
-    note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation — hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
+    note: 'Matches you with a lawyer for paid legal services. Ask about limited (unbundled) representation: hiring a lawyer for just part of your case, like reviewing your paperwork, while you handle the rest.'
 
 resources:
   - id: nd_name_change_guidance
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
-    note: "The court's official adult name-change page — process overview and the source for every form in your packet."
+    note: "The court's official adult name-change page: process overview and the source for every form in your packet."
+  - id: nd_century_code
+    label: 'North Dakota Century Code Chapter 32-28'
+    url: 'https://ndlegis.gov/cencode/t32c28.html'
+    note: 'The state law this name-change process follows.'
   - id: fee_waiver
     label: 'Filing-fee waiver forms'
     url: 'https://www.ndcourts.gov/legal-self-help/fee-waiver'
@@ -59,7 +67,7 @@ resources:
   - id: criminal_history_check
     label: 'Criminal history record check (edo.cjis.gov)'
     url: 'https://www.edo.cjis.gov'
-    note: 'If the judge requires a background check, request it here. You pay the cost, and it can take weeks — ask the clerk early.'
+    note: 'If the judge requires a background check, request it here. You pay the cost, and it can take weeks, so ask the clerk early.'
   - id: nd_free_legal_answers
     label: 'North Dakota Free Legal Answers'
     url: 'https://nd.freelegalanswers.org'
@@ -70,63 +78,39 @@ sections:
     id: overview
     heading: 'Changing your first or middle name in North Dakota'
     body: |
-      This walks you through a standalone adult name-change petition in North
-      Dakota district court, on the waiver track — for changing your first
-      and/or middle name only, leaving your last name unchanged.
+      This walks you through a standalone adult name-change petition in North Dakota district court, on the waiver track: changing your first and/or middle name only, leaving your last name unchanged.
 
-      On this track a judge may waive the newspaper publication requirement, and
-      if publication is waived there is no 30-day waiting period. The waiver is
-      the judge's decision on the facts you present — it is not guaranteed, so
-      plan for the possibility that publication is still required.
+      On this track a judge may waive the newspaper publication requirement, and if publication is waived there is no 30-day waiting period. The waiver is the judge's decision on the facts you present. It is not guaranteed, so plan for the possibility that publication is still required.
 
-      If you are changing your last name (or any combination that includes it),
-      use the standard-track page instead.
+      If you are changing your last name (or any combination that includes it), use the publication-required version of this tool instead.
 
-      One common mix-up: if you wanted your name changed as part of a divorce,
-      that has to be requested inside the divorce case — it is not handled here.
+      One common mix-up: if you wanted your name changed as part of a divorce, that has to be requested inside the divorce case. It is not handled here.
 
   - kind: info
     id: eligibility
     heading: 'Who can file'
     body: |
-      To petition for a name change in North Dakota you must be a U.S. citizen
-      or a U.S. permanent resident. You attest to this on the Petition.
+      To petition for a name change in North Dakota you must be a U.S. citizen or a U.S. permanent resident. You attest to this on the Petition.
 
-      A name change cannot be used to defraud anyone or to evade a legal
-      obligation (for example, debts or a criminal record). These are conditions
-      you confirm on the forms — not something you have to explain to anyone here.
+      A name change cannot be used to defraud anyone or to evade a legal obligation (for example, debts or a criminal record). These are conditions you confirm on the forms, not something you have to explain to anyone here.
 
   - kind: info
     id: costs
     heading: 'What it costs'
     body: |
-      The filing fee is $160. If you cannot afford it, you can file fee-waiver
-      forms at the same time asking the judge to waive the fee — the fee-waiver
-      link is in your resources below.
+      The filing fee is $160. If you cannot afford it, you can file fee-waiver forms at the same time asking the judge to waive the fee. The fee-waiver link is in the official resources at the end of this page.
 
-      Two other costs can come up later: if the judge requires a criminal-history
-      background check, you pay for it; and certified copies of your final Order
-      cost $10 for the first copy and $5 for each additional copy requested at
-      the same time.
+      Two other costs can come up later: if the judge requires a criminal history background check, you pay for it; and certified copies of your final Order cost $10 for the first copy and $5 for each additional copy requested at the same time.
 
   - kind: info
     id: criminal_history
-    heading: 'The criminal-history check'
+    heading: 'Criminal history background check'
     body: |
-      Asking to waive publication does not remove the criminal-history step.
-      Before granting a name change, the judge has to determine whether you have
-      a criminal record. Some judges require every adult filer to get a statewide
-      or national criminal-history background check; others decide after reviewing
-      your petition. Call the clerk before you file to ask which applies in your
-      county — the check can take weeks, so it is worth starting early.
+      Asking to waive publication does not remove the criminal history step. Before granting a name change, the judge has to determine whether you have a criminal record. Some judges require every adult filer to get a statewide or national criminal history background check; others decide after reviewing your petition. Call the clerk before you file to ask which applies in your county. The check can take weeks, so it is worth starting early.
 
-      If the judge requires one, you request it at edo.cjis.gov and pay the cost
-      yourself.
+      If the judge requires one, you request it at edo.cjis.gov and pay the cost yourself.
 
-      If you have a felony conviction, North Dakota law assumes a name-change
-      request is made in bad faith. A judge may still grant it, but you would need
-      to show by clear and convincing evidence that your request is made in good
-      faith and not to defraud, mislead, injure anyone, or compromise public safety.
+      If you have a felony conviction, North Dakota law assumes a name-change request is made in bad faith. A judge may still grant it, but you would need to show by clear and convincing evidence that your request is made in good faith and not to defraud, mislead, injure anyone, or compromise public safety.
 
   - kind: fact_gather
     id: your_details
@@ -151,11 +135,11 @@ sections:
       - id: requested_middle
         label: 'Requested middle name(s)'
         type: text
-        help_text: 'Your last name stays the same on this track — only first and middle change.'
+        help_text: 'Your last name stays the same on this track. Only first and middle change.'
       - id: filing_county
         label: 'County where you will file'
         type: text
-        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill — or look up your address with the court locator at ndcourts.gov/court-locations."
+        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill, or look up your address with the court locator at ndcourts.gov/court-locations."
 
   - kind: output
     output_type: packet
@@ -181,36 +165,25 @@ sections:
     id: publication_waiver
     heading: 'About the publication waiver'
     body: |
-      Because you are not changing your last name, you can ask the judge to
-      waive the requirement to publish a notice in the newspaper. If the judge
-      grants the waiver, there is no 30-day waiting period and your petition can
-      be considered sooner.
+      Because you are not changing your last name, you can ask the judge to waive the requirement to publish a notice in the newspaper. If the judge grants the waiver, there is no 30-day waiting period and your petition can be considered sooner.
 
-      The judge decides this on your particular facts, so it is not automatic.
-      Ask the clerk how your county handles the waiver request, and be ready in
-      case publication is still required.
+      The judge decides this on your particular facts, so it is not automatic. Ask the clerk how your county handles the waiver request, and be ready in case publication is still required.
 
   - kind: info
     id: form_gotchas
     heading: 'Before you sign'
     body: |
-      A few North Dakota specifics that trip people up:
+      A few things in North Dakota's process are easy to miss, and each one has a real consequence if it is:
 
-      Leave the case number blank — the clerk assigns it when you file.
-
-      Do not sign the proposed Order. Only the judge signs that one.
-
-      The Confidential Information Form is sealed and stays out of the public
-      file. Keep copies — it must be attached to every certified copy of your
-      Order, or North Dakota Vital Records will reject your updates later.
+      - The case number stays blank. The clerk assigns it when you file.
+      - Only the judge signs the Proposed Order.
+      - The Confidential Information Form is sealed and stays out of the public file. A copy must be attached to every certified copy of your Order, or North Dakota Vital Records will reject your updates later. Keep copies.
 
   - kind: info
     id: hearing
     heading: 'Will there be a hearing?'
     body: |
-      North Dakota does not presumptively require a hearing for a name change,
-      but the judge may decide one is needed. If a hearing is scheduled, the
-      Clerk of District Court will send notice with the date, time, and location.
+      North Dakota does not presumptively require a hearing for a name change, but the judge may decide one is needed. If a hearing is scheduled, the Clerk of District Court will send notice with the date, time, and location.
 
   - kind: output
     output_type: vcf
@@ -229,6 +202,7 @@ sections:
     heading: 'Official North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
+      - nd_century_code
       - fee_waiver
       - criminal_history_check
       - nd_free_legal_answers
@@ -237,13 +211,9 @@ sections:
     id: after_order
     heading: 'After the judge signs your Order'
     body: |
-      Ask the clerk for at least three certified copies of your Order — each one
-      needs the Confidential Information Form attached.
+      Ask the clerk for at least three certified copies of your Order. Certified copies cost $10 for the first and $5 for each additional copy requested at the same time, and each one needs the Confidential Information Form attached.
 
-      Then update your records in this order, because each step verifies against
-      the one before it: Social Security Administration first, then the North
-      Dakota DMV, then your passport, then financial accounts, your employer and
-      health insurance, your home title, and voter registration.
+      Then update your records in this order, because each step verifies against the one before it: Social Security Administration first, then the North Dakota DMV, then your passport, then financial accounts, your employer and health insurance, your home title, and voter registration.
 
   - kind: output
     output_type: summary

--- a/litigant_portal/prompts/base.py
+++ b/litigant_portal/prompts/base.py
@@ -57,6 +57,8 @@ COMMUNICATION STYLE
 - Format responses using markdown: **bold** for key info, bullet lists for \
   steps, clear paragraph breaks.
 - Keep responses concise and focused.
+- No em-dashes. Use a period, comma, colon, or parentheses instead. \
+  Em-dash-heavy prose reads as AI-generated and undermines trust.
 - Consistent identity handling — use neutral procedural language. "Current \
   legal name" and "requested name," not "real name," "birth name," "maiden \
   name," or "given name" unless the user introduces those words first. No \

--- a/litigant_portal/prompts/base.py
+++ b/litigant_portal/prompts/base.py
@@ -11,7 +11,7 @@ the knowledge of experienced attorneys and court self-help professionals.
 
 FACT GATHERING (PRIORITY ONE)
 Your first goal is to understand the facts of the user's case through natural \
-conversation. Ask ONE question at a time — don't overwhelm with multiple asks. \
+conversation. Ask ONE question at a time. Don't overwhelm with multiple asks. \
 Let the conversation flow naturally. As users describe their situation, ask \
 clarifying questions to uncover:
 - What type of legal matter this is (eviction, small claims, etc.)
@@ -24,19 +24,19 @@ clarifying questions to uncover:
 - Family composition and household size (affects eligibility for programs)
 - Income situation (affects eligibility for legal aid and assistance programs)
 
-Call UpdateCaseFacts immediately whenever you learn any fact — don't wait until \
+Call UpdateCaseFacts immediately whenever you learn any fact. Don't wait until \
 you know everything. Partial updates as facts emerge are preferred. For example, \
 if the user says "my landlord Acme Properties sent me an eviction notice," call \
 UpdateCaseFacts right away with what you know.
 
 CONVERSATION STYLE
 - Ask one question at a time. Build the picture incrementally.
-- Show your work — explain HOW you reached conclusions:
+- Show your work, explaining HOW you reached conclusions:
   "Based on your household size of 3 and income, you may qualify for..."
   "A 5-day notice means..."
 - Reference what they've said: "You mentioned you have 2 children..." \
   "Earlier you said the landlord won't fix the mold..."
-- Don't ask questions in a vacuum — connect them to context.
+- Don't ask questions in a vacuum. Connect them to context.
 - Let paperwork do the work: "What does it say at the top of the notice?" \
   is better than asking them to recall from memory.
 - Don't lead with examples: say "Do you receive child support?" not \
@@ -46,20 +46,20 @@ CONVERSATION STYLE
 - Ask about *what*, not *why*. Load-bearing questions are about what the \
   user is doing or changing, not why they're doing it. Reasons are rarely \
   required for legal routing and asking for them can feel like \
-  interrogation. If a form truly requires a reason, say so plainly — \
-  otherwise don't probe.
+  interrogation. If a form truly requires a reason, say so plainly. \
+  Otherwise don't probe.
 
 COMMUNICATION STYLE
-- Plain language, no legal jargon — but preserve legal precision when citing \
+- Plain language, no legal jargon, but preserve legal precision when citing \
   statutes, form names, or deadlines.
-- Empathetic and reassuring — people are often frightened when dealing with \
+- Empathetic and reassuring: people are often frightened when dealing with \
   legal issues. Deliver hard truths gently but honestly.
 - Format responses using markdown: **bold** for key info, bullet lists for \
   steps, clear paragraph breaks.
 - Keep responses concise and focused.
 - No em-dashes. Use a period, comma, colon, or parentheses instead. \
   Em-dash-heavy prose reads as AI-generated and undermines trust.
-- Consistent identity handling — use neutral procedural language. "Current \
+- Consistent identity handling: use neutral procedural language. "Current \
   legal name" and "requested name," not "real name," "birth name," "maiden \
   name," or "given name" unless the user introduces those words first. No \
   name is more authentic than another.
@@ -72,31 +72,31 @@ respects that users arrived here to do something, not to be screened.
 
 Follow an escalation ladder when you do need user input:
 
-1. **Inform** — present the facts or rules relevant to the situation. No \
+1. **Inform**: present the facts or rules relevant to the situation. No \
    question. Let the user apply the rule to themselves.
-2. **Offer help** — if the user signals they're unsure, offer to walk them \
+2. **Offer help**: if the user signals they're unsure, offer to walk them \
    through it. Acknowledge that this requires more specifics from them, and \
    pair the offer with a brief privacy reassurance.
-3. **Ask for specifics** — only after the user accepts help. Each ask in \
+3. **Ask for specifics**: only after the user accepts help. Each ask in \
    this step should be paired with a privacy reassurance so the user \
    understands why you need the information.
 
 Disqualifiers and eligibility criteria follow the same pattern: "these \
-conditions can prevent X" — not "are you one of these people?" Users apply \
+conditions can prevent X," not "are you one of these people?" Users apply \
 the rule to themselves and self-attest where the form requires it. Never \
 interrogate users about legally-sensitive conditions.
 
 ACTION PLAN (UpdateActionPlan)
 As issues, next steps, and resources emerge in conversation, call \
 UpdateActionPlan to build the user's action plan in the sidebar. Call it \
-incrementally — each call adds to what's already there.
+incrementally: each call adds to what's already there.
 
 Call UpdateActionPlan when you:
-- Identify a legal defense or right (spotted issue) — e.g. habitability \
+- Identify a legal defense or right (spotted issue), e.g. habitability \
   defense, retaliation protection, improper notice
-- Surface a possible next step (action item) — e.g. filing an Appearance, \
+- Surface a possible next step (action item), e.g. filing an Appearance, \
   applying for rental assistance, gathering documents
-- Discover a relevant program or service (resource) — e.g. legal aid, \
+- Discover a relevant program or service (resource), e.g. legal aid, \
   fee waiver, rental assistance program
 
 Mark action items as "urgent" priority when they have imminent deadlines. \
@@ -115,8 +115,8 @@ surface them naturally:
 When you surface an issue, call UpdateActionPlan to record it.
 
 BLOCKERS
-Any step that moots further progress if not handled — a required clerk \
-call, an identity verification step, a pre-filing action — is a **blocker**. \
+Any step that moots further progress if not handled (a required clerk \
+call, an identity verification step, a pre-filing action) is a **blocker**. \
 Surface blockers at the very start of the stage they apply to, and instruct \
 that they pin to the top of the user's sidebar or action plan (mark as \
 urgent priority via UpdateActionPlan). Never bury a blocker inside a \
@@ -136,7 +136,7 @@ DOCUMENT UPLOADS
 The app has a document upload feature. Users can upload PDF documents using \
 the upload button (document icon) next to the chat input. When they ask about \
 uploading documents, tell them to click the upload button. Do NOT say you \
-cannot receive files — the app handles PDF uploads and extracts the text for \
+cannot receive files: the app handles PDF uploads and extracts the text for \
 you automatically.
 
 When the user uploads a legal document, you'll receive context in a [Document \
@@ -151,7 +151,7 @@ When the user shares their underlying motivation (a passport application, a \
 job offer, a travel plan, a child's school enrollment, a housing deadline), \
 hold that context throughout the conversation and reference it at \
 sequencing-critical moments. Example: "since your passport is what started \
-all this, I'll make sure the records sequencing is right — SSA first, then \
+all this, I'll make sure the records sequencing is right: SSA first, then \
 DMV, then passport." Users should feel seen, not funneled through generic \
 steps.
 
@@ -171,7 +171,7 @@ You provide legal INFORMATION, not legal ADVICE. This distinction is critical:
   "One option available to you is..."
   "In similar situations, people often..."
   "You may want to look into..."
-- Cite statutes and procedures when possible — this shows information, not advice
+- Cite statutes and procedures when possible: this shows information, not advice
 - Always mention that consulting with a licensed attorney is an option for \
   case-specific advice
 - End conversations or major topic shifts with a brief disclaimer when \
@@ -181,5 +181,5 @@ The inform-first framing applies to scope-adjacent items too. When \
 something lies outside the specific legal matter but touches the user's \
 situation (e.g., a name change may prompt re-execution of wills or powers \
 of attorney; a housing matter may intersect with benefits eligibility), \
-mention it as a fact with a link to relevant resources — never as a "you \
+mention it as a fact with a link to relevant resources, never as a "you \
 should" recommendation. The user decides what's relevant to them."""


### PR DESCRIPTION
Implements Jessica's top-of-page redraft on the standard track and codifies her content rules. Info-section copy is now hers: merged overview (what the tool does, who can/can't use it, what to expect up front), standalone filing-fee / criminal-history / where-to-file sections, and a new objection-handling section (verified against the court's *Instructions for a Name Change (Adult)* petitioner-side steps). Adds North Dakota Century Code ch. 32-28 to official resources — URL taken from the court's own source-doc hyperlinks. Tracks renamed **Publication Required** / **Publication Waiver**.

Also ships the no-em-dash rule everywhere content gets produced: base chat prompt (live agent output), AI tone guide anti-patterns, and a new CLAUDE.md content-style section. Both corpus tracks swept.

**Rendering bug fixed along the way:** info bodies pipe through Django `linebreaks`, so the old hard-wrapped YAML rendered a mid-sentence `<br>` at every source line wrap, on every info section. Body paragraphs are single-line now, and the constraint is documented in CLAUDE.md.

**Three calls for Jessica to confirm:**
- Her draft drops the no-fraud/no-evasion attestation from the top-of-page copy. Followed the draft — the conditions still live on the Petition and Declaration forms themselves.
- The waiver cross-link is text only ("use the publication-waiver version of this tool"). Info bodies can't carry links until #518.
- "Before you sign" stays adjacent to the filing packet rather than the draft's top placement, since it's about filling the forms.

The waiver track keeps its structure (mechanical fixes only) — its redraft follows once #615 settles that track's shape.

Closes #620

Test plan:
- [x] Both corpora load and validate via the real loader; ICS deadline + resource ids resolve
- [x] Em-dash + wrapped-paragraph sweep verified programmatically (user-facing fields on both tracks)
- [x] `make lint && make test` green
- [ ] QA: /t/north-dakota/adult-name-change/standard/ shows the new copy, no mid-sentence line breaks, checklists render as dash lines