### PR TITLE
feat(corpus): prune unused ND name-change fact-gather fields

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,11 +33,11 @@ Concretely: the docassemble document-assembly handoff is served at `<host>/inter
 
 The `packet` output hands off to a [docassemble](https://docassemble.org) interview that fills the actual court forms. Two systems, two jobs, one contract — and a deliberate split of _which_ facts each side owns:
 
-- **Topic Flow owns** the light fact set it already needs for deadlines and the summary recap, named to match the interview's variables 1:1 so a future prefill is lossless (no ambiguous name-splitting). These `fact_gather` question ids are the contract:
+- **Topic Flow owns** a light fact set, named to match the interview's variables 1:1 so a future prefill is lossless (no ambiguous name-splitting). Today it collects only what a page actually uses — `publication_date` on the standard track, which drives the 30-day deadline (#621); the other ids return when prefill (#531) gives them a consumer. These `fact_gather` question ids are the contract:
   `current_first` · `current_middle` · `current_last` · `requested_first` · `requested_middle` (· `requested_last`, standard track only — the waiver track leaves the last name unchanged) · `filing_county` · `publication_date`.
 - **The interview owns** the full document fact set Topic Flow never collects: residence street/city/zip, residency-since, citizenship, criminal history, publication newspaper, and any track-specific fields. Asking these in the AI-free flow would duplicate the interview and bloat a deliberately light surface.
 
-Names are collected as structured first / middle / last (not a single free-text field) precisely because the forms and the interview are structured that way — splitting a combined name string back apart is lossy and ambiguous.
+The contract keeps names as structured first / middle / last (not a single free-text field) precisely because the forms and the interview are structured that way — splitting a combined name string back apart is lossy and ambiguous.
 
 **v1 is link-out + manual return, no prefill** (#543): the flow links out to the interview, the litigant completes and downloads their packet there, then returns to LP for filing steps. The prefill seam — POSTing this answer set to start a prefilled session, keeping PII out of the URL — is the deferred v2 (#531), and an AI-free session-state "Briefcase" (#177) is the natural carrier for it. The contract above is what makes that future drop-in: same ids, no rework.
 

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -128,37 +128,13 @@ sections:
       File in the district court for the county where you have lived for the past 6 months. Your driver's license, lease, or a utility bill usually shows this. The court locator link in the contacts at the end of this page can also help.
 
   - kind: fact_gather
-    id: your_details
-    heading: 'Your details'
+    # Pruned to the one fact the page actually uses (#621): publication_date
+    # drives the 30-day deadline and its calendar export. The name/county
+    # fields only echoed back in the summary, so they come back when
+    # docassemble prefill (#531) can reuse them downstream.
+    id: publication_details
+    heading: 'Your publication date'
     questions:
-      - id: current_first
-        label: 'Your current first name'
-        type: text
-        required: true
-      - id: current_middle
-        label: 'Your current middle name(s)'
-        type: text
-        help_text: 'Leave blank if you have none.'
-      - id: current_last
-        label: 'Your current last name'
-        type: text
-        required: true
-      - id: requested_first
-        label: 'Requested first name'
-        type: text
-        required: true
-      - id: requested_middle
-        label: 'Requested middle name(s)'
-        type: text
-        help_text: 'Leave blank if you have none.'
-      - id: requested_last
-        label: 'Requested last name'
-        type: text
-        required: true
-      - id: filing_county
-        label: 'County where you will file'
-        type: text
-        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill, or look up your address with the court locator at ndcourts.gov/court-locations."
       - id: publication_date
         label: 'Date your notice was published'
         type: date

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -112,34 +112,9 @@ sections:
 
       If you have a felony conviction, North Dakota law assumes a name-change request is made in bad faith. A judge may still grant it, but you would need to show by clear and convincing evidence that your request is made in good faith and not to defraud, mislead, injure anyone, or compromise public safety.
 
-  - kind: fact_gather
-    id: your_details
-    heading: 'Your details'
-    questions:
-      - id: current_first
-        label: 'Your current first name'
-        type: text
-        required: true
-      - id: current_middle
-        label: 'Your current middle name(s)'
-        type: text
-        help_text: 'Leave blank if you have none.'
-      - id: current_last
-        label: 'Your current last name'
-        type: text
-        required: true
-      - id: requested_first
-        label: 'Requested first name'
-        type: text
-        required: true
-      - id: requested_middle
-        label: 'Requested middle name(s)'
-        type: text
-        help_text: 'Your last name stays the same on this track. Only first and middle change.'
-      - id: filing_county
-        label: 'County where you will file'
-        type: text
-        help_text: "You file in the district court for the county where you have lived the past 6 months. Not sure which county? It is on your driver's license, lease, or a utility bill, or look up your address with the court locator at ndcourts.gov/court-locations."
+  # No fact_gather on this track (#621): the waiver flow computes no deadline,
+  # so the page uses no answers. The name/county fields only echoed back in
+  # the summary; they return when docassemble prefill (#531) can reuse them.
 
   - kind: output
     output_type: packet
@@ -214,8 +189,3 @@ sections:
       Ask the clerk for at least three certified copies of your Order. Certified copies cost $10 for the first and $5 for each additional copy requested at the same time, and each one needs the Confidential Information Form attached.
 
       Then update your records in this order, because each step verifies against the one before it: Social Security Administration first, then the North Dakota DMV, then your passport, then financial accounts, your employer and health insurance, your home title, and voter registration.
-
-  - kind: output
-    output_type: summary
-    id: recap
-    heading: 'Summary of what you entered'


### PR DESCRIPTION
The flow asked for seven facts it never used. Standard track now collects only the publication date (it drives the 30-day deadline and calendar export) under a self-explaining 'Your publication date' heading. The waiver track computes no deadline, so it now collects nothing: fact_gather and its now-empty summary section are removed. Fields return when docassemble prefill (#531) can carry answers into the forms.

Closes #621

Stacked on #644 (same YAML files); GitHub retargets the base to main when it merges.

Test plan: both corpora validate against the Corpus schema (checked locally via the repo venv); the deadline's offset_from linkage to publication_date is intact; engine behavior is covered by existing synthetic-corpus tests, which don't reference the pruned fields.