### PR TITLE
fix(content): drop 'official' from user-facing copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ Rules for authoring user-facing content — corpus YAML (`litigant_portal/conten
 - **No em-dashes.** Use a period, comma, colon, or parentheses instead. Em-dash-heavy prose reads as AI-generated and undermines user trust (legal review, #620). Dev-facing text (code comments, docs, commit messages) is exempt.
 - **Corpus info bodies: one line per paragraph.** The renderer pipes `body` through Django's `linebreaks`, so every newline becomes a `<br>` — hard-wrapped prose breaks mid-sentence on the page. Separate paragraphs with blank lines; never wrap a paragraph across source lines.
 - **Dash-prefixed lines** (`- item`) render as visual line-broken lists (not semantic `<ul>`) until #518 adds rich text to info bodies. Links in body prose are not supported yet (#518) — route them through the corpus `resources`/`contacts` sections instead.
+- **Never label resources or forms "official."** Courts reserve "official" for institutionally designated things — ND's own site uses it only for official county newspapers, the official record of the Court, and to disclaim that Self Help Center forms "aren't official court forms" (#646). Attribute instead of anointing: say whose page or form it is ("the North Dakota Legal Self Help Center's name-change page").
 
 ## Issue creation
 

--- a/litigant_portal/app/templates/pages/profile/edit.html
+++ b/litigant_portal/app/templates/pages/profile/edit.html
@@ -21,7 +21,7 @@
         <div class="space-y-4">
           {% trans "Full Legal Name" as name_label %}
           {% trans "Your full legal name" as name_placeholder %}
-          {% trans "Used for official documents and forms" as name_help %}
+          {% trans "Used for court documents and forms" as name_help %}
           <c-molecules.form-field label="{{ name_label }}" type="text" name="name" id="id_name" placeholder="{{ name_placeholder }}" autocomplete="name" value="{{ form.name.value|default:'' }}" :errors="form.name.errors" help_text="{{ name_help }}" />
           {% trans "Phone Number" as phone_label %}
           {% trans "(555) 123-4567" as phone_placeholder %}

--- a/litigant_portal/content/_test_fixture.yml
+++ b/litigant_portal/content/_test_fixture.yml
@@ -34,7 +34,7 @@ resources:
   - id: self_help_page
     label: 'Name-change guidance and forms'
     url: 'https://example.gov/legal-self-help/name-change'
-    note: 'The official process page and form source.'
+    note: 'The process page and form source.'
 
 sections:
   - kind: info
@@ -83,7 +83,7 @@ sections:
   - kind: output
     output_type: resources
     id: official_resources
-    heading: 'Official resources'
+    heading: 'Resources'
     resource_ids:
       - self_help_page
 

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -60,7 +60,7 @@ resources:
   - id: nd_name_change_guidance
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
-    note: "The court's official adult name-change page: process overview and the source for every form in your packet."
+    note: "The North Dakota Legal Self Help Center's adult name-change page: process overview and the source for every form in your packet."
   - id: nd_century_code
     label: 'North Dakota Century Code Chapter 32-28'
     url: 'https://ndlegis.gov/cencode/t32c28.html'
@@ -101,13 +101,13 @@ sections:
       - Wait time: You must wait 30 days after the notice runs before a judge can decide.
       - Background check: The judge may require a criminal history check. This can take several weeks, so it helps to ask early.
 
-      This process follows North Dakota Century Code Chapter 32-28, linked in the official resources at the end of this page.
+      This process follows North Dakota Century Code Chapter 32-28, linked in the resources at the end of this page.
 
   - kind: info
     id: filing_fee
     heading: 'Filing fee'
     body: |
-      Filing this petition costs $160. If you cannot pay this fee, you can ask the court to waive it. The fee-waiver forms and instructions are linked in the official resources at the end of this page.
+      Filing this petition costs $160. If you cannot pay this fee, you can ask the court to waive it. The fee-waiver forms and instructions are linked in the resources at the end of this page.
 
       File the fee-waiver request at the same time as your name-change documents, and keep a copy for your records.
 
@@ -205,7 +205,7 @@ sections:
   - kind: output
     output_type: resources
     id: official_resources
-    heading: 'Official North Dakota resources'
+    heading: 'North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
       - nd_century_code

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -55,7 +55,7 @@ resources:
   - id: nd_name_change_guidance
     label: 'North Dakota name-change guidance and forms'
     url: 'https://www.ndcourts.gov/legal-self-help/name-change-adult'
-    note: "The court's official adult name-change page: process overview and the source for every form in your packet."
+    note: "The North Dakota Legal Self Help Center's adult name-change page: process overview and the source for every form in your packet."
   - id: nd_century_code
     label: 'North Dakota Century Code Chapter 32-28'
     url: 'https://ndlegis.gov/cencode/t32c28.html'
@@ -98,7 +98,7 @@ sections:
     id: costs
     heading: 'What it costs'
     body: |
-      The filing fee is $160. If you cannot afford it, you can file fee-waiver forms at the same time asking the judge to waive the fee. The fee-waiver link is in the official resources at the end of this page.
+      The filing fee is $160. If you cannot afford it, you can file fee-waiver forms at the same time asking the judge to waive the fee. The fee-waiver link is in the resources at the end of this page.
 
       Two other costs can come up later: if the judge requires a criminal history background check, you pay for it; and certified copies of your final Order cost $10 for the first copy and $5 for each additional copy requested at the same time.
 
@@ -174,7 +174,7 @@ sections:
   - kind: output
     output_type: resources
     id: official_resources
-    heading: 'Official North Dakota resources'
+    heading: 'North Dakota resources'
     resource_ids:
       - nd_name_change_guidance
       - nd_century_code


### PR DESCRIPTION
The ND courts' site reserves "official" for designated things and explicitly disclaims Self Help Center forms as not official court forms. Resources headings, body references, the Self Help Center note, and the profile name-field help now attribute instead of anointing ("the North Dakota Legal Self Help Center's adult name-change page"). CLAUDE.md content-style rule added so new corpora and prompt work don't reintroduce the term; #608/#373 already retitled.

Closes #646

Test plan: both corpora + fixture validate against the Corpus schema; remaining "official" hits are dev-facing (YAML comments, section ids, test literals, court.json field names) per the issue's DoD.