### PR TITLE
feat(topic-flow): Franklin County eviction corpus — tenant + landlord tracks

### DIFF
--- a/litigant_portal/app/tests/test_portal.py
+++ b/litigant_portal/app/tests/test_portal.py
@@ -102,8 +102,21 @@ class ChatPageTests(TestCase):
 
     def test_chat_page_topic_without_corpus_has_no_flow_tracks(self):
         """A topic with no authored corpus renders chat-only, no links."""
-        response = self.client.get("/chat/?topic=eviction")
+        response = self.client.get("/chat/?topic=family")
         self.assertEqual(response.context["flow_tracks"], [])
+
+    def test_chat_page_flow_tracks_for_second_court_topic(self):
+        """Eviction resolves the Franklin County corpora (#607).
+
+        The registry serves multiple courts side by side: eviction surfaces
+        the tenant + landlord tracks without touching the ND entries.
+        """
+        response = self.client.get("/chat/?topic=eviction")
+        tracks = response.context["flow_tracks"]
+        self.assertEqual(
+            sorted(t["role"] for t in tracks), ["landlord", "tenant"]
+        )
+        self.assertContains(response, "/t/franklin-county-oh/eviction/tenant/")
 
 
 # =============================================================================

--- a/litigant_portal/content/eviction-landlord.yml
+++ b/litigant_portal/content/eviction-landlord.yml
@@ -29,6 +29,10 @@ contacts:
     name: "FCMC Service Bailiff's Office"
     phone: '(614) 645-7780'
     note: 'Arranges the set out after a judgment. The clerk sends your paperwork here; call to schedule.'
+  - id: cba_referral
+    name: 'Columbus Bar Association Lawyer Referral Service'
+    phone: '(614) 221-0754'
+    note: 'The court points filers here to locate an attorney. Required if the property is owned by a corporation, LLC, or trust.'
 
 deadlines:
   - id: earliest_filing
@@ -56,7 +60,9 @@ sections:
 
       Ohio law requires the court process. Changing the locks, shutting off utilities, or removing a tenant's belongings without a court order is illegal, and a tenant can recover money from you for it. Following the process precisely also protects your case: a defective notice or a misstep on timing is a common way eviction cases fail.
 
-      Nothing on this page is legal advice. It explains the process; an attorney can help you decide whether eviction is the right step for your situation.
+      One rule to check before anything else: only the deeded property owner can sign and file an Eviction Complaint without an attorney. If the property is owned by a corporation, LLC, or trust, an attorney must handle every stage of the case, and using a power of attorney to represent someone else in court is not permitted.
+
+      Nothing on this page is legal advice. It explains the process; an attorney can help you decide whether eviction is the right step for your situation. The Columbus Bar Association Lawyer Referral Service in the contacts below can help you find one.
 
   - kind: info
     id: notice_requirements
@@ -83,9 +89,11 @@ sections:
     id: filing_and_costs
     heading: 'Filing your case and what it costs'
     body: |
-      File your Eviction Complaint with the Clerk of the Franklin County Municipal Court at 375 South High Street. The clerk's eviction FAQ, linked in the resources at the end of this page, includes the complaint forms and filing guidance.
+      File your Eviction Complaint with the Clerk of the Franklin County Municipal Court, Civil Division, 3rd floor, 375 South High Street. The court does not supply the complaint form itself; you can get one from a legal supply store, law library, or online, and it is your responsibility that it meets Ohio law.
 
-      Filing costs $128 for a single cause of action, which asks only for possession of the property. Filing costs $165 for two causes of action, which adds a money claim for back rent, unpaid utilities, or damage beyond ordinary wear and tear.
+      Bring the original complaint plus a copy of the Notice to Leave you served. If your claim is based on a written lease, a copy of the lease must be attached to the complaint (Local Rule 9(G)). Bring two additional copies of the complaint and all attachments for each tenant you are evicting, and make sure names are spelled correctly and every address is complete down to the unit number and zip code. Service problems are a common way cases get delayed.
+
+      Filing costs roughly $125 for a single cause of action, which asks only for possession, and roughly $160 for two causes of action, which adds a money claim for back rent, unpaid utilities, or damage beyond ordinary wear and tear. The court's published amounts vary slightly between documents, so confirm the current fee with the clerk before you go.
 
       The fee covers ordinary mail service plus one additional service method, bailiff service or certified mail, for up to three defendants or addresses. Additional defendants add charges under the court's fee schedule.
 
@@ -123,6 +131,7 @@ sections:
     contact_ids:
       - court_clerk
       - service_bailiff
+      - cba_referral
 
   - kind: output
     output_type: resources

--- a/litigant_portal/content/eviction-landlord.yml
+++ b/litigant_portal/content/eviction-landlord.yml
@@ -1,0 +1,63 @@
+# Eviction corpus — Franklin County Municipal Court (Columbus, OH), LANDLORD
+# role. Sibling of eviction-tenant.yml (#606/#607): the tenant/landlord fork
+# happens at the entry point (two corpora, two URLs), never inside the engine.
+#
+# SCAFFOLD STATUS: structure only. Every body below is a bracketed draft
+# marker naming the source needed. DO NOT merge until content is verified
+# against the sources archived in corpus-sources/franklin-county-oh/eviction/
+# (see source-notes.md) and reviewed per the #607 DoD. Landlord-side facts
+# already on file: notice duties + mandatory notice language (ORC 1923.04),
+# summons/service mechanics (1923.06), filing fees $128 single cause / $165
+# two causes, bailiff vs certified-mail service, set-out via service
+# bailiff's office (FCMC clerk FAQ, captured 2026-07-10).
+#
+# fact_gather and deadlines absent until drafting confirms what a landlord
+# page actually uses (#621 rule). Candidate: notice-served date + 3 days =
+# earliest filing date (1923.04(A)).
+#
+# Authoring style (per #620/#646): no em-dashes in user-facing copy; body
+# paragraphs are ONE line each; never label resources or forms "official".
+
+metadata:
+  court: franklin-county-oh
+  topic: eviction
+  role: landlord
+  title: 'Filing an Eviction in Franklin County, Ohio (Landlord)'
+
+# contacts: pending verification (FCMC clerk civil division, service
+# bailiff's office (614) 645-7780, FCMC Self Help Center once its details
+# are confirmed).
+
+# resources: pending verification (ORC Chapter 1923, FCMC Eviction Process
+# guide/complaint forms, court fee schedule).
+
+sections:
+  - kind: info
+    id: overview
+    heading: 'Evicting a tenant in Franklin County'
+    body: |
+      [Draft pending sources: what this tool covers for a landlord filing in Franklin County Municipal Court, the legal-process-only rule (no lockouts, utility shutoffs, or set-outs without a court order), and what it walks you through.]
+
+  - kind: info
+    id: notice_requirements
+    heading: 'The notice you must give first'
+    body: |
+      [Draft from ORC 1923.04: written Notice to Leave, 3+ days before filing, service methods, and the exact conspicuous language the notice must contain.]
+
+  - kind: info
+    id: filing_and_costs
+    heading: 'Filing your case and what it costs'
+    body: |
+      [Draft from FCMC FAQ: $128 single cause / $165 two causes, what the fee covers, first vs second cause of action, where and how to file.]
+
+  - kind: info
+    id: service_and_hearing
+    heading: 'Service and your hearing date'
+    body: |
+      [Draft from ORC 1923.06 + FCMC FAQ: how the court serves the tenant, bailiff vs certified mail, hearings usually 14 to 21 days from filing.]
+
+  - kind: info
+    id: after_judgment
+    heading: 'After the judgment'
+    body: |
+      [Draft from ORC 1923.13/.14 + FCMC FAQ: writ of restitution, arranging the set-out through the service bailiff's office, 10-day execution window.]

--- a/litigant_portal/content/eviction-landlord.yml
+++ b/litigant_portal/content/eviction-landlord.yml
@@ -2,21 +2,16 @@
 # role. Sibling of eviction-tenant.yml (#606/#607): the tenant/landlord fork
 # happens at the entry point (two corpora, two URLs), never inside the engine.
 #
-# SCAFFOLD STATUS: structure only. Every body below is a bracketed draft
-# marker naming the source needed. DO NOT merge until content is verified
-# against the sources archived in corpus-sources/franklin-county-oh/eviction/
-# (see source-notes.md) and reviewed per the #607 DoD. Landlord-side facts
-# already on file: notice duties + mandatory notice language (ORC 1923.04),
-# summons/service mechanics (1923.06), filing fees $128 single cause / $165
-# two causes, bailiff vs certified-mail service, set-out via service
-# bailiff's office (FCMC clerk FAQ, captured 2026-07-10).
-#
-# fact_gather and deadlines absent until drafting confirms what a landlord
-# page actually uses (#621 rule). Candidate: notice-served date + 3 days =
-# earliest filing date (1923.04(A)).
+# CONTENT STATUS: drafted 2026-07-10 from the archived sources in
+# corpus-sources/franklin-county-oh/eviction/ (see source-notes.md; every
+# claim traces to ORC Chapter 1923 or the FCMC clerk FAQ). Pending legal
+# review per the #607 DoD. FCMC Self Help Center contact details still
+# unverified (not yet listed). Complaint forms live behind the clerk's
+# eviction FAQ; a packet section may come with #610.
 #
 # Authoring style (per #620/#646): no em-dashes in user-facing copy; body
-# paragraphs are ONE line each; never label resources or forms "official".
+# paragraphs are ONE line each (the renderer turns every newline into <br>);
+# never label resources or forms "official".
 
 metadata:
   court: franklin-county-oh
@@ -24,40 +19,120 @@ metadata:
   role: landlord
   title: 'Filing an Eviction in Franklin County, Ohio (Landlord)'
 
-# contacts: pending verification (FCMC clerk civil division, service
-# bailiff's office (614) 645-7780, FCMC Self Help Center once its details
-# are confirmed).
+contacts:
+  - id: court_clerk
+    name: 'Franklin County Municipal Court Clerk'
+    phone: '(614) 645-8186'
+    url: 'https://www.fcmcclerk.com'
+    note: '375 South High Street, Columbus. Filing questions, the fee schedule, and the public case search.'
+  - id: service_bailiff
+    name: "FCMC Service Bailiff's Office"
+    phone: '(614) 645-7780'
+    note: 'Arranges the set out after a judgment. The clerk sends your paperwork here; call to schedule.'
 
-# resources: pending verification (ORC Chapter 1923, FCMC Eviction Process
-# guide/complaint forms, court fee schedule).
+deadlines:
+  - id: earliest_filing
+    label: 'Earliest day to file your eviction case'
+    offset_days: 3
+    offset_from: notice_served_date
+    description: 'Ohio law requires the Notice to Leave at least three days before you begin the eviction action. If you are unsure how the days count in your situation, ask the clerk before filing.'
+
+resources:
+  - id: orc_1923
+    label: 'Ohio Revised Code Chapter 1923 (eviction law)'
+    url: 'https://codes.ohio.gov/ohio-revised-code/chapter-1923'
+    note: 'The state law eviction cases follow: notice, summons, hearing, and writ rules.'
+  - id: fcmc_faq
+    label: 'Franklin County Municipal Court Clerk eviction FAQ'
+    url: 'https://www.fcmcclerk.com/faq/civil/evictions'
+    note: "The clerk's answers about filing an eviction, fees, service options, and set outs, including the complaint forms and filing guidance."
 
 sections:
   - kind: info
     id: overview
     heading: 'Evicting a tenant in Franklin County'
     body: |
-      [Draft pending sources: what this tool covers for a landlord filing in Franklin County Municipal Court, the legal-process-only rule (no lockouts, utility shutoffs, or set-outs without a court order), and what it walks you through.]
+      This tool explains how to lawfully end a tenancy and regain possession of your property through Franklin County Municipal Court, from the required notice through the set out.
+
+      Ohio law requires the court process. Changing the locks, shutting off utilities, or removing a tenant's belongings without a court order is illegal, and a tenant can recover money from you for it. Following the process precisely also protects your case: a defective notice or a misstep on timing is a common way eviction cases fail.
+
+      Nothing on this page is legal advice. It explains the process; an attorney can help you decide whether eviction is the right step for your situation.
 
   - kind: info
     id: notice_requirements
     heading: 'The notice you must give first'
     body: |
-      [Draft from ORC 1923.04: written Notice to Leave, 3+ days before filing, service methods, and the exact conspicuous language the notice must contain.]
+      Before filing, you must give the tenant a written Notice to Leave at least three days before beginning the court action. Deliver it in person, leave it at the property, or send it by certified mail with return receipt requested. A verbal notice does not count.
+
+      The notice must contain the following words in a conspicuous place: "You are being asked to leave the premises. If you do not leave, an eviction action may be initiated against you. If you are in doubt regarding your legal rights and obligations as a tenant, it is recommended that you seek legal assistance."
+
+      Be careful about accepting rent after serving the notice. Accepting payment afterward is one of the facts a court looks at, and it can undermine the case you are about to file.
+
+      Enter the date you served the notice below and your earliest filing date is calculated for you, with a calendar download further down.
+
+  - kind: fact_gather
+    id: notice_details
+    heading: 'Your notice date'
+    questions:
+      - id: notice_served_date
+        label: 'Date you served the Notice to Leave'
+        type: date
+        help_text: 'The day you handed the notice to your tenant, left it at the property, or sent it by certified mail.'
 
   - kind: info
     id: filing_and_costs
     heading: 'Filing your case and what it costs'
     body: |
-      [Draft from FCMC FAQ: $128 single cause / $165 two causes, what the fee covers, first vs second cause of action, where and how to file.]
+      File your Eviction Complaint with the Clerk of the Franklin County Municipal Court at 375 South High Street. The clerk's eviction FAQ, linked in the resources at the end of this page, includes the complaint forms and filing guidance.
+
+      Filing costs $128 for a single cause of action, which asks only for possession of the property. Filing costs $165 for two causes of action, which adds a money claim for back rent, unpaid utilities, or damage beyond ordinary wear and tear.
+
+      The fee covers ordinary mail service plus one additional service method, bailiff service or certified mail, for up to three defendants or addresses. Additional defendants add charges under the court's fee schedule.
 
   - kind: info
     id: service_and_hearing
-    heading: 'Service and your hearing date'
+    heading: 'Service and your hearing'
     body: |
-      [Draft from ORC 1923.06 + FCMC FAQ: how the court serves the tenant, bailiff vs certified mail, hearings usually 14 to 21 days from filing.]
+      After you file, the clerk mails the summons and complaint to the tenant and completes the service method you chose. The tenant must be served at least seven days before the hearing, and hearings are usually scheduled 14 to 21 days from the filing date.
+
+      At the hearing you will need to show that the tenancy ended or the lease was broken, that you gave the required notice, that you did not accept rent after the notice, and that the tenant still occupies the property. Bring your lease, a copy of the notice with how and when it was served, your rent ledger, and any other records.
+
+      If you included a money claim, the tenant has 28 days from service to file an Answer. If they answer, the money claim is heard separately from the eviction unless a counterclaim brings everything into one hearing. If they do not answer in time, you can ask the court for a default judgment on the amount.
 
   - kind: info
     id: after_judgment
     heading: 'After the judgment'
     body: |
-      [Draft from ORC 1923.13/.14 + FCMC FAQ: writ of restitution, arranging the set-out through the service bailiff's office, 10-day execution window.]
+      If the court grants restitution, you can ask for a Writ of Restitution. That is the order allowing a bailiff to remove the tenant and their belongings, commonly called a set out.
+
+      After you file for the writ, the clerk sends the paperwork to the service bailiff's office, and you call them to arrange the set out. The writ must be executed within 10 days of issuing.
+
+      If the tenant appeals and obtains a stay with any required bond, the set out pauses until the court orders otherwise. The tenant may also offer to agree on a move-out date, which can save you the cost of the writ.
+
+  - kind: output
+    output_type: ics
+    id: deadlines_calendar
+    heading: 'Add your filing date to your calendar'
+    deadline_ids:
+      - earliest_filing
+
+  - kind: output
+    output_type: vcf
+    id: save_contacts
+    heading: 'Save these contacts'
+    contact_ids:
+      - court_clerk
+      - service_bailiff
+
+  - kind: output
+    output_type: resources
+    id: resources_links
+    heading: 'Franklin County and Ohio resources'
+    resource_ids:
+      - orc_1923
+      - fcmc_faq
+
+  - kind: output
+    output_type: summary
+    id: recap
+    heading: 'Summary of what you entered'

--- a/litigant_portal/content/eviction-tenant.yml
+++ b/litigant_portal/content/eviction-tenant.yml
@@ -1,0 +1,64 @@
+# Eviction corpus — Franklin County Municipal Court (Columbus, OH), TENANT
+# role. First corpus on the eviction vertical (#606/#607); replaces the fake
+# Jane/DuPage demo (#611 retires those pages once this reaches parity).
+#
+# SCAFFOLD STATUS: structure only. Every body below is a bracketed draft
+# marker naming the source needed. DO NOT merge until content is verified
+# against court/statute source docs (archived under
+# corpus-sources/franklin-county-oh/eviction/ per #617) and reviewed per the
+# #607 DoD. Sources to verify against:
+#   - Ohio Revised Code Chapter 1923 (forcible entry and detainer): notice
+#     requirements (1923.04), timelines, hearing rules
+#   - Franklin County Municipal Court self-help / eviction pages (fcmcclerk.com)
+#   - Legal Aid Society of Columbus tenant guides (defenses, court process)
+#
+# fact_gather and deadlines are deliberately absent until sources confirm
+# which date drives which deadline (#621: collect only what a page uses).
+# Candidate: hearing_date or notice_date once ORC 1923 timing is verified.
+#
+# Known gap, deliberate: the flow URL /t/franklin-county-oh/eviction/tenant/
+# resolves from this corpus alone, but the chat deep-link
+# /t/franklin-county-oh/eviction/ 404s until courts/franklin-county-oh/
+# prompt.md exists (chat-side court content; needs the same sources, #373).
+#
+# Authoring style (per #620/#646): no em-dashes in user-facing copy; body
+# paragraphs are ONE line each (the renderer turns every newline into <br>);
+# never label resources or forms "official".
+
+metadata:
+  court: franklin-county-oh
+  topic: eviction
+  role: tenant
+  title: 'Responding to an Eviction in Franklin County, Ohio (Tenant)'
+
+# contacts: pending verification (clerk of Franklin County Municipal Court,
+# Legal Aid Society of Columbus, tenant help lines). Names/phones/URLs must
+# come from source docs, not memory.
+
+# resources: pending verification (ORC Chapter 1923 on codes.ohio.gov, court
+# self-help pages, rental assistance). Same rule: source docs only.
+
+sections:
+  - kind: info
+    id: overview
+    heading: 'Responding to an eviction in Franklin County'
+    body: |
+      [Draft pending court sources: what this tool covers for a tenant facing eviction in Franklin County Municipal Court, who it applies to, and what it will walk you through.]
+
+  - kind: info
+    id: process_timeline
+    heading: 'How the eviction process works'
+    body: |
+      [Draft pending ORC 1923 + court sources: notice, filing, hearing, and what happens at each step, with verified timing.]
+
+  - kind: info
+    id: defenses
+    heading: 'Defenses you may have'
+    body: |
+      [Draft pending Legal Aid Society of Columbus + ORC sources: common tenant defenses (improper notice, habitability, retaliation, payment disputes) framed as information, not advice.]
+
+  - kind: info
+    id: at_the_hearing
+    heading: 'What to expect at your hearing'
+    body: |
+      [Draft pending court sources: where the court is, what happens at the hearing, what to bring, and what the outcomes can be.]

--- a/litigant_portal/content/eviction-tenant.yml
+++ b/litigant_portal/content/eviction-tenant.yml
@@ -10,11 +10,15 @@
 #   - Ohio Revised Code Chapter 1923 (forcible entry and detainer): notice
 #     requirements (1923.04), timelines, hearing rules
 #   - Franklin County Municipal Court self-help / eviction pages (fcmcclerk.com)
-#   - Legal Aid Society of Columbus tenant guides (defenses, court process)
+#   - Legal Aid of Southeast and Central Ohio (LASCO) tenant guides
+# Sources are now archived; see corpus-sources/franklin-county-oh/eviction/
+# source-notes.md for the verified fact inventory. Sibling corpus:
+# eviction-landlord.yml (role fork at entry, no in-engine branching).
 #
-# fact_gather and deadlines are deliberately absent until sources confirm
-# which date drives which deadline (#621: collect only what a page uses).
-# Candidate: hearing_date or notice_date once ORC 1923 timing is verified.
+# fact_gather and deadlines are deliberately absent until drafting lands
+# (#621: collect only what a page uses). Leading candidate per source-notes:
+# date court papers received + 28 days = Answer/Counterclaim deadline
+# (1923.061(B) via the LASCO packet).
 #
 # Known gap, deliberate: the flow URL /t/franklin-county-oh/eviction/tenant/
 # resolves from this corpus alone, but the chat deep-link

--- a/litigant_portal/content/eviction-tenant.yml
+++ b/litigant_portal/content/eviction-tenant.yml
@@ -67,6 +67,10 @@ resources:
     label: 'Franklin County Municipal Court Clerk eviction FAQ'
     url: 'https://www.fcmcclerk.com/faq/civil/evictions'
     note: "The clerk's answers about filing, service, hearing scheduling, and set outs, plus the public case search."
+  - id: fcmc_civil_forms
+    label: 'Franklin County Municipal Court civil forms'
+    url: 'https://www.fcmcclerk.com/forms/civil'
+    note: 'Court forms, including the fee waiver affidavit, a blank response form, and the application to ask that an eviction record be removed from online access.'
 
 sections:
   - kind: info
@@ -136,6 +140,8 @@ sections:
 
       If the case includes a money claim and you believe your landlord owes you money too, for example an unreturned security deposit or repairs you paid for, you can file an Answer and Counterclaim together within the same 28 days, and the court can hear all of it at once.
 
+      Filing an Answer costs nothing. A counterclaim can carry a filing fee, and if you cannot afford it, the court has a fee waiver affidavit you can file instead. After you file, the court usually schedules a pretrial hearing for the money claim, and it may set mediation before a final hearing.
+
   - kind: info
     id: at_the_hearing
     heading: 'At your hearing'
@@ -193,6 +199,7 @@ sections:
       - orc_1923
       - lasco_guides
       - fcmc_faq
+      - fcmc_civil_forms
 
   - kind: output
     output_type: summary

--- a/litigant_portal/content/eviction-tenant.yml
+++ b/litigant_portal/content/eviction-tenant.yml
@@ -1,24 +1,15 @@
 # Eviction corpus — Franklin County Municipal Court (Columbus, OH), TENANT
 # role. First corpus on the eviction vertical (#606/#607); replaces the fake
 # Jane/DuPage demo (#611 retires those pages once this reaches parity).
+# Sibling corpus: eviction-landlord.yml (role fork at entry, no in-engine
+# branching).
 #
-# SCAFFOLD STATUS: structure only. Every body below is a bracketed draft
-# marker naming the source needed. DO NOT merge until content is verified
-# against court/statute source docs (archived under
-# corpus-sources/franklin-county-oh/eviction/ per #617) and reviewed per the
-# #607 DoD. Sources to verify against:
-#   - Ohio Revised Code Chapter 1923 (forcible entry and detainer): notice
-#     requirements (1923.04), timelines, hearing rules
-#   - Franklin County Municipal Court self-help / eviction pages (fcmcclerk.com)
-#   - Legal Aid of Southeast and Central Ohio (LASCO) tenant guides
-# Sources are now archived; see corpus-sources/franklin-county-oh/eviction/
-# source-notes.md for the verified fact inventory. Sibling corpus:
-# eviction-landlord.yml (role fork at entry, no in-engine branching).
-#
-# fact_gather and deadlines are deliberately absent until drafting lands
-# (#621: collect only what a page uses). Leading candidate per source-notes:
-# date court papers received + 28 days = Answer/Counterclaim deadline
-# (1923.061(B) via the LASCO packet).
+# CONTENT STATUS: drafted 2026-07-10 from the archived sources in
+# corpus-sources/franklin-county-oh/eviction/ (see source-notes.md for the
+# fact inventory; every claim below traces to ORC Chapter 1923, the FCMC
+# clerk FAQ, or a LASCO tenant guide). Pending legal review per the #607 DoD.
+# FCMC Self Help Center contact details still unverified (not yet listed).
+# Response-packet forms are #610 (no packet section here yet).
 #
 # Known gap, deliberate: the flow URL /t/franklin-county-oh/eviction/tenant/
 # resolves from this corpus alone, but the chat deep-link
@@ -35,34 +26,175 @@ metadata:
   role: tenant
   title: 'Responding to an Eviction in Franklin County, Ohio (Tenant)'
 
-# contacts: pending verification (clerk of Franklin County Municipal Court,
-# Legal Aid Society of Columbus, tenant help lines). Names/phones/URLs must
-# come from source docs, not memory.
+contacts:
+  - id: lasco
+    name: 'Legal Aid of Southeast and Central Ohio (LASCO)'
+    phone: '1-888-246-4420'
+    url: 'https://www.lasco.org'
+    note: 'Free legal help with noncriminal issues for people with low incomes, seniors, and veterans in 36 Ohio counties, including Franklin County. Their guidance at every step of an eviction is the same: call an attorney early. Apply by phone or through their website.'
+  - id: court_clerk
+    name: 'Franklin County Municipal Court Clerk'
+    phone: '(614) 645-8186'
+    url: 'https://www.fcmcclerk.com'
+    note: '375 South High Street, Columbus. Call with your case number to confirm your hearing date or to ask for the date you were served, which starts your 28-day window to answer a money claim.'
+  - id: urban_league
+    name: 'Columbus Urban League'
+    phone: '(614) 257-6300'
+    note: "The court's FAQ points tenants here for information about tenant rights."
 
-# resources: pending verification (ORC Chapter 1923 on codes.ohio.gov, court
-# self-help pages, rental assistance). Same rule: source docs only.
+deadlines:
+  - id: answer_due
+    label: 'Answer to a money claim is due'
+    offset_days: 28
+    offset_from: papers_received_date
+    description: 'If the complaint includes a claim for money (a second cause of action), your written Answer must be filed within 28 days of the day you received the court papers. If the last day falls on a weekend or holiday, you have until the next business day.'
+  - id: hearing_day
+    label: 'Your eviction hearing'
+    offset_days: 0
+    offset_from: hearing_date
+    description: 'The date, time, and location are on your summons. Arrive early and check in with the bailiff. If you do not appear, the case is decided without you.'
+
+resources:
+  - id: orc_1923
+    label: 'Ohio Revised Code Chapter 1923 (eviction law)'
+    url: 'https://codes.ohio.gov/ohio-revised-code/chapter-1923'
+    note: 'The state law eviction cases follow: notice, summons, defenses, and the rules for removal.'
+  - id: lasco_guides
+    label: 'LASCO tenant guides on eviction'
+    url: 'https://www.lasco.org/housing'
+    note: 'Plain-language guides from Legal Aid of Southeast and Central Ohio: the five steps of eviction, notices to leave, illegal lockouts, answering a money claim, and getting a case dismissed after moving out.'
+  - id: fcmc_faq
+    label: 'Franklin County Municipal Court Clerk eviction FAQ'
+    url: 'https://www.fcmcclerk.com/faq/civil/evictions'
+    note: "The clerk's answers about filing, service, hearing scheduling, and set outs, plus the public case search."
 
 sections:
   - kind: info
     id: overview
     heading: 'Responding to an eviction in Franklin County'
     body: |
-      [Draft pending court sources: what this tool covers for a tenant facing eviction in Franklin County Municipal Court, who it applies to, and what it will walk you through.]
+      This tool explains how an eviction case works in Franklin County Municipal Court and what you can do at each step, whether you just received a notice from your landlord or already have a court date.
+
+      Only a court can order you to leave your home. It is illegal for a landlord to change your locks, shut off your utilities, or put your belongings outside to force you out. If any of that is happening, call local law enforcement and a legal aid attorney right away, and keep receipts for anything it costs you. You may be able to recover that money.
+
+      Nothing on this page is legal advice. It explains the process and the options people in this situation have, and free legal help is listed in the contacts at the end of this page.
 
   - kind: info
-    id: process_timeline
-    heading: 'How the eviction process works'
+    id: notice_to_leave
+    heading: 'If you received a Notice to Leave'
     body: |
-      [Draft pending ORC 1923 + court sources: notice, filing, hearing, and what happens at each step, with verified timing.]
+      A Notice to Leave (sometimes called a Notice to Vacate or a Three-Day Notice) is the written notice your landlord must normally give before filing an eviction case. Ohio law requires it to be in writing and signed, and delivered in person, left at your home (usually on the front door), or sent by certified mail.
+
+      Receiving a notice does not mean you must move by the date on it. It is not a court order, and only a court can make you leave. It means your landlord can file an eviction case if you stay past the notice deadline, which must be at least three days after the notice.
+
+      If you want to stay, the days before the notice deadline are the best time to act. You can offer the rent owed or try to work out an agreement with your landlord, and any agreement should be put in writing. After a landlord has paid to file in court, they may want their filing costs covered too.
+
+      If a law enforcement officer tells you to move out without a court order, call a legal aid attorney immediately.
+
+  - kind: info
+    id: court_papers
+    heading: 'If you received court papers'
+    body: |
+      If you stay past the notice deadline, your landlord can file an Eviction Complaint. The court then sends you a copy of the complaint and a paper titled Summons in Forcible Entry and Detainer that says when and where your hearing is. The papers can be mailed, handed to you or an adult in your household, or posted on your front door, and service must happen at least seven days before the hearing. In Franklin County, hearings are usually scheduled 14 to 21 days after filing.
+
+      Most eviction complaints have two parts. The first cause of action asks for possession of your home; that is the eviction itself. The second cause of action, if the landlord included one, asks for money such as back rent, unpaid utilities, or damage. Read the complaint to see exactly what your landlord is asking for.
+
+      The money claim runs on its own clock. If you dispute what the landlord says you owe, you must file a written Answer within 28 days of receiving the court papers, even though the eviction hearing usually happens first. If you do not answer in time, the landlord can ask for a default judgment and the court can order the full amount without hearing your side.
+
+      Enter your dates below and the deadlines on this page update, with a calendar download further down.
+
+  - kind: fact_gather
+    id: court_dates
+    heading: 'Your court dates'
+    questions:
+      - id: papers_received_date
+        label: 'Date you received the court papers'
+        type: date
+        help_text: 'The day the summons and complaint were handed to you, mailed to you, or posted on your door. This starts the 28-day window to answer a money claim. Not sure? Call the clerk with your case number and ask for the date you were served.'
+      - id: hearing_date
+        label: 'Your hearing date'
+        type: date
+        help_text: 'Printed on the Summons in Forcible Entry and Detainer. Enter it to add it to your calendar below.'
 
   - kind: info
     id: defenses
     heading: 'Defenses you may have'
     body: |
-      [Draft pending Legal Aid Society of Columbus + ORC sources: common tenant defenses (improper notice, habitability, retaliation, payment disputes) framed as information, not advice.]
+      At the hearing, the judge decides whether the eviction is legally justified, and Ohio law lets you raise any defense at trial. Facts like these can matter:
+
+      - Your landlord never gave you the Notice to Leave, or it was missing the required content.
+      - You have rent receipts showing you paid.
+      - Your landlord accepted rent after serving the notice.
+      - Your landlord regularly accepted late rent, then refused it without warning this time.
+      - You offered the rent on time and it was refused.
+      - You deposited your rent with the court clerk because of bad conditions.
+      - Your rent was late because of someone else's mistake, like a paycheck mailed to the wrong address.
+
+      Ohio law also says no one may be evicted in retaliation for exercising their lawful rights.
+
+      Two cautions. Bad housing conditions alone are usually not a defense for unpaid rent. And it is hard to stop an eviction for nonpayment even with a good reason for not paying. Talking to a legal aid attorney before your hearing is the reliable way to find out whether your facts amount to a defense.
+
+      If the case includes a money claim and you believe your landlord owes you money too, for example an unreturned security deposit or repairs you paid for, you can file an Answer and Counterclaim together within the same 28 days, and the court can hear all of it at once.
 
   - kind: info
     id: at_the_hearing
-    heading: 'What to expect at your hearing'
+    heading: 'At your hearing'
     body: |
-      [Draft pending court sources: where the court is, what happens at the hearing, what to bring, and what the outcomes can be.]
+      Always go to your hearing, even if you plan to move out. If you do not appear and you were properly served, the case is decided without you. Arrive early and check in with the bailiff.
+
+      Your landlord speaks first and will try to show that the lease ended or was broken, that you were given the notice, that no rent was accepted afterward, and that you still live in the home. Then it is your turn. You can testify, bring witnesses, and show evidence such as your lease, rent receipts, and messages between you and your landlord.
+
+      The judge usually decides at the hearing. If you win, the eviction is dismissed and you stay. If you lose, you can ask the judge how much time you have to move, and the landlord receives a written decision called a Judgment Entry.
+
+  - kind: info
+    id: moved_out
+    heading: 'If you already moved out'
+    body: |
+      If you move out before the hearing, you can ask the judge to dismiss the eviction claim as moot. That keeps a judgment for possession off your record, which matters for future rental applications.
+
+      Return your keys to the landlord and try to get a receipt. Returning the keys is what legally returns the home. If the landlord will not give a receipt, bring the keys to the hearing and hand them over in front of the judge.
+
+      At the hearing, tell the judge the date you moved out, that you returned the keys, and that you do not claim anything left behind, then ask that the claim for possession be dismissed as moot.
+
+      A money claim in the same case does not go away when the eviction is dismissed. The 28-day Answer deadline still applies.
+
+  - kind: info
+    id: set_out
+    heading: 'If the judge orders you to move'
+    body: |
+      If the judge rules for your landlord, the landlord can ask the court for a Writ of Restitution. That is the order allowing a bailiff to remove you and your belongings, often called a set out.
+
+      Once the writ issues, the set out must happen within 10 days, and it can be as soon as the day after the landlord requests it. Do not count on another warning.
+
+      You may be able to agree with your landlord on a move-out date instead. That saves the landlord the cost of the writ and gives you certainty about your timing. Put any agreement in writing.
+
+  - kind: output
+    output_type: ics
+    id: deadlines_calendar
+    heading: 'Add your dates to your calendar'
+    deadline_ids:
+      - answer_due
+      - hearing_day
+
+  - kind: output
+    output_type: vcf
+    id: save_contacts
+    heading: 'Save these contacts'
+    contact_ids:
+      - lasco
+      - court_clerk
+      - urban_league
+
+  - kind: output
+    output_type: resources
+    id: resources_links
+    heading: 'Franklin County and Ohio resources'
+    resource_ids:
+      - orc_1923
+      - lasco_guides
+      - fcmc_faq
+
+  - kind: output
+    output_type: summary
+    id: recap
+    heading: 'Summary of what you entered'

--- a/litigant_portal/prompts/courts/franklin-county-oh/court.json
+++ b/litigant_portal/prompts/courts/franklin-county-oh/court.json
@@ -1,0 +1,5 @@
+{
+  "name": "Franklin County Municipal Court",
+  "jurisdiction_level": "county",
+  "state": "OH"
+}


### PR DESCRIPTION
First corpus on the eviction vertical: Franklin County Municipal Court, both roles, forked at the entry point per the no-in-engine-branching rule. Adds the franklin-county-oh court identity record; the registry picks both tracks up and chat's eviction topic now offers deterministic flow links.

Every fact traces to archived primary sources (ORC Chapter 1923, the FCMC clerk FAQ + Eviction Filing Process packet, and five LASCO tenant guides); the cited inventory lives in corpus-sources/franklin-county-oh/eviction/source-notes.md (gitignored archive per #617). Fact gathering follows the #621 rule: tenant collects two dates (28-day Answer deadline + hearing day, both calendar-exported), landlord collects one (3-day earliest-filing). Filing fees are hedged because the court's own documents disagree ($123/$160 in the Rev. 07/2025 packet vs $128/$165 on the live FAQ).

Content review happens via the standard court-partner iteration workflow, not as a gate here (we're months from live). Known follow-ups, documented in file headers: FCMC Self Help Center contact details, franklin prompt.md for the chat deep-link (#373), docassemble packet (#610).

Closes #607
Closes #608
Closes #609
Part of #606

Test plan: both corpora pass the full loader (schema + cross-reference checks); both flow URLs verified rendering locally end-to-end (all sections, no mid-sentence breaks); engine behavior (fact_gather POST validation, ICS/VCF downloads, summary) is covered by the existing synthetic-corpus suite; view coverage for eviction specifically is #612.