### PR TITLE
feat(deploy): restore manual QA deploy to DigitalOcean

### DIFF
--- a/.github/workflows/qa-deploy-do.yml
+++ b/.github/workflows/qa-deploy-do.yml
@@ -1,0 +1,111 @@
+name: Deploy to DigitalOcean QA (manual)
+
+# TEMPORARY manual deploy for the DigitalOcean QA box (qa.litigantportal.com),
+# which is LP's only live env until the AWS `qa-litigant` env is wired up (#587).
+# Manual-only (workflow_dispatch): pick a ref, build its image, push to Docker
+# Hub, and roll it out on the box over SSH. No auto-deploy on merge — image
+# publishing for AWS still lives in deploy.yml and is unaffected.
+#
+# REMOVAL AT CUTOVER: delete this file + the `deploy/qa-do/` dir. Nothing else
+# references either. See deploy/qa-do/README.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_ref:
+        description: 'Branch or tag to build and deploy (image + box config both come from this ref)'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: read
+
+# Serialize deploys so back-to-back dispatches don't race the SSH step.
+concurrency:
+  group: qa-do-deploy
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build, push, deploy to DO QA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.deploy_ref }}
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Push a moving `:qa` tag (what the box compose pulls) plus an immutable
+      # `<sha>-prod` tag for provenance / manual rollback.
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: docker/django/Dockerfile
+          push: true
+          tags: |
+            freelawproject/litigant-portal:qa
+            freelawproject/litigant-portal:${{ steps.sha.outputs.short }}-prod
+
+      - name: Deploy to QA box
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.QA_HOST }}
+          username: ${{ secrets.QA_USER }}
+          key: ${{ secrets.QA_SSH_KEY }}
+          envs: DEPLOY_REF
+          script: |
+            set -euo pipefail
+            cd /opt/litigant-portal
+            COMPOSE="docker compose -f deploy/qa-do/docker-compose.qa.yml --env-file /opt/litigant-portal/.env"
+
+            # Rollback breadcrumb: record the image the box is running NOW before
+            # we replace it. QA is the only live env, so if the new image
+            # misbehaves you can repull this digest by hand.
+            echo "Currently-running django image (for rollback):"
+            $COMPOSE images django || true
+
+            # Sync the box tree to the deployed ref so the compose + Caddyfile on
+            # the box match the image. Pulling the image alone never updates
+            # compose/Caddy (#501); reset --hard keeps the box an exact mirror
+            # (the deploy box holds no local edits).
+            git fetch origin
+            git reset --hard "origin/${DEPLOY_REF}"
+
+            # Reclaim disk BEFORE pulling. Superseded images accumulate unbounded
+            # and once filled the box to 99% mid-pull, taking QA down (#521). The
+            # running stack's images are referenced by their containers so they're
+            # kept; only orphaned images go. No --volumes, so Postgres data is safe.
+            docker image prune -af
+
+            # Pull the freshly-built :qa image (and any updated base images), then
+            # recreate. --no-build: the box never builds, it only runs published
+            # images. --remove-orphans cleans up any service renamed/removed since.
+            $COMPOSE pull
+            $COMPOSE up -d --no-build --remove-orphans
+        env:
+          DEPLOY_REF: ${{ inputs.deploy_ref }}
+
+      - name: Verify deploy
+        # Poll /api/health/ until 200 or timeout, so a crash-looping image fails
+        # the workflow loudly instead of Actions reporting a green deploy over a
+        # dead site.
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS https://qa.litigantportal.com/api/health/ > /dev/null; then
+              echo "deploy healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "deploy failed health check"
+          exit 1

--- a/deploy/qa-do/Caddyfile.qa
+++ b/deploy/qa-do/Caddyfile.qa
@@ -1,0 +1,23 @@
+# Caddy config for the DigitalOcean QA box (TEMPORARY — see docker-compose.qa.yml).
+#
+# One hostname serves both the LP app and the docassemble interview, so a court
+# partner needs just one CNAME for the whole portal (see ARCHITECTURE.md → Open
+# Contracts). Caddy auto-provisions HTTPS via Let's Encrypt for {$DOMAIN}.
+
+{$DOMAIN} {
+	# Document-assembly interviews. `handle` (not `handle_path`) keeps the
+	# /interview/ prefix, which docassemble expects because POSTURLROOT mounts it
+	# there. Matched before the catch-all so it wins.
+	handle /interview/* {
+		reverse_proxy docassemble:80
+	}
+
+	# Everything else is the Litigant Portal app.
+	handle {
+		reverse_proxy django:8000
+	}
+
+	log {
+		output stdout
+	}
+}

--- a/deploy/qa-do/README.md
+++ b/deploy/qa-do/README.md
@@ -1,0 +1,42 @@
+# DigitalOcean QA deploy (temporary)
+
+This directory and the `.github/workflows/qa-deploy-do.yml` workflow are a
+**temporary** manual deploy path for the DigitalOcean QA box
+(`qa.litigantportal.com`). It exists only until the AWS `qa-litigant`
+environment is wired up (#587). Until then, DO QA is LP's only live environment.
+
+## Why it exists
+
+The manual DO deploy (`cd.yml`) was removed in #603, and the root
+`docker-compose.yml` was reduced to local-dev only in #460 (prod moved to
+CL/EKS infra). That left no way to deploy current `main` to the QA box. This
+path restores that ability in isolation, without reintroducing prod services
+into the local-dev compose.
+
+## How to deploy
+
+GitHub → Actions → **Deploy to DigitalOcean QA (manual)** → Run workflow →
+pick the ref (default `main`). It builds the image, pushes `:qa` to Docker Hub,
+and rolls it out on the box over SSH, then health-checks `/api/health/`.
+
+## What it touches
+
+- **Secrets:** `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `QA_HOST`, `QA_USER`,
+  `QA_SSH_KEY` (all already in the repo).
+- **Box `.env`** at `/opt/litigant-portal/.env` provides app config
+  (`SECRET_KEY`, `POSTGRES_PASSWORD`, `OPENAI_API_KEY`, `DOMAIN`, `DA_HOSTNAME`,
+  `ALLOWED_HOSTS`, `SITE_PASSWORD`, `CHAT_MODEL`).
+- **Postgres:** a standalone containerized pgvector instance with its own
+  docker-managed volume, seeded by the `web-prod` entrypoint's `migrate` on boot.
+  It is **not** shared with AWS — the box's `POSTGRES_PASSWORD` is its own
+  generated secret, independent of the EKS `litigant-env` secret. QA holds only
+  seed/demo data; reset with `docker compose -f deploy/qa-do/docker-compose.qa.yml down -v`.
+
+## Removal at AWS cutover
+
+```bash
+git rm -r deploy/qa-do .github/workflows/qa-deploy-do.yml
+```
+
+Nothing else references either — no edits to `docker-compose.yml`, `deploy.yml`,
+or `staging-deploy.yml` to unwind.

--- a/deploy/qa-do/docker-compose.qa.yml
+++ b/deploy/qa-do/docker-compose.qa.yml
@@ -1,0 +1,129 @@
+# Litigant Portal — DigitalOcean QA stack (TEMPORARY)
+#
+# Self-contained prod-style stack for the DigitalOcean QA box
+# (qa.litigantportal.com). It exists ONLY until the AWS `qa-litigant` env is
+# wired up (#587) — at cutover, delete this whole `deploy/qa-do/` dir and the
+# `.github/workflows/qa-deploy-do.yml` workflow and nothing else needs unwinding.
+#
+# Why a separate file: the root `docker-compose.yml` is local-dev only (#460
+# dropped the prod profile when LP moved to CL/EKS infra). Rather than
+# reintroduce prod services there, the DO QA path is fully isolated here.
+#
+# Driven by the manual deploy workflow, which on the box runs:
+#   docker compose -f deploy/qa-do/docker-compose.qa.yml \
+#     --env-file /opt/litigant-portal/.env up -d --no-build
+#
+# The box .env must provide: SECRET_KEY, POSTGRES_PASSWORD, OPENAI_API_KEY,
+# DOMAIN (scheme-prefixed, e.g. https://qa.litigantportal.com), DA_HOSTNAME
+# (BARE host, e.g. qa.litigantportal.com), ALLOWED_HOSTS, SITE_PASSWORD,
+# CHAT_MODEL. (Box checks #1/#2 confirmed present — Mitch, 2026-07-13.)
+
+# Pin the project name so it's stable regardless of which dir compose runs from.
+# It MUST match the box's currently-running stack, or `up` spins up a parallel
+# stack and collides on ports 80/443 (taking the only live env down). Confirm on
+# the box: `docker compose ls`.
+name: litigant-portal # FILL IN — confirm matches the running stack
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      - POSTGRES_DB=litigant_portal
+      - POSTGRES_USER=postgres
+      # DO-DEDICATED SECRET: this box's .env must set its OWN generated
+      # POSTGRES_PASSWORD, independent of the AWS `litigant-env` k8s secret. The
+      # DO QA DB is a standalone one-off; it shares no credentials with AWS.
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    volumes:
+      # Fresh DO-local volume — there is no live QA DB to preserve (postgres was
+      # never stood up on this box). Docker creates it on first `up` and keeps it
+      # across deploys (deploys prune images, never volumes). QA holds only
+      # seed/demo data; the web-prod entrypoint runs `migrate` on boot, so a fresh
+      # DB self-populates. To wipe QA back to zero: `docker compose ... down -v`.
+      - qa_postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --save "" --appendonly no
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  django:
+    image: freelawproject/litigant-portal:qa
+    restart: unless-stopped
+    command: web-prod
+    environment:
+      - DEBUG=false
+      - DEPLOYMENT_ENV=qa
+      - SECRET_KEY=${SECRET_KEY}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - REDIS_URL=redis://redis:6379/0
+      - ALLOWED_HOSTS=localhost,${ALLOWED_HOSTS}
+      - GUNICORN_WORKERS=${GUNICORN_WORKERS:-3}
+      - GUNICORN_THREADS=${GUNICORN_THREADS:-2}
+      - SITE_PASSWORD=${SITE_PASSWORD}
+      - CHAT_ENABLED=${CHAT_ENABLED:-true}
+      - CHAT_MODEL=${CHAT_MODEL:-openai/gpt-4o-mini}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/health/']
+      interval: 5s
+      timeout: 3s
+      start_period: 30s
+      retries: 3
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  # docassemble document-assembly interview, served under the LP hostname at
+  # /interview/* (Caddy routes it; see Caddyfile.qa). Internal only — no public
+  # port, TLS terminated by Caddy. ~20 GB image; box needs >=4 GB RAM.
+  docassemble:
+    image: jhpyle/docassemble
+    container_name: docassemble-qa
+    restart: unless-stopped
+    environment:
+      # DA_HOSTNAME is the BARE LP host (e.g. qa.litigantportal.com) — no scheme,
+      # or docassemble builds https://https://… URLs. Caddy terminates TLS;
+      # docassemble serves plain HTTP and trusts the proxy.
+      DAHOSTNAME: ${DA_HOSTNAME}
+      POSTURLROOT: '/interview/'
+      USEHTTPS: 'false'
+      BEHINDHTTPSLOADBALANCER: 'true'
+      TIMEZONE: 'America/New_York'
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      - DOMAIN=${DOMAIN}
+    volumes:
+      - ./Caddyfile.qa:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      django:
+        condition: service_healthy
+
+volumes:
+  # Fresh, docker-managed volume for the standalone DO QA database. Not external
+  # (nothing to attach — postgres was never live here). Survives deploys.
+  qa_postgres_data:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Restores a manual deploy path to the DigitalOcean QA box, which is LP's only live environment until AWS `qa-litigant` is wired up (#587). #603 removed the old `cd.yml` deploy workflow and #460 stripped the prod profile from `docker-compose.yml`, leaving no way to deploy current `main` to the box.

Adds an isolated, manual (`workflow_dispatch`) path under `deploy/qa-do/` plus one workflow file:

- **`.github/workflows/qa-deploy-do.yml`** — build the image from a chosen ref, push `:qa` to Docker Hub, roll out on the box over SSH (preserving the #501 tree-sync / #521 disk-prune hardening from the old script), then health-check `/api/health/`.
- **`deploy/qa-do/docker-compose.qa.yml`** — self-contained prod stack (django `web-prod`, standalone pgvector postgres with its own `.env` secret + fresh volume, redis, caddy, docassemble).
- **`deploy/qa-do/Caddyfile.qa`** — one hostname, `/interview/*` → docassemble, everything else → django, auto-TLS.
- **`deploy/qa-do/README.md`** — what it is + one-command removal at cutover.

Postgres is a standalone container, isolated from AWS: its `POSTGRES_PASSWORD` lives in the DO box `.env`, not the EKS `litigant-env` secret. The `web-prod` entrypoint runs `migrate` on boot, so the fresh DB self-populates (QA is seed/demo data only).

**Removable at AWS cutover** with no unwinding: `git rm -r deploy/qa-do .github/workflows/qa-deploy-do.yml` — no edits to `docker-compose.yml`, `deploy.yml`, or `staging-deploy.yml`.

**Ordering caveat:** `workflow_dispatch` only becomes available once the workflow file is on the default branch, so the "Run workflow" button appears **after this merges**. First deploy is a supervised, post-merge dispatch against `main` (docassemble already up on the box; `.env` in place incl. `POSTGRES_PASSWORD`).

Closes #649

## Test plan

- [ ] Merge, confirm "Deploy to DigitalOcean QA (manual)" appears under Actions
- [ ] Supervised first dispatch (ref `main`); confirm build → Docker Hub `:qa` push → SSH rollout → `/api/health/` returns 200
- [ ] `qa.litigantportal.com` serves current content; `/interview/` (docassemble) reachable
- [ ] Re-dispatch is idempotent (image prune runs, no disk/port issues, DB volume persists)