### PR TITLE
fix(deploy): run DO QA on filesystem storage without S3

### DIFF
--- a/deploy/qa-do/Caddyfile.qa
+++ b/deploy/qa-do/Caddyfile.qa
@@ -12,6 +12,15 @@
 		reverse_proxy docassemble:80
 	}
 
+	# Static assets. Django doesn't serve these under DEBUG=false (no whitenoise,
+	# no S3 on this box), so Caddy serves the collectstatic output from the shared
+	# qa_static volume. handle_path strips /static/ so the file path resolves
+	# under the root.
+	handle_path /static/* {
+		root * /srv/static
+		file_server
+	}
+
 	# Everything else is the Litigant Portal app.
 	handle {
 		reverse_proxy django:8000

--- a/deploy/qa-do/docker-compose.qa.yml
+++ b/deploy/qa-do/docker-compose.qa.yml
@@ -64,6 +64,11 @@ services:
     command: web-prod
     environment:
       - DEBUG=false
+      # Self-contained: no S3 on this box. Storage falls back to the local
+      # filesystem; static is collected to the shared qa_static volume and
+      # served by Caddy (see Caddyfile.qa). Django doesn't serve static under
+      # DEBUG=false and there's no whitenoise, so Caddy owns /static/.
+      - USE_S3=false
       - DEPLOYMENT_ENV=qa
       - SECRET_KEY=${SECRET_KEY}
       - POSTGRES_HOST=postgres
@@ -82,6 +87,10 @@ services:
       timeout: 3s
       start_period: 30s
       retries: 3
+    volumes:
+      # collectstatic (run by the web-prod entrypoint) writes here; Caddy mounts
+      # the same volume read-only and serves it at /static/.
+      - qa_static:/app/litigant_portal/app/staticfiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -115,6 +124,7 @@ services:
       - DOMAIN=${DOMAIN}
     volumes:
       - ./Caddyfile.qa:/etc/caddy/Caddyfile:ro
+      - qa_static:/srv/static:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
@@ -125,5 +135,8 @@ volumes:
   # Fresh, docker-managed volume for the standalone DO QA database. Not external
   # (nothing to attach — postgres was never live here). Survives deploys.
   qa_postgres_data:
+  # Collected static, shared django (writer) → caddy (reader). Refreshed each
+  # deploy by collectstatic --clear.
+  qa_static:
   caddy_data:
   caddy_config:

--- a/litigant_portal/app/tests/test_settings_storage.py
+++ b/litigant_portal/app/tests/test_settings_storage.py
@@ -1,0 +1,65 @@
+"""Storage backend selection is gated by USE_S3, not DEBUG directly.
+
+A non-debug deploy without S3 credentials (the self-contained DigitalOcean QA
+box) must be able to run on local filesystem storage. These tests pin that
+contract and the back-compatible default (S3 whenever DEBUG is off, filesystem
+otherwise) by reloading the settings module under a controlled environment.
+"""
+
+import importlib
+import os
+from unittest import mock
+
+FILESYSTEM = "django.core.files.storage.FileSystemStorage"
+S3 = "storages.backends.s3.S3Storage"
+
+
+def _storage_backends(env: dict[str, str]) -> dict:
+    """Reload settings with exactly ``env`` set and return the resolved
+    USE_S3 flag and the `default`/`public` storage backends. Restores the
+    module to the ambient environment afterward so other tests are unaffected.
+    """
+    import litigant_portal.settings as settings_module
+
+    with mock.patch.dict(os.environ, env, clear=True):
+        importlib.reload(settings_module)
+        result = {
+            "use_s3": settings_module.USE_S3,
+            "default": settings_module.STORAGES["default"]["BACKEND"],
+            "public": settings_module.STORAGES["public"]["BACKEND"],
+        }
+    # Reload once more under the real environment to undo the patched reload.
+    importlib.reload(settings_module)
+    return result
+
+
+def test_use_s3_false_forces_filesystem_even_when_not_debug():
+    """The DO QA case: DEBUG off but USE_S3=false → filesystem, no S3."""
+    result = _storage_backends({"DEBUG": "false", "USE_S3": "false"})
+    assert result["use_s3"] is False
+    assert result["default"] == FILESYSTEM
+    assert result["public"] == FILESYSTEM
+
+
+def test_default_is_s3_when_not_debug_and_flag_unset():
+    """AWS/EKS behavior preserved: DEBUG off, USE_S3 unset → S3."""
+    result = _storage_backends({"DEBUG": "false"})
+    assert result["use_s3"] is True
+    assert result["default"] == S3
+    assert result["public"] == S3
+
+
+def test_default_is_filesystem_when_debug_and_flag_unset():
+    """Dev behavior preserved: DEBUG on, USE_S3 unset → filesystem."""
+    result = _storage_backends({"DEBUG": "true"})
+    assert result["use_s3"] is False
+    assert result["default"] == FILESYSTEM
+    assert result["public"] == FILESYSTEM
+
+
+def test_use_s3_true_forces_s3_even_when_debug():
+    """Explicit opt-in overrides the DEBUG-derived default."""
+    result = _storage_backends({"DEBUG": "true", "USE_S3": "true"})
+    assert result["use_s3"] is True
+    assert result["default"] == S3
+    assert result["public"] == S3

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -164,7 +164,13 @@ STATICFILES_DIRS = [
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 MEDIA_ROOT = BASE_DIR / "app" / "media"
 
-# Storage — local filesystem in dev/test, S3 in prod/QA.
+# Storage — local filesystem in dev/test, S3 in prod/QA. Gated by USE_S3 rather
+# than DEBUG directly, so a non-debug deploy can still run on local storage when
+# it has no S3 creds (the self-contained DigitalOcean QA box). Default preserves
+# the prior behavior: S3 whenever DEBUG is off, filesystem otherwise.
+USE_S3 = (
+    os.environ.get("USE_S3", "false" if DEBUG else "true").lower() == "true"
+)
 S3_CONNECTION = {
     "access_key": os.environ.get("AWS_ACCESS_KEY_ID", ""),
     "secret_key": os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
@@ -183,7 +189,7 @@ AWS_S3_PUBLIC_CUSTOM_DOMAIN = (
     None  # os.environ.get("AWS_S3_CUSTOM_DOMAIN") or None
 )
 
-if DEBUG:
+if not USE_S3:
     STORAGES = {
         "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
         "public": {"BACKEND": "django.core.files.storage.FileSystemStorage"},


### PR DESCRIPTION
The first DO QA deploy (#650) failed: django came up unhealthy because `/api/health/` probes both S3 storage backends, which `DEBUG=False` forced on — but the box has no S3 creds. The unhealthy container blocked caddy and aborted the deploy.

Decouples the storage backend from `DEBUG` via a `USE_S3` flag (default unchanged: S3 when not DEBUG, filesystem in dev), so the self-contained DO QA box runs `USE_S3=false` on local filesystem storage — no S3 dependency. Since Django doesn't serve static under `DEBUG=False` (no whitenoise), collectstatic writes to a shared `qa_static` volume that Caddy serves at `/static/`, keeping the box self-contained and styled.

Closes #651
Follow-up to #649 / #650.

## Test plan

- [x] Unit tests pin storage selection: `USE_S3=false` + `DEBUG=False` → filesystem; unset defaults preserved (S3 when not DEBUG, filesystem in dev); explicit `USE_S3=true` → S3 (a revert to the old `if DEBUG:` gate fails the first test)
- [ ] `make lint` / `make test` green
- [ ] Merge → re-dispatch "Deploy to DigitalOcean QA (manual)" (ref `main`) → build → SSH rollout → `/api/health/` returns 200 (storage checks pass on filesystem)
- [ ] `qa.litigantportal.com` serves **styled** pages (Caddy serving `/static/`); `/interview/` reachable