### PR TITLE
fix(deploy): bind-mount box dir for DO QA static, not a named volume

### DIFF
--- a/deploy/qa-do/Caddyfile.qa
+++ b/deploy/qa-do/Caddyfile.qa
@@ -13,9 +13,9 @@
 	}
 
 	# Static assets. Django doesn't serve these under DEBUG=false (no whitenoise,
-	# no S3 on this box), so Caddy serves the collectstatic output from the shared
-	# qa_static volume. handle_path strips /static/ so the file path resolves
-	# under the root.
+	# no S3 on this box), so Caddy serves the collectstatic output from the box
+	# bind mount at /opt/litigant-portal/qa-static. handle_path strips /static/ so
+	# the file path resolves under the root.
 	handle_path /static/* {
 		root * /srv/static
 		file_server

--- a/deploy/qa-do/README.md
+++ b/deploy/qa-do/README.md
@@ -44,7 +44,7 @@ uid before the first deploy:
 
 ```bash
 # 1. Find appuser's uid in the image (expected: 1000)
-docker run --rm --entrypoint id freelawproject/litigant-portal:qa
+docker run --rm --entrypoint id freelawproject/litigant-portal:qa -u
 
 # 2. Create the dir and chown it to that uid (substitute if not 1000)
 mkdir -p /opt/litigant-portal/qa-static

--- a/deploy/qa-do/README.md
+++ b/deploy/qa-do/README.md
@@ -31,6 +31,30 @@ and rolls it out on the box over SSH, then health-checks `/api/health/`.
   It is **not** shared with AWS — the box's `POSTGRES_PASSWORD` is its own
   generated secret, independent of the EKS `litigant-env` secret. QA holds only
   seed/demo data; reset with `docker compose -f deploy/qa-do/docker-compose.qa.yml down -v`.
+- **Static files:** bind-mounted from `/opt/litigant-portal/qa-static` on the
+  box. Django (`web-prod` entrypoint) runs `collectstatic` into it; Caddy serves
+  it read-only at `/static/`. A Docker named volume can't be used here — it inits
+  root-owned and the container runs as non-root `appuser`, so `collectstatic`
+  would fail. See one-time setup below.
+
+## One-time box setup (static directory)
+
+The static bind-mount dir must exist and be owned by the container's `appuser`
+uid before the first deploy:
+
+```bash
+# 1. Find appuser's uid in the image (expected: 1000)
+docker run --rm --entrypoint id freelawproject/litigant-portal:qa
+
+# 2. Create the dir and chown it to that uid (substitute if not 1000)
+mkdir -p /opt/litigant-portal/qa-static
+sudo chown -R 1000:1000 /opt/litigant-portal/qa-static
+```
+
+`collectstatic --clear` refreshes the _contents_ each deploy but leaves the
+dir's ownership intact, so this chown is one-time. (The old root-owned
+`litigant-portal_qa_static` named volume from earlier attempts can be removed:
+`docker volume rm litigant-portal_qa_static`.)
 
 ## Removal at AWS cutover
 

--- a/deploy/qa-do/docker-compose.qa.yml
+++ b/deploy/qa-do/docker-compose.qa.yml
@@ -65,8 +65,8 @@ services:
     environment:
       - DEBUG=false
       # Self-contained: no S3 on this box. Storage falls back to the local
-      # filesystem; static is collected to the shared qa_static volume and
-      # served by Caddy (see Caddyfile.qa). Django doesn't serve static under
+      # filesystem; static is collected to a box bind-mount (see volumes below)
+      # and served by Caddy (see Caddyfile.qa). Django doesn't serve static under
       # DEBUG=false and there's no whitenoise, so Caddy owns /static/.
       - USE_S3=false
       - DEPLOYMENT_ENV=qa
@@ -89,8 +89,12 @@ services:
       retries: 3
     volumes:
       # collectstatic (run by the web-prod entrypoint) writes here; Caddy mounts
-      # the same volume read-only and serves it at /static/.
-      - qa_static:/app/litigant_portal/app/staticfiles
+      # the same directory read-only and serves it at /static/. This is a bind
+      # mount to a box-owned dir (NOT a Docker named volume): named volumes init
+      # root-owned and the container runs as non-root appuser, so collectstatic
+      # can't write. The box dir must be chowned to the appuser uid — see
+      # deploy/qa-do/README.md for the one-time setup.
+      - /opt/litigant-portal/qa-static:/app/litigant_portal/app/staticfiles
     depends_on:
       postgres:
         condition: service_healthy
@@ -124,7 +128,7 @@ services:
       - DOMAIN=${DOMAIN}
     volumes:
       - ./Caddyfile.qa:/etc/caddy/Caddyfile:ro
-      - qa_static:/srv/static:ro
+      - /opt/litigant-portal/qa-static:/srv/static:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
@@ -135,8 +139,5 @@ volumes:
   # Fresh, docker-managed volume for the standalone DO QA database. Not external
   # (nothing to attach — postgres was never live here). Survives deploys.
   qa_postgres_data:
-  # Collected static, shared django (writer) → caddy (reader). Refreshed each
-  # deploy by collectstatic --clear.
-  qa_static:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
The second DO QA deploy crash-looped: `collectstatic` hit `PermissionError` writing to the `qa_static` Docker named volume. Named volumes init **root-owned**, but the container runs as non-root `appuser`, so the write failed and `set -e` killed the boot.

Swaps the named volume for a **bind-mount** to a box-owned directory (`/opt/litigant-portal/qa-static`) that's chowned to the `appuser` uid. No root, no new deps, nothing outside the isolated `deploy/qa-do/` layer touched. django's `collectstatic` writes there; Caddy serves it read-only at `/static/`. README documents the one-time dir + chown.

Closes #653
Follow-up to #651 / #652.

## Test plan

- [x] One-time box setup: `/opt/litigant-portal/qa-static` created and chowned to the `appuser` uid (`docker run --rm --entrypoint id …:qa` → expected 1000)
- [ ] `make lint` / `make test` green
- [ ] Merge → re-dispatch "Deploy to DigitalOcean QA (manual)" (ref `main`) → `collectstatic` succeeds → django healthy → `/api/health/` 200
- [ ] `qa.litigantportal.com` serves **styled** pages (Caddy `/static/` from the bind-mount); `/interview/` reachable