### PR TITLE
Bootstrap superuser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Django allowed hosts — must include app domain (comma-separated, no spaces)
 # ALLOWED_HOSTS=yourdomain.com
 
-# Bootstrap superuser — created (or promoted) at startup when both are set
+# Bootstrap superuser — created at startup when both are set
 # SUPERUSER_EMAIL=admin@yourdomain.com
 # SUPERUSER_PASSWORD=generate-a-strong-password
 

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Django allowed hosts — must include app domain (comma-separated, no spaces)
 # ALLOWED_HOSTS=yourdomain.com
 
+# Bootstrap superuser — created (or promoted) at startup when both are set
+# SUPERUSER_EMAIL=admin@yourdomain.com
+# SUPERUSER_PASSWORD=generate-a-strong-password
+
 # Chat model (LiteLLM format)
 # CHAT_MODEL=openai/gpt-4o-mini
 

--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -9,6 +9,11 @@ run_migrations() {
     manage migrate --noinput
 }
 
+run_bootstrap_superuser() {
+    echo "Bootstrapping superuser ..."
+    manage bootstrap_superuser
+}
+
 run_collectstatic() {
     echo "Collecting static files ..."
     manage collectstatic --noinput --clear
@@ -45,6 +50,7 @@ case "$1" in
         run_compilemessages
         run_collectstatic
         run_migrations
+        run_bootstrap_superuser
         run_dev_server
         ;;
 
@@ -53,6 +59,7 @@ case "$1" in
         run_compilemessages
         run_collectstatic
         run_migrations
+        run_bootstrap_superuser
         run_prod_server
         ;;
 

--- a/litigant_portal/app/management/commands/bootstrap_superuser.py
+++ b/litigant_portal/app/management/commands/bootstrap_superuser.py
@@ -31,25 +31,24 @@ class Command(BaseCommand):
                     email=email,
                     password=password,
                 )
+                EmailAddress.objects.get_or_create(
+                    user=user,
+                    email=user.email,
+                    defaults={"verified": True, "primary": True},
+                )
                 self.stdout.write(
                     self.style.SUCCESS(f"Created superuser {email}.")
                 )
-            elif user.is_staff and user.is_superuser:
+            elif user.is_superuser:
                 self.stdout.write(
                     f"Superuser {email} already exists; nothing to do."
                 )
             else:
-                user.is_staff = True
-                user.is_superuser = True
-                user.save(update_fields=["is_staff", "is_superuser"])
                 self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Promoted existing user {email} to superuser."
+                    self.style.WARNING(
+                        f"User {email} already exists but is not a "
+                        "superuser; refusing to promote a pre-existing "
+                        "account. Remove or rename that account, or "
+                        "promote it manually."
                     )
                 )
-
-            EmailAddress.objects.get_or_create(
-                user=user,
-                email=user.email,
-                defaults={"verified": True, "primary": True},
-            )

--- a/litigant_portal/app/management/commands/bootstrap_superuser.py
+++ b/litigant_portal/app/management/commands/bootstrap_superuser.py
@@ -1,0 +1,55 @@
+import os
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+
+class Command(BaseCommand):
+    help = "Create or promote a superuser from SUPERUSER_EMAIL / SUPERUSER_PASSWORD"
+
+    def handle(self, *args, **options):
+        email = os.environ.get("SUPERUSER_EMAIL", "").strip()
+        password = os.environ.get("SUPERUSER_PASSWORD", "")
+
+        if not email or not password:
+            self.stdout.write(
+                "SUPERUSER_EMAIL / SUPERUSER_PASSWORD not set; skipping "
+                "superuser bootstrap."
+            )
+            return
+
+        User = get_user_model()
+
+        with transaction.atomic():
+            user = User.objects.filter(email__iexact=email).first()
+
+            if user is None:
+                user = User.objects.create_superuser(
+                    username=email,
+                    email=email,
+                    password=password,
+                )
+                self.stdout.write(
+                    self.style.SUCCESS(f"Created superuser {email}.")
+                )
+            elif user.is_staff and user.is_superuser:
+                self.stdout.write(
+                    f"Superuser {email} already exists; nothing to do."
+                )
+            else:
+                user.is_staff = True
+                user.is_superuser = True
+                user.save(update_fields=["is_staff", "is_superuser"])
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Promoted existing user {email} to superuser."
+                    )
+                )
+
+            EmailAddress.objects.get_or_create(
+                user=user,
+                email=user.email,
+                defaults={"verified": True, "primary": True},
+            )

--- a/litigant_portal/app/tests/test_bootstrap_superuser.py
+++ b/litigant_portal/app/tests/test_bootstrap_superuser.py
@@ -1,0 +1,77 @@
+"""Tests for the bootstrap_superuser management command."""
+
+from io import StringIO
+from unittest import mock
+
+import pytest
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+User = get_user_model()
+
+EMAIL = "admin@example.com"
+PASSWORD = "test-bootstrap-password"
+
+
+def _run(**env):
+    out = StringIO()
+    with mock.patch.dict("os.environ", env, clear=False):
+        call_command("bootstrap_superuser", stdout=out)
+    return out.getvalue()
+
+
+@pytest.mark.postgres
+class BootstrapSuperuserTests(TestCase):
+    def test_skips_when_env_unset(self):
+        output = _run(SUPERUSER_EMAIL="", SUPERUSER_PASSWORD="")
+        self.assertIn("skipping", output)
+        self.assertEqual(User.objects.count(), 0)
+
+    def test_skips_when_only_email_set(self):
+        output = _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD="")
+        self.assertIn("skipping", output)
+        self.assertEqual(User.objects.count(), 0)
+
+    def test_creates_superuser_with_verified_email(self):
+        output = _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
+        self.assertIn("Created superuser", output)
+
+        user = User.objects.get(email=EMAIL)
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.check_password(PASSWORD))
+
+        address = EmailAddress.objects.get(user=user, email=EMAIL)
+        self.assertTrue(address.verified)
+        self.assertTrue(address.primary)
+
+    def test_promotes_existing_user_without_touching_password(self):
+        user = User.objects.create_user(
+            username=EMAIL, email=EMAIL, password="original-password"
+        )
+        output = _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
+        self.assertIn("Promoted existing user", output)
+
+        user.refresh_from_db()
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.check_password("original-password"))
+
+    def test_rerun_is_a_noop(self):
+        _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
+        output = _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
+        self.assertIn("nothing to do", output)
+        self.assertEqual(User.objects.filter(email=EMAIL).count(), 1)
+        self.assertEqual(EmailAddress.objects.filter(email=EMAIL).count(), 1)
+
+    def test_email_lookup_is_case_insensitive(self):
+        User.objects.create_user(
+            username=EMAIL, email=EMAIL, password="original-password"
+        )
+        output = _run(
+            SUPERUSER_EMAIL=EMAIL.upper(), SUPERUSER_PASSWORD=PASSWORD
+        )
+        self.assertIn("Promoted existing user", output)
+        self.assertEqual(User.objects.count(), 1)

--- a/litigant_portal/app/tests/test_bootstrap_superuser.py
+++ b/litigant_portal/app/tests/test_bootstrap_superuser.py
@@ -47,17 +47,19 @@ class BootstrapSuperuserTests(TestCase):
         self.assertTrue(address.verified)
         self.assertTrue(address.primary)
 
-    def test_promotes_existing_user_without_touching_password(self):
+    def test_refuses_to_promote_existing_user(self):
         user = User.objects.create_user(
             username=EMAIL, email=EMAIL, password="original-password"
         )
         output = _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
-        self.assertIn("Promoted existing user", output)
+        self.assertIn("refusing to promote", output)
 
         user.refresh_from_db()
-        self.assertTrue(user.is_staff)
-        self.assertTrue(user.is_superuser)
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
         self.assertTrue(user.check_password("original-password"))
+        # And never mark a pre-registered account's email as verified.
+        self.assertFalse(EmailAddress.objects.filter(user=user).exists())
 
     def test_rerun_is_a_noop(self):
         _run(SUPERUSER_EMAIL=EMAIL, SUPERUSER_PASSWORD=PASSWORD)
@@ -73,5 +75,5 @@ class BootstrapSuperuserTests(TestCase):
         output = _run(
             SUPERUSER_EMAIL=EMAIL.upper(), SUPERUSER_PASSWORD=PASSWORD
         )
-        self.assertIn("Promoted existing user", output)
+        self.assertIn("refusing to promote", output)
         self.assertEqual(User.objects.count(), 1)


### PR DESCRIPTION
Adds a management command to bootstrap a superuser account from env vars. The command is wired into the entrypoint and will create a superuser account when SUPERUSER_EMAIL and SUPERUSER_PASSWORD are set (but does not elevate the superuser status if the account exists). This will let us create a shared initial account that can be used to grant admin access to other accounts.

To actually create the shared account we should complete #663