### PR TITLE
fix(qa-deploy): raise django healthcheck start_period to 90s

### DIFF
--- a/deploy/qa-do/docker-compose.qa.yml
+++ b/deploy/qa-do/docker-compose.qa.yml
@@ -85,7 +85,10 @@ services:
       test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/health/']
       interval: 5s
       timeout: 3s
-      start_period: 30s
+      # Cold boot runs compilemessages + collectstatic --clear + migrate before
+      # gunicorn serves /api/health/ (~50s on this box). 30s tripped the
+      # depends_on health gate mid-boot and false-failed the deploy (#665).
+      start_period: 90s
       retries: 3
     volumes:
       # collectstatic (run by the web-prod entrypoint) writes here; Caddy mounts


### PR DESCRIPTION
Cold boot on the DO QA box (compilemessages + collectstatic --clear + migrate + gunicorn) runs ~50s. The 30s `start_period` + retries tripped the `depends_on: django → service_healthy` gate mid-boot at ~45s, so `docker compose up` exited 1 and the manual QA deploy false-failed over an app that was actually healthy (went green seconds later). First surfaced deploying #662.

Closes #665

## Test plan

- Re-dispatch **Deploy to DigitalOcean QA (manual)** against `main` after merge; it should complete green now that the health gate tolerates the cold boot.
- QA continues serving current main (verified live: qa.litigantportal.com is up on #662).