### PR TITLE
Discovery: Topic Flow links + least-possible prompt on v2 chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Pre-commit runs automatically on commit. Key hooks:
 
 Run all hooks manually: `pre-commit run --all-files`
 
-**Note:** djlint runs in **lint-only mode** (no auto-formatter). Its formatter was mangling template tags inside HTML attributes — expanding single-line `{% block %}` tags to multi-line and injecting whitespace into rendered attributes. See "Template Formatting" below for the manual conventions that replace the formatter.
+**Note:** djlint runs in **lint-only mode** (no auto-formatter). Its formatter was mangling template tags inside HTML attributes — the manual conventions that replace it live in the global `django-templates` skill (see Template Formatting below).
 
 ### Before Committing
 
@@ -80,146 +80,9 @@ make pre-commit   # lint → test, short-circuits if lint fails/fixes anything
 
 Equivalent to `make lint && make test`. If lint auto-fixes files, the target stops before tests — re-stage the changes and re-run. The name mirrors the `pre-commit` hook tool intentionally — same concept, different invocation surface.
 
-### Template Formatting (Manual Conventions)
+### Template Formatting
 
-No auto-formatter for `.html` templates — djlint runs lint-only. Follow these Prettier-inspired conventions (Prettier is the source of truth — a Cotton plugin is planned). Cotton components (`<c-atoms.button>`, `<c-organisms.header>`) are valid HTML5 custom elements and follow the same rules as any HTML tag.
-
-**1. Indentation: 2 spaces.** For HTML elements, Cotton components, and template tags alike.
-
-**2. Attribute wrapping: single vs multi-line.**
-
-If all attributes fit on one line within ~120 chars, keep them inline:
-
-```html
-<div class="flex items-center gap-2">
-  <c-atoms.icon name="check" class="w-4 h-4" />
-  <c-atoms.button
-    type="button"
-    variant="primary"
-    x-on:click="save"
-  ></c-atoms.button>
-</div>
-```
-
-If they don't fit, one attribute per line. Closing `>` or `/>` goes on its own line (Prettier default, `bracketSameLine: false`):
-
-```html
-<input
-  type="text"
-  x-bind:value="inputText"
-  x-on:input="updateInput"
-  name="q"
-  placeholder="{% trans 'Ask a question' %}"
-  class="chat-input"
-  aria-label="{% trans 'Ask a question' %}"
-/>
-```
-
-For Cotton components, same rule — first attribute on the tag line, rest aligned:
-
-```html
-<c-molecules.form-field
-  label="Email"
-  type="email"
-  name="email"
-  required
-  value="{{ form.email.value|default:'' }}"
-/>
-```
-
-**3. Template tags inside HTML attributes MUST stay on one line.**
-
-This is the critical rule. Django template tags (`{% block %}`, `{% if %}`, `{{ var }}`) inside an attribute value must remain on the same line as the attribute. Multi-line = literal whitespace in the rendered HTML.
-
-```html
-<!-- GOOD -->
-<body
-  class="{% block body_class %}min-h-dvh flex flex-col bg-greyscale-25{% endblock body_class %}"
->
-  <main class="flex-1 {% block main_class %}{% endblock main_class %}">
-    <meta
-      name="description"
-      content="{% block meta_description %}{% trans 'Default' %}{% endblock meta_description %}"
-    />
-
-    <!-- BAD: whitespace injected into rendered class attribute -->
-    <body
-      class="{% block body_class %}
-    min-h-dvh flex flex-col bg-greyscale-25{% endblock body_class %}
-    "
-    ></body>
-  </main>
-</body>
-```
-
-These lines will be long. That's OK — attribute values are not breakable.
-
-**4. Block-level template tags get their own lines.**
-
-Outside of attributes, `{% block %}`, `{% if %}`, `{% for %}` etc. get their own lines and indent their children:
-
-```html
-{% block content %}
-<div class="container">
-  <h1>Title</h1>
-</div>
-{% endblock content %} {% if user.is_authenticated %}
-<p>Welcome</p>
-{% else %}
-<p>Please sign in</p>
-{% endif %}
-```
-
-**5. Self-closing tags.**
-
-Prettier adds `/>` to void HTML elements and self-closing components alike. Follow Prettier:
-
-```html
-<!-- Void HTML elements -->
-<meta charset="UTF-8" />
-<input type="text" name="q" />
-<img src="logo.svg" alt="Logo" class="h-12" />
-
-<!-- Cotton self-closing -->
-<c-atoms.icon name="check" class="w-4 h-4" />
-<c-atoms.typing-indicator />
-<c-organisms.header />
-```
-
-**6. Quotes: double quotes** for all HTML attributes. Single quotes only inside attribute values for Django template tags: `value="{{ form.email.value|default:'' }}"`.
-
-**`{% trans %}` in Cotton props:** Never put `{% trans %}` directly in a prop attribute — the single quotes needed to avoid closing the HTML attribute violate djlint T002. Extract to a variable first:
-
-```html
-{% trans "Check your email" as status_heading %}
-<c-molecules.auth-status
-  heading="{{ status_heading }}"
-></c-molecules.auth-status>
-```
-
-**7. Blank lines.** One blank line between logical sections. Never multiple consecutive blank lines. No blank line immediately after an opening tag or before a closing tag:
-
-```html
-<!-- GOOD -->
-<div class="container">
-  <h1>Title</h1>
-  <p>Content</p>
-</div>
-
-<!-- BAD: blank line after opening tag -->
-<div class="container">
-  <h1>Title</h1>
-</div>
-```
-
-**8. Short inline elements stay on one line** when they fit:
-
-```html
-<p class="text-sm text-greyscale-500">{% trans "No activity yet" %}</p>
-<span class="font-semibold">{% trans "Activity" %}</span>
-```
-
-**9. Long `class` values.** Tailwind classes stay on one line inside the `class` attribute even when long — don't break a class string across lines. If the element also has many other attributes, the `class` attribute gets its own line in the multi-line format (rule 2), but the value itself stays unbroken.
+No auto-formatter for `.html` templates — djlint runs lint-only. **Load the global `django-templates` skill before writing or editing any template**; it holds the full Prettier-inspired conventions (attribute wrapping, template-tags-stay-on-one-line, self-closing, quotes, blank lines). A custom Prettier/Cotton plugin is a WIP to replace the manual rules — LP is its home.
 
 ## Content style (user-facing copy)
 
@@ -308,15 +171,7 @@ Every page follows the same frame: **site header → sub-header (contextual) →
 - **Mobile-first and responsive**, but layout stability for WCAG always wins over visual flair. Buttons, links, and navigation stay in predictable locations across all views and states.
 - **Inputs flow with content** — don't pin chat inputs to the viewport bottom. Follow conversation UX: the input lives at the end of the message flow.
 
-**Patterns from the CSP migration:**
-
-- **Pre-compute in JS, bind in templates** — ternaries (`role === 'user' ? 'chat-bubble-user' : 'chat-bubble-assistant'`) become getter properties (`msg.bubbleClass`). Templates only reference the result.
-- **CSS over Alpine for animation** — `@keyframes` + `x-on:animationend` replaces `x-transition` + `setTimeout`. Native `<details>` + `grid-rows-[0fr]/[1fr]` replaces `x-collapse`.
-- **Flat getters for nested data** — optional chaining (`caseInfo?.court_info?.phone`) can't appear in templates. Create flat getters (`get courtPhone()`) that encapsulate the traversal.
-- **`x-effect` → method calls** — side effects on state change (like loading data when a menu opens) go in the method that triggers the change (`openMenu()` loads timeline), not in `x-effect`.
-- **No `!` negation in templates** — `x-show="!isOpen"` fails in CSP build. Create negated getters (`get isClosed()`) instead.
-- **No `x-model`** — CSP build can't evaluate the setter (`expr = __placeholder`). Use `x-bind:value="prop"` + `x-on:input="updateMethod"` instead, where the method reads `e.target.value`.
-- **Spread flattens getters** — `{ ...createChat() }` invokes getters and copies static values. If a composed component needs reactive getters from a base, re-define them after the spread.
+**Patterns from the CSP migration** — promoted to the org level; see `~/flp/CLAUDE.md` Alpine section (pre-compute getters, CSS-over-Alpine animation, flat getters, no `!`/`x-model`, spread-flattens-getters).
 
 ### Component System (Django Cotton + Atomic Design)
 
@@ -333,14 +188,7 @@ litigant_portal/app/templates/cotton/
 
 Style guide available at `/style-guide/` during development.
 
-**NEVER** create custom CSS classes or raw HTML that duplicates what an existing atom/molecule already does. **ALWAYS** check existing components before writing any UI element:
-
-1. Check `litigant_portal/app/templates/cotton/` for an existing component at the right atomic level
-2. Check component props — variants, sizes, `href`, `full_width`, `class` passthrough — before assuming a component can't do what you need
-3. If a component is _almost_ right, **extend it** with a new prop rather than bypassing it with custom CSS
-4. Check Tailwind theme tokens in `litigant_portal/app/src/main.css` before inventing new values
-
-Only create a new component when no combination of existing ones works. Only add new theme tokens when the design system genuinely needs them.
+Component & style discipline follows the org rule (`~/flp/CLAUDE.md`): compose from existing components first, extend with a prop when almost-right, new components/tokens only when nothing combines. LP paths: components in `litigant_portal/app/templates/cotton/`, theme tokens in `litigant_portal/app/src/main.css`. Check props (variants, sizes, `href`, `full_width`, `class` passthrough) before assuming a component can't do it.
 
 **Atomic design check (both directions):** After any template or component change:
 
@@ -369,17 +217,7 @@ Build: `tailwindcss -i litigant_portal/app/src/main.css -o litigant_portal/app/s
 
 ### CSP Compliance (Content Security Policy)
 
-**No inline event handlers.** Use Alpine.js directives instead:
-
-```html
-<!-- BAD: Violates CSP -->
-<button onclick="doSomething()">
-  <!-- GOOD: CSP-compliant -->
-  <button x-on:click="doSomething"></button>
-</button>
-```
-
-Pre-commit hook enforces this (`csp-inline-check`).
+No inline event handlers (org CSP mandate) — use Alpine directives (`x-on:click="doSomething"`, never `onclick=`). Enforced by the `csp-inline-check` pre-commit hook.
 
 ### Alpine.js (CSP Build - Local)
 

--- a/litigant_portal/agents_v2/assistant.py
+++ b/litigant_portal/agents_v2/assistant.py
@@ -1,3 +1,5 @@
+from litigant_portal.app.topic_flow.registry import registry
+
 from .base import Agent
 from .tools.query_document import QueryDocument
 
@@ -12,6 +14,27 @@ files appear directly in the conversation. A note reading [Attached file \
 tool with its upload_id to read or query it. Never guess at the contents \
 of a file you haven't seen."""
 
+# Discovery #670: the least prompt possible to make the assistant aware the
+# hard Topic Flow links exist. Iterate the wording here as chatting teaches us.
+FLOW_PROMPT = """
+
+The portal also offers guided step-by-step flows for specific situations. \
+They are linked in the sidebar under "Guided steps":
+{inventory}
+
+When the user's situation matches one of these, point them to the matching \
+sidebar link. The flows work without chat and let people move at their own \
+pace."""
+
+
+def flow_prompt_section() -> str:
+    """Inventory of authored Topic Flow tracks, or empty when none exist."""
+    tracks = registry.all_tracks()
+    if not tracks:
+        return ""
+    inventory = "\n".join(f"- {track['title']}" for track in tracks)
+    return FLOW_PROMPT.format(inventory=inventory)
+
 
 class LitigantAssistant(Agent):
     """The user-facing assistant for self-represented litigants."""
@@ -19,4 +42,4 @@ class LitigantAssistant(Agent):
     tools = [QueryDocument]
 
     def generate_system_prompt(self, *, thread_id) -> str:
-        return BASE_PROMPT
+        return BASE_PROMPT + flow_prompt_section()

--- a/litigant_portal/app/templates/v2/chat/index.html
+++ b/litigant_portal/app/templates/v2/chat/index.html
@@ -52,9 +52,11 @@
            class="text-xs text-greyscale-400 px-3 py-2">{% trans "No conversations yet." %}</p>
       </div>
       {# Discovery #670: hard links to the guided flows — full inventory, no topic context. #}
-      <div class="flex-shrink-0 border-t border-greyscale-200 p-4">
-        <c-molecules.flow-links :tracks="flow_tracks" />
-      </div>
+      {% if flow_tracks %}
+        <div class="flex-shrink-0 border-t border-greyscale-200 p-4">
+          <c-molecules.flow-links :tracks="flow_tracks" />
+        </div>
+      {% endif %}
     </aside>
     {# Center panel — conversation #}
     <section class="flex-1 min-w-0 flex flex-col min-h-0 border-r border-greyscale-200">

--- a/litigant_portal/app/templates/v2/chat/index.html
+++ b/litigant_portal/app/templates/v2/chat/index.html
@@ -51,6 +51,10 @@
            x-cloak
            class="text-xs text-greyscale-400 px-3 py-2">{% trans "No conversations yet." %}</p>
       </div>
+      {# Discovery #670: hard links to the guided flows — full inventory, no topic context. #}
+      <div class="flex-shrink-0 border-t border-greyscale-200 p-4">
+        <c-molecules.flow-links :tracks="flow_tracks" />
+      </div>
     </aside>
     {# Center panel — conversation #}
     <section class="flex-1 min-w-0 flex flex-col min-h-0 border-r border-greyscale-200">

--- a/litigant_portal/app/tests/test_assistant_flow_prompt.py
+++ b/litigant_portal/app/tests/test_assistant_flow_prompt.py
@@ -1,0 +1,50 @@
+"""Discovery #670: the v2 assistant knows the guided-flow links exist."""
+
+from litigant_portal.agents_v2 import assistant as assistant_module
+from litigant_portal.agents_v2.assistant import (
+    BASE_PROMPT,
+    LitigantAssistant,
+    flow_prompt_section,
+)
+
+TRACKS = [
+    {
+        "court": "franklin-county-oh",
+        "topic": "eviction",
+        "role": "tenant",
+        "label": "Responding to an Eviction in Franklin County, Ohio (Tenant)",
+        "title": "Responding to an Eviction in Franklin County, Ohio (Tenant)",
+    },
+    {
+        "court": "north-dakota",
+        "topic": "adult-name-change",
+        "role": "standard",
+        "label": "Adult Name Change in North Dakota (Publication Required)",
+        "title": "Adult Name Change in North Dakota (Publication Required)",
+    },
+]
+
+
+def test_flow_section_lists_each_track(monkeypatch):
+    monkeypatch.setattr(
+        assistant_module.registry, "all_tracks", lambda: TRACKS
+    )
+    section = flow_prompt_section()
+    for track in TRACKS:
+        assert track["title"] in section
+    # Must name the UI affordance the links live under.
+    assert "Guided steps" in section
+
+
+def test_flow_section_empty_when_no_corpora(monkeypatch):
+    monkeypatch.setattr(assistant_module.registry, "all_tracks", lambda: [])
+    assert flow_prompt_section() == ""
+
+
+def test_system_prompt_appends_flow_section(monkeypatch):
+    monkeypatch.setattr(
+        assistant_module.registry, "all_tracks", lambda: TRACKS
+    )
+    prompt = LitigantAssistant().generate_system_prompt(thread_id=None)
+    assert prompt.startswith(BASE_PROMPT)
+    assert TRACKS[0]["title"] in prompt

--- a/litigant_portal/app/tests/test_chat_v2_page.py
+++ b/litigant_portal/app/tests/test_chat_v2_page.py
@@ -1,0 +1,24 @@
+"""Discovery #670: the v2 chat page surfaces the guided-flow links."""
+
+import pytest
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from litigant_portal.app.topic_flow.registry import registry
+
+
+@pytest.mark.postgres
+class ChatV2FlowTracksTests(TestCase):
+    """The v2 chat view exposes the full track inventory (no topic context)."""
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_context_exposes_all_authored_tracks(self):
+        response = self.client.get(reverse("pages:chat_v2"))
+        assert response.status_code == 200
+        tracks = response.context["flow_tracks"]
+        # Topic-less surface gets the whole inventory, not a topic slice.
+        assert tracks == registry.all_tracks()
+        assert tracks, "repo corpus should yield at least one track"
+        assert {"court", "topic", "role", "label", "title"} <= set(tracks[0])

--- a/litigant_portal/app/tests/test_topic_flow_registry.py
+++ b/litigant_portal/app/tests/test_topic_flow_registry.py
@@ -155,3 +155,25 @@ def test_tracks_for_ordered_tracks_precede_unordered(tmp_path):
     registry = CorpusRegistry(content_dir=tmp_path)
     roles = [t["role"] for t in registry.tracks_for("test_topic")]
     assert roles == ["respondent", "petitioner"]
+
+
+def test_all_tracks_lists_every_corpus_ordered(tmp_path):
+    (tmp_path / "a.yml").write_text(VALID)
+    # Same topic, second role, explicit order: sorts ahead of unordered.
+    other = VALID.replace(
+        "  role: petitioner", "  role: respondent\n  order: 1"
+    )
+    (tmp_path / "b.yml").write_text(other)
+    registry = CorpusRegistry(content_dir=tmp_path)
+    tracks = registry.all_tracks()
+    assert [t["role"] for t in tracks] == ["respondent", "petitioner"]
+    first = tracks[0]
+    assert first["court"] == "test-court"
+    assert first["topic"] == "test_topic"
+    # Self-describing label in a mixed, topic-less list: the corpus title.
+    assert first["label"] == first["title"]
+
+
+def test_all_tracks_empty_registry(tmp_path):
+    registry = CorpusRegistry(content_dir=tmp_path)
+    assert registry.all_tracks() == []

--- a/litigant_portal/app/topic_flow/registry.py
+++ b/litigant_portal/app/topic_flow/registry.py
@@ -97,6 +97,33 @@ class CorpusRegistry:
         )
         return [track for _, track in matches]
 
+    def all_tracks(self) -> list[dict]:
+        """Every authored track across all corpora, grouped by topic.
+
+        For surfaces with no topic context (the v2 chat discovery, #670).
+        Labels are the corpus titles, which are self-describing in a mixed
+        list; explicit ``order:`` sorts within a topic like ``tracks_for``.
+        """
+        self.load()
+        entries = [
+            (
+                corpus_topic,
+                corpus.metadata.order,
+                {
+                    "court": court,
+                    "topic": corpus_topic,
+                    "role": role,
+                    "label": corpus.metadata.title,
+                    "title": corpus.metadata.title,
+                },
+            )
+            for (court, corpus_topic, role), corpus in self._index.items()
+        ]
+        entries.sort(
+            key=lambda e: (e[0], e[1] is None, e[1] if e[1] is not None else 0)
+        )
+        return [track for _, _, track in entries]
+
 
 # Module-level default over the repo's content/ directory.
 registry = CorpusRegistry()

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -245,7 +245,15 @@ def chat_v2_view(request):
         "CHAT_MODEL": CHAT_MODEL,
         "CHAT_ENABLED": CHAT_ENABLED,
     }
-    return render(request, "v2/chat/index.html", {"debug_env": debug_env})
+    return render(
+        request,
+        "v2/chat/index.html",
+        {
+            "debug_env": debug_env,
+            # Discovery #670: topic-less surface gets the whole inventory.
+            "flow_tracks": registry.all_tracks(),
+        },
+    )
 
 
 def deep_link(request, court, topic):


### PR DESCRIPTION
Pre-plan discovery test (throwaway-eligible): puts the hard Topic Flow links on the v2 chat page and gives the assistant the least prompt possible to know they exist — a registry-derived title inventory plus one instruction naming the "Guided steps" sidebar section. No corpus, no prompt.md layers, no topic grounding: the point is to chat with the ungrounded assistant and learn what grounding is actually load-bearing before investing in plumbing. Findings land on the issue; `FLOW_PROMPT` in `agents_v2/assistant.py` is the wording-iteration surface.

The repo CLAUDE.md slim-down originally rode this branch as its first commit; it moved to #674 (with the REVIEW.md change) to keep this PR single-purpose.

Part of #670 — the issue stays open as the findings home; it closes by hand when the discovery write-up lands.

Test plan:
- [x] TDD: registry `all_tracks()` ordering + empty case; v2 view exposes the full inventory in context; prompt section lists every track, names "Guided steps", and vanishes when no corpora exist
- [x] `make pre-commit` green (lint reformat amended into the prompt commit)
- [ ] Manual discovery loop: `/chat-v2/` shows Guided steps under the thread list; eviction- and name-change-shaped questions get pointed at the matching link; iterate `FLOW_PROMPT` as chatting teaches

