### PR TITLE
Skip auto-review on branch-sync PRs; slim repo CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Pre-commit runs automatically on commit. Key hooks:
 
 Run all hooks manually: `pre-commit run --all-files`
 
-**Note:** djlint runs in **lint-only mode** (no auto-formatter). Its formatter was mangling template tags inside HTML attributes — expanding single-line `{% block %}` tags to multi-line and injecting whitespace into rendered attributes. See "Template Formatting" below for the manual conventions that replace the formatter.
+**Note:** djlint runs in **lint-only mode** (no auto-formatter). Its formatter was mangling template tags inside HTML attributes — the manual conventions that replace it live in the global `django-templates` skill (see Template Formatting below).
 
 ### Before Committing
 
@@ -80,146 +80,9 @@ make pre-commit   # lint → test, short-circuits if lint fails/fixes anything
 
 Equivalent to `make lint && make test`. If lint auto-fixes files, the target stops before tests — re-stage the changes and re-run. The name mirrors the `pre-commit` hook tool intentionally — same concept, different invocation surface.
 
-### Template Formatting (Manual Conventions)
+### Template Formatting
 
-No auto-formatter for `.html` templates — djlint runs lint-only. Follow these Prettier-inspired conventions (Prettier is the source of truth — a Cotton plugin is planned). Cotton components (`<c-atoms.button>`, `<c-organisms.header>`) are valid HTML5 custom elements and follow the same rules as any HTML tag.
-
-**1. Indentation: 2 spaces.** For HTML elements, Cotton components, and template tags alike.
-
-**2. Attribute wrapping: single vs multi-line.**
-
-If all attributes fit on one line within ~120 chars, keep them inline:
-
-```html
-<div class="flex items-center gap-2">
-  <c-atoms.icon name="check" class="w-4 h-4" />
-  <c-atoms.button
-    type="button"
-    variant="primary"
-    x-on:click="save"
-  ></c-atoms.button>
-</div>
-```
-
-If they don't fit, one attribute per line. Closing `>` or `/>` goes on its own line (Prettier default, `bracketSameLine: false`):
-
-```html
-<input
-  type="text"
-  x-bind:value="inputText"
-  x-on:input="updateInput"
-  name="q"
-  placeholder="{% trans 'Ask a question' %}"
-  class="chat-input"
-  aria-label="{% trans 'Ask a question' %}"
-/>
-```
-
-For Cotton components, same rule — first attribute on the tag line, rest aligned:
-
-```html
-<c-molecules.form-field
-  label="Email"
-  type="email"
-  name="email"
-  required
-  value="{{ form.email.value|default:'' }}"
-/>
-```
-
-**3. Template tags inside HTML attributes MUST stay on one line.**
-
-This is the critical rule. Django template tags (`{% block %}`, `{% if %}`, `{{ var }}`) inside an attribute value must remain on the same line as the attribute. Multi-line = literal whitespace in the rendered HTML.
-
-```html
-<!-- GOOD -->
-<body
-  class="{% block body_class %}min-h-dvh flex flex-col bg-greyscale-25{% endblock body_class %}"
->
-  <main class="flex-1 {% block main_class %}{% endblock main_class %}">
-    <meta
-      name="description"
-      content="{% block meta_description %}{% trans 'Default' %}{% endblock meta_description %}"
-    />
-
-    <!-- BAD: whitespace injected into rendered class attribute -->
-    <body
-      class="{% block body_class %}
-    min-h-dvh flex flex-col bg-greyscale-25{% endblock body_class %}
-    "
-    ></body>
-  </main>
-</body>
-```
-
-These lines will be long. That's OK — attribute values are not breakable.
-
-**4. Block-level template tags get their own lines.**
-
-Outside of attributes, `{% block %}`, `{% if %}`, `{% for %}` etc. get their own lines and indent their children:
-
-```html
-{% block content %}
-<div class="container">
-  <h1>Title</h1>
-</div>
-{% endblock content %} {% if user.is_authenticated %}
-<p>Welcome</p>
-{% else %}
-<p>Please sign in</p>
-{% endif %}
-```
-
-**5. Self-closing tags.**
-
-Prettier adds `/>` to void HTML elements and self-closing components alike. Follow Prettier:
-
-```html
-<!-- Void HTML elements -->
-<meta charset="UTF-8" />
-<input type="text" name="q" />
-<img src="logo.svg" alt="Logo" class="h-12" />
-
-<!-- Cotton self-closing -->
-<c-atoms.icon name="check" class="w-4 h-4" />
-<c-atoms.typing-indicator />
-<c-organisms.header />
-```
-
-**6. Quotes: double quotes** for all HTML attributes. Single quotes only inside attribute values for Django template tags: `value="{{ form.email.value|default:'' }}"`.
-
-**`{% trans %}` in Cotton props:** Never put `{% trans %}` directly in a prop attribute — the single quotes needed to avoid closing the HTML attribute violate djlint T002. Extract to a variable first:
-
-```html
-{% trans "Check your email" as status_heading %}
-<c-molecules.auth-status
-  heading="{{ status_heading }}"
-></c-molecules.auth-status>
-```
-
-**7. Blank lines.** One blank line between logical sections. Never multiple consecutive blank lines. No blank line immediately after an opening tag or before a closing tag:
-
-```html
-<!-- GOOD -->
-<div class="container">
-  <h1>Title</h1>
-  <p>Content</p>
-</div>
-
-<!-- BAD: blank line after opening tag -->
-<div class="container">
-  <h1>Title</h1>
-</div>
-```
-
-**8. Short inline elements stay on one line** when they fit:
-
-```html
-<p class="text-sm text-greyscale-500">{% trans "No activity yet" %}</p>
-<span class="font-semibold">{% trans "Activity" %}</span>
-```
-
-**9. Long `class` values.** Tailwind classes stay on one line inside the `class` attribute even when long — don't break a class string across lines. If the element also has many other attributes, the `class` attribute gets its own line in the multi-line format (rule 2), but the value itself stays unbroken.
+No auto-formatter for `.html` templates — djlint runs lint-only. **Load the global `django-templates` skill before writing or editing any template**; it holds the full Prettier-inspired conventions (attribute wrapping, template-tags-stay-on-one-line, self-closing, quotes, blank lines). A custom Prettier/Cotton plugin is a WIP to replace the manual rules — LP is its home.
 
 ## Content style (user-facing copy)
 
@@ -308,15 +171,7 @@ Every page follows the same frame: **site header → sub-header (contextual) →
 - **Mobile-first and responsive**, but layout stability for WCAG always wins over visual flair. Buttons, links, and navigation stay in predictable locations across all views and states.
 - **Inputs flow with content** — don't pin chat inputs to the viewport bottom. Follow conversation UX: the input lives at the end of the message flow.
 
-**Patterns from the CSP migration:**
-
-- **Pre-compute in JS, bind in templates** — ternaries (`role === 'user' ? 'chat-bubble-user' : 'chat-bubble-assistant'`) become getter properties (`msg.bubbleClass`). Templates only reference the result.
-- **CSS over Alpine for animation** — `@keyframes` + `x-on:animationend` replaces `x-transition` + `setTimeout`. Native `<details>` + `grid-rows-[0fr]/[1fr]` replaces `x-collapse`.
-- **Flat getters for nested data** — optional chaining (`caseInfo?.court_info?.phone`) can't appear in templates. Create flat getters (`get courtPhone()`) that encapsulate the traversal.
-- **`x-effect` → method calls** — side effects on state change (like loading data when a menu opens) go in the method that triggers the change (`openMenu()` loads timeline), not in `x-effect`.
-- **No `!` negation in templates** — `x-show="!isOpen"` fails in CSP build. Create negated getters (`get isClosed()`) instead.
-- **No `x-model`** — CSP build can't evaluate the setter (`expr = __placeholder`). Use `x-bind:value="prop"` + `x-on:input="updateMethod"` instead, where the method reads `e.target.value`.
-- **Spread flattens getters** — `{ ...createChat() }` invokes getters and copies static values. If a composed component needs reactive getters from a base, re-define them after the spread.
+**Patterns from the CSP migration** — promoted to the org level; see `~/flp/CLAUDE.md` Alpine section (pre-compute getters, CSS-over-Alpine animation, flat getters, no `!`/`x-model`, spread-flattens-getters).
 
 ### Component System (Django Cotton + Atomic Design)
 
@@ -333,14 +188,7 @@ litigant_portal/app/templates/cotton/
 
 Style guide available at `/style-guide/` during development.
 
-**NEVER** create custom CSS classes or raw HTML that duplicates what an existing atom/molecule already does. **ALWAYS** check existing components before writing any UI element:
-
-1. Check `litigant_portal/app/templates/cotton/` for an existing component at the right atomic level
-2. Check component props — variants, sizes, `href`, `full_width`, `class` passthrough — before assuming a component can't do what you need
-3. If a component is _almost_ right, **extend it** with a new prop rather than bypassing it with custom CSS
-4. Check Tailwind theme tokens in `litigant_portal/app/src/main.css` before inventing new values
-
-Only create a new component when no combination of existing ones works. Only add new theme tokens when the design system genuinely needs them.
+Component & style discipline follows the org rule (`~/flp/CLAUDE.md`): compose from existing components first, extend with a prop when almost-right, new components/tokens only when nothing combines. LP paths: components in `litigant_portal/app/templates/cotton/`, theme tokens in `litigant_portal/app/src/main.css`. Check props (variants, sizes, `href`, `full_width`, `class` passthrough) before assuming a component can't do it.
 
 **Atomic design check (both directions):** After any template or component change:
 
@@ -369,17 +217,7 @@ Build: `tailwindcss -i litigant_portal/app/src/main.css -o litigant_portal/app/s
 
 ### CSP Compliance (Content Security Policy)
 
-**No inline event handlers.** Use Alpine.js directives instead:
-
-```html
-<!-- BAD: Violates CSP -->
-<button onclick="doSomething()">
-  <!-- GOOD: CSP-compliant -->
-  <button x-on:click="doSomething"></button>
-</button>
-```
-
-Pre-commit hook enforces this (`csp-inline-check`).
+No inline event handlers (org CSP mandate) — use Alpine directives (`x-on:click="doSomething"`, never `onclick=`). Enforced by the `csp-inline-check` pre-commit hook.
 
 ### Alpine.js (CSP Build - Local)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,11 @@
+# Review instructions
+
+## Skip branch-sync PRs
+
+Do not review pull requests that merge one long-lived branch into another
+(for example main into staging, or staging into main). Post no findings and
+no summary comment. The commits in these PRs were already reviewed on their
+feature PRs; anything flagged there was fixed or intentionally dismissed at
+merge time, and re-raising it on the sync PR re-litigates settled decisions.
+
+Review feature branches into main as normal.


### PR DESCRIPTION
Two repo-hygiene fixes that sit together:

1. **`REVIEW.md` (new, repo root)** — instructs the managed Claude auto-review to post nothing on branch-sync PRs (main→staging, staging→main): those commits were already reviewed on their feature PRs, and anything flagged there was fixed or intentionally dismissed at merge time. Feature PRs into main keep normal review. `REVIEW.md` is the documented mechanism; the admin console has no base-branch filter, and the review run still executes — it just goes quiet on sync PRs.

2. **Repo CLAUDE.md slim-down (−162 lines)** — template-formatting conventions extracted to the global django-templates skill; Alpine CSP-migration patterns and component/style discipline promoted to org-level `~/flp/CLAUDE.md`. The repo file now references instead of duplicating. (Moved over from #671 to keep the discovery PR single-purpose.)

Closes #674

Test plan:
- [x] Docs/config only — no code paths; pre-commit hooks green on both commits
- [ ] REVIEW.md efficacy verifies on the next "merge main to staging" PR: expect no bot findings/summary
- [ ] CLAUDE.md: next session loads the slimmed file; template work pulls the django-templates skill on demand