### PR TITLE
chat === v2: route the default chat URL to the v2 surface

### DIFF
--- a/litigant_portal/app/tests/test_chat_default_surface.py
+++ b/litigant_portal/app/tests/test_chat_default_surface.py
@@ -1,0 +1,29 @@
+"""chat === v2 (#676): the default chat surface is the v2 page."""
+
+import pytest
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+@pytest.mark.postgres
+class ChatDefaultSurfaceTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_chat_serves_v2(self):
+        response = self.client.get(reverse("pages:chat"))
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "v2/chat/index.html")
+
+    def test_v1_query_params_are_ignored_not_fatal(self):
+        # Deep links still carry ?topic=/?court=; v2 has no topic grounding
+        # yet (#670 tests that condition), so they must be harmless.
+        response = self.client.get(reverse("pages:chat"), {"topic": "eviction"})
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "v2/chat/index.html")
+
+    def test_v1_reference_url_still_serves(self):
+        # Known-URL access to v1 for the UI/UX merge reference (#668).
+        response = self.client.get(reverse("pages:chat_v1"))
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "pages/chat.html")

--- a/litigant_portal/app/tests/test_chat_default_surface.py
+++ b/litigant_portal/app/tests/test_chat_default_surface.py
@@ -18,7 +18,9 @@ class ChatDefaultSurfaceTests(TestCase):
     def test_v1_query_params_are_ignored_not_fatal(self):
         # Deep links still carry ?topic=/?court=; v2 has no topic grounding
         # yet (#670 tests that condition), so they must be harmless.
-        response = self.client.get(reverse("pages:chat"), {"topic": "eviction"})
+        response = self.client.get(
+            reverse("pages:chat"), {"topic": "eviction"}
+        )
         assert response.status_code == 200
         self.assertTemplateUsed(response, "v2/chat/index.html")
 

--- a/litigant_portal/app/tests/test_portal.py
+++ b/litigant_portal/app/tests/test_portal.py
@@ -48,6 +48,10 @@ class HomePageTests(TestCase):
 
 
 @pytest.mark.postgres
+@pytest.mark.skip(
+    reason="v1 chat page moved to /chat-v1/ (chat === v2, #676); "
+    "port these contracts to v2 per #677"
+)
 class ChatPageTests(TestCase):
     """Tests for the chat page at /chat/."""
 
@@ -504,6 +508,10 @@ class TopicDetailTests(TestCase):
 
 
 @pytest.mark.postgres
+@pytest.mark.skip(
+    reason="v1 chat page moved to /chat-v1/ (chat === v2, #676); "
+    "port these contracts to v2 per #677"
+)
 class ChatPageTopicTests(TestCase):
     """Tests for topic context routing on the chat page."""
 
@@ -617,6 +625,10 @@ class DeepLinkTests(TestCase):
 
 
 @pytest.mark.postgres
+@pytest.mark.skip(
+    reason="v1 chat page moved to /chat-v1/ (chat === v2, #676); "
+    "port these contracts to v2 per #677"
+)
 class ChatPageCourtTests(TestCase):
     """Tests for court parameter handling on /chat/ (#327)."""
 

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -31,7 +31,11 @@ app_patterns = [
         pages.topic_flow_download,
         name="topic_flow_download",
     ),
-    path("chat/", pages.chat_page, name="chat"),
+    # chat === v2 (#676): the default chat surface. v1 stays reachable at a
+    # URL we know, as reference for the UI/UX merge (#668) and the atomic
+    # conversion; it leaves with the v1 cleanout. chat-v2 kept as an alias.
+    path("chat/", pages.chat_v2_view, name="chat"),
+    path("chat-v1/", pages.chat_page, name="chat_v1"),
     path("chat-v2/", pages.chat_v2_view, name="chat_v2"),
     path("chat/action-plan/", endpoints.action_plan, name="action_plan"),
     path("style-guide/", pages.style_guide, name="style_guide"),


### PR DESCRIPTION
`/chat/` now serves the v2 chat view — every entry point (topic cards, deep links, nav) funnels to v2 through `name="chat"` with zero template changes. No settings, no flag, no redirect chain; a flag only appears if something actually needs a per-environment split this week. v1 stays reachable at `/chat-v1/` as reference for the UI/UX merge (#668) and the atomic conversion, and `/chat-v2/` remains as an alias.

The three v1 chat-page test classes are skipped (reason cites #677, which tracks porting their contracts to v2 as it gains the equivalent surface).

Closes #676

Test plan:
- [x] New contract tests: `/chat/` serves the v2 template; deep-link `?topic=/?court=` params are harmless on v2 (the #670 ungrounded condition); `/chat-v1/` still serves the v1 template
- [x] `make pre-commit` green; 3 classes skipped, 0 failures
- [ ] Post-merge smoke: topic card → lands on v2 chat with Guided steps (once #671 is in); `/chat-v1/` renders grounded v1