### PR TITLE
fix(deploy): persist docassemble state on the DO QA box across deploys

### DIFF
--- a/.github/workflows/qa-deploy-do.yml
+++ b/.github/workflows/qa-deploy-do.yml
@@ -92,6 +92,13 @@ jobs:
             # images. --remove-orphans cleans up any service renamed/removed since.
             $COMPOSE pull
             $COMPOSE up -d --no-build --remove-orphans
+
+            # Compose only recreates a container when its service definition
+            # changes — edits to the bind-mounted Caddyfile.qa don't count, and
+            # caddy doesn't watch its config. Reload explicitly so Caddyfile
+            # changes apply on the deploy that ships them (zero-downtime; no-op
+            # when the config is unchanged).
+            $COMPOSE exec -T caddy caddy reload --config /etc/caddy/Caddyfile
         env:
           DEPLOY_REF: ${{ inputs.deploy_ref }}
 

--- a/deploy/qa-do/Caddyfile.qa
+++ b/deploy/qa-do/Caddyfile.qa
@@ -5,6 +5,10 @@
 # Contracts). Caddy auto-provisions HTTPS via Let's Encrypt for {$DOMAIN}.
 
 {$DOMAIN} {
+	# Bare /interview (no trailing slash) wouldn't match /interview/* and would
+	# fall through to the LP app as a 404; 308 preserves method/body for any POST.
+	redir /interview /interview/ 308
+
 	# Document-assembly interviews. `handle` (not `handle_path`) keeps the
 	# /interview/ prefix, which docassemble expects because POSTURLROOT mounts it
 	# there. Matched before the catch-all so it wins.

--- a/deploy/qa-do/README.md
+++ b/deploy/qa-do/README.md
@@ -36,6 +36,13 @@ and rolls it out on the box over SSH, then health-checks `/api/health/`.
   it read-only at `/static/`. A Docker named volume can't be used here — it inits
   root-owned and the container runs as non-root `appuser`, so `collectstatic`
   would fail. See one-time setup below.
+- **docassemble state:** named volumes on `/usr/share/docassemble/backup` and
+  `/files` — docassemble backs itself up there (clean stop + nightly) and
+  restores on boot, so playground interviews, config, and the admin password
+  survive deploys. Without them a recreate wipes everything and resets the admin
+  login to its public default (#701, the 2026-07 wipe). If a recreate ever comes
+  up empty anyway (unsafe shutdown skips the restore), re-seed from
+  `docassemble/nd-name-change/` per that folder's README.
 
 ## One-time box setup (static directory)
 

--- a/deploy/qa-do/README.md
+++ b/deploy/qa-do/README.md
@@ -29,8 +29,11 @@ and rolls it out on the box over SSH, then health-checks `/api/health/`.
 - **Postgres:** a standalone containerized pgvector instance with its own
   docker-managed volume, seeded by the `web-prod` entrypoint's `migrate` on boot.
   It is **not** shared with AWS — the box's `POSTGRES_PASSWORD` is its own
-  generated secret, independent of the EKS `litigant-env` secret. QA holds only
-  seed/demo data; reset with `docker compose -f deploy/qa-do/docker-compose.qa.yml down -v`.
+  generated secret, independent of the EKS `litigant-env` secret. The DB holds
+  only seed/demo data, but ⚠️ **don't reset with `down -v`** — that removes
+  _every_ named volume in the file, including the docassemble state below
+  (re-triggering the #701 wipe). To wipe just the DB:
+  `docker compose -f deploy/qa-do/docker-compose.qa.yml down && docker volume rm litigant-portal_qa_postgres_data`.
 - **Static files:** bind-mounted from `/opt/litigant-portal/qa-static` on the
   box. Django (`web-prod` entrypoint) runs `collectstatic` into it; Caddy serves
   it read-only at `/static/`. A Docker named volume can't be used here — it inits

--- a/deploy/qa-do/docker-compose.qa.yml
+++ b/deploy/qa-do/docker-compose.qa.yml
@@ -120,6 +120,19 @@ services:
       USEHTTPS: 'false'
       BEHINDHTTPSLOADBALANCER: 'true'
       TIMEZONE: 'America/New_York'
+    # docassemble writes a full backup (its internal Postgres, playground files,
+    # config) to /usr/share/docassemble/backup on clean stop + nightly cron, and
+    # restores from it on boot (jhpyle/docassemble Docker/initialize.sh). Without
+    # these volumes every recreate wipes all interviews and resets the admin
+    # login to its public default (#701). The pinned project name resolves them
+    # to the pre-existing litigant-portal_docassemble_qa_* volumes on the box.
+    # The 600s grace period lets the shutdown backup finish before docker kills
+    # the container — SIGKILL both loses the delta and marks the next boot as an
+    # unsafe shutdown, which skips the restore.
+    stop_grace_period: 600s
+    volumes:
+      - docassemble_qa_backup:/usr/share/docassemble/backup
+      - docassemble_qa_files:/usr/share/docassemble/files
 
   caddy:
     image: caddy:2-alpine
@@ -144,3 +157,9 @@ volumes:
   qa_postgres_data:
   caddy_data:
   caddy_config:
+  # docassemble state (see the service's volume comment). These names resolve to
+  # litigant-portal_docassemble_qa_{backup,files} — the volumes the original
+  # override created — so the first boot after this lands restores the pre-wipe
+  # playground.
+  docassemble_qa_backup:
+  docassemble_qa_files:

--- a/docs/docassemble-qa-hosting.md
+++ b/docs/docassemble-qa-hosting.md
@@ -1,8 +1,8 @@
 # docassemble on QA over HTTPS
 
-How to host the docassemble interview at `https://<lp-host>/interview/` (e.g.
-`https://qa.litigantportal.com/interview/`) so the Topic Flow link-out is clean
-for court-partner demos. Infra side of #531 (branding is #549).
+How docassemble is hosted at `https://qa.litigantportal.com/interview/` so the
+Topic Flow link-out is clean for court-partner demos. Infra side of #531
+(branding is #549).
 
 > **Path, not subdomain — on purpose.** docassemble routes _under_ the existing
 > LP hostname at `/interview/`, so a court partner needs only their one existing
@@ -16,22 +16,49 @@ for court-partner demos. Infra side of #531 (branding is #549).
 
 ## How it works
 
-A QA-only compose override (`docker-compose.docassemble.qa.yml`) layers on the
-base compose. It adds a `docassemble` service to the LP project network so
-**caddy-prod reaches it as `docassemble:80`** — no public port (unlike the bench's
-`:8100`). docassemble is mounted at the `/interview/` prefix via `POSTURLROOT`
-(it regenerates its internal nginx for the sub-path); Caddy passes the prefix
-through. Caddy terminates TLS and forwards plain HTTP; docassemble runs with
-`BEHINDHTTPSLOADBALANCER=true` so it still builds `https://` URLs and secure
-cookies.
+docassemble is a service in the DO QA stack (`deploy/qa-do/docker-compose.qa.yml`)
+— it deploys, restarts, and is removed with the rest of the box. (An earlier
+standalone override, `docker-compose.docassemble.qa.yml`, was retired with the
+CL-infra move; `deploy/qa-do/` is the single home now.)
 
-The route lives in `docker/caddy/conf.d/docassemble.caddy` as a `handle
-/interview/*` block, pulled into the main `{$DOMAIN}` site by `import
-conf.d/*.caddy`. The override mounts `conf.d` into caddy **only on QA**, so a
-base-only (prod) deploy loads none of it — the glob matches nothing.
+Caddy reaches it as `docassemble:80` on the project network — no public port.
+docassemble is mounted at the `/interview/` prefix via `POSTURLROOT` (it
+regenerates its internal nginx for the sub-path); the `handle /interview/*`
+block in `deploy/qa-do/Caddyfile.qa` passes the prefix through. Caddy terminates
+TLS and forwards plain HTTP; docassemble runs with `BEHINDHTTPSLOADBALANCER=true`
+so it still builds `https://` URLs and secure cookies.
 
 **No new certificate.** Because `/interview/` is on the _existing_ LP hostname,
 Caddy already serves TLS for it — there's no extra ACME/DNS challenge.
+
+## Persistence (survives deploys)
+
+docassemble keeps **all** state internally — its own Postgres, playground
+files, server config, user accounts. The container is stateless only if you let
+it be: its `initialize.sh` writes a full backup to
+`/usr/share/docassemble/backup` on clean stop and nightly by cron, and restores
+from it on boot.
+
+The QA service therefore mounts two named volumes (see the compose comment):
+
+- `docassemble_qa_backup:/usr/share/docassemble/backup` — the backup/restore
+  cycle above; this is what makes recreates safe
+- `docassemble_qa_files:/usr/share/docassemble/files` — live file storage
+
+Supporting pieces:
+
+- `stop_grace_period: 600s` — the shutdown backup needs time; a SIGKILL loses
+  the delta **and** flags the next boot as an unsafe shutdown, which skips the
+  restore.
+- The compose `name: litigant-portal` pin resolves the volumes to
+  `litigant-portal_docassemble_qa_*` on the box.
+
+**History (#701):** the service ran without these volumes after the `deploy/qa-do/`
+rebuild (#650), so a July 2026 deploy recreated it empty — interviews 404'd and
+the admin login reset to its public default. If a recreate ever comes up empty
+again, check `docker volume ls | grep docassemble` before re-uploading anything:
+if the volumes exist, a recreate with the mounts restores them; only if they're
+gone do you re-seed from `docassemble/nd-name-change/` (steps in that README).
 
 ## Prerequisites
 
@@ -39,7 +66,7 @@ Caddy already serves TLS for it — there's no extra ACME/DNS challenge.
   the 4 GB tier (#534). At 2 GB it OOMs.
 - **No new DNS.** Uses the existing host record (`qa.litigantportal.com` already
   resolves to the droplet).
-- **`DA_HOSTNAME`** in the QA `.env` = the existing LP host as a **bare hostname**,
+- **`DA_HOSTNAME`** in the box `.env` = the existing LP host as a **bare hostname**,
   e.g. `DA_HOSTNAME=qa.litigantportal.com`. docassemble needs its own hostname for
   URL building. ⚠️ Unlike `DOMAIN` (which is `https://qa.litigantportal.com`),
   `DA_HOSTNAME` has **no scheme** — a `https://` prefix makes docassemble build
@@ -47,64 +74,54 @@ Caddy already serves TLS for it — there's no extra ACME/DNS challenge.
 
 ## Deploy
 
-On `lp-qa`, from `/opt/litigant-portal`:
+Nothing docassemble-specific: it rides the manual QA deploy
+(GitHub → Actions → **Deploy to DigitalOcean QA (manual)**), which syncs the box
+tree and runs the whole stack via `deploy/qa-do/docker-compose.qa.yml`. First
+boot pulls the ~20 GB image and inits docassemble's DB — give it **5–10 min**.
+
+Verify:
 
 ```bash
-# Stop the local-bench container first if it's still running (frees :8100, avoids
-# two docassemble instances):
-docker rm -f docassemble-dev 2>/dev/null || true
-
-# Bring up LP + docassemble together, behind Caddy:
-docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml \
-  --profile prod up -d
-```
-
-First boot pulls the image and inits docassemble's own DB — give it **5–10 min**.
-Then verify:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.docassemble.qa.yml \
-  --profile prod ps                                       # docassemble + LP all up
 curl -sI https://qa.litigantportal.com/interview/ | head -1   # 200 / 302 into docassemble
 curl -sI https://qa.litigantportal.com/ | head -1             # LP root still 200
-docker stats --no-stream                                  # docassemble ~2 GB, LP healthy
+docker stats --no-stream                                      # docassemble ~2 GB, LP healthy
 ```
 
 ## After it's up
 
-- **Load the interview** — upload the interviews + `petition.pdf` to this
-  instance's Playground (same steps as the bench README), or publish them as a
-  package for a clean anonymous URL.
+- **Load the interview** — restored automatically from the backup volume; on a
+  truly fresh instance, upload the interviews + PDFs to the Playground (steps in
+  `docassemble/nd-name-change/README.md`), or publish them as a package for a
+  clean anonymous URL (#556).
+- **Rotate the admin password** — a fresh instance boots with docassemble's
+  public default login; change it before anything else. A restored instance
+  keeps the rotated one.
 - **Branding** — apply the LP look + download-only + anonymous config (#549).
 - **Set the corpus `interview_url`** to `https://qa.litigantportal.com/interview/...`
   so the Topic Flow "Fill out your forms" button goes live (#543 seam).
 
-## Reboot durability
-
-The service is `restart: unless-stopped`, so a reboot brings it back (pairs with
-#548 for the LP stack). A cold boot starts LP + docassemble together on 2 vCPUs,
-so there's a brief window where docassemble's init competes for CPU — LP recovers
-once it settles.
-
 ## Troubleshooting
 
 - **The interview loads but live updates hang** → the WebSocket isn't threading
-  the `/interview/` prefix. This is the main thing to verify in path mode: confirm
-  `POSTURLROOT=/interview/` took (check docassemble's logs/nginx) and that Caddy's
-  `reverse_proxy docassemble:80` is upgrading the socket. **Test this first.**
+  the `/interview/` prefix. Confirm `POSTURLROOT=/interview/` took (check
+  docassemble's logs/nginx) and that Caddy's `reverse_proxy docassemble:80` is
+  upgrading the socket. **Test this first.**
 - **Assets/links 404 under `/interview/`** → `POSTURLROOT` not applied; recreate
   the container so `initialize.sh` regenerates nginx with the prefix.
 - **Bare `/interview` (no trailing slash)** → redirected to `/interview/` with a
-  308 (in `conf.d/docassemble.caddy`), so hand-typed/trailing-slash-stripped URLs
-  still land.
-- **docassemble fails to initialize / builds wrong URLs** → `DA_HOSTNAME` unset (or
-  scheme-prefixed) while the override is active. Compose substitutes an empty
-  string with a warning — Caddy still starts (it uses `DOMAIN`, not `DA_HOSTNAME`),
+  308 (in `Caddyfile.qa`), so hand-typed/trailing-slash-stripped URLs still land.
+- **Playground empty / default login after a recreate** → the state volumes
+  weren't mounted (or an unsafe shutdown skipped the restore). See Persistence
+  above before re-uploading by hand.
+- **docassemble fails to initialize / builds wrong URLs** → `DA_HOSTNAME` unset
+  (or scheme-prefixed) in the box `.env`. Compose substitutes an empty string
+  with a warning — Caddy still starts (it uses `DOMAIN`, not `DA_HOSTNAME`),
   but docassemble runs with no hostname. Set a bare host in `.env`.
 
-## Prod safety
+## At the AWS cutover
 
-Production deploys (`docker compose -f docker-compose.yml --profile prod up -d`,
-no override) load **none** of this — no docassemble service, no `conf.d` mount, no
-`/interview/` route. docassemble's real production home rides the CL infra move
-(#461); this is the interim QA demo host.
+The DO _hosting path_ goes away with `deploy/qa-do/` (see its README), but
+**docassemble itself persists** — it gets its own docker instance on the AWS
+infra (#461). The state requirement travels with it: whatever runs it there
+must mount `/usr/share/docassemble/backup` (volume or S3-backed), or the wipe
+this doc's Persistence section describes happens again on the first recreate.


### PR DESCRIPTION
The docassemble service lost its state volumes when the DO QA stack was rebuilt in `deploy/qa-do/` (#650) — the retired override had them; the port dropped them. Every deploy since recreated the container empty (`--remove-orphans` + no mounts): playground interviews 404'd and the admin login reset to docassemble's public default. This restores the volumes (docassemble self-backs-up to `/usr/share/docassemble/backup` on clean stop + nightly and restores on boot, per `jhpyle/docassemble` `Docker/initialize.sh`), the 600s stop grace the shutdown backup needs, and the bare-`/interview` 308 lost in the same port. The hosting doc is synced to the `deploy/qa-do` architecture with the persistence/recovery story, including the AWS carry-over note (docassemble outlives the DO box).

Closes #701

Test plan:
- [ ] `docker compose -f deploy/qa-do/docker-compose.qa.yml config` validates (done locally)
- [ ] Dispatch the DO QA deploy — the pinned project name reattaches the surviving `litigant-portal_docassemble_qa_*` volumes and the pre-wipe playground self-restores
- [ ] `https://qa.litigantportal.com/interview/interview?i=docassemble.playground1:petition-standard.yml` loads
- [ ] Admin login is not the default (rotate if the restore predates the rotation)
- [ ] Redeploy again and confirm state survives the recreate