### PR TITLE
refactor(frontend): remove orphaned action plan component

### DIFF
--- a/litigant_portal/app/static/js/components.js
+++ b/litigant_portal/app/static/js/components.js
@@ -60,14 +60,4 @@ document.addEventListener('alpine:init', () => {
       location.reload()
     },
   }))
-
-  // ===========================================================================
-  // Action plan page (print button)
-  // ===========================================================================
-
-  Alpine.data('actionPlanPage', () => ({
-    printPage() {
-      window.print()
-    },
-  }))
 })


### PR DESCRIPTION
## Summary

Closes #692.

Remove the orphaned `actionPlanPage` Alpine component and its comment banner.
Its only template consumer was archived, so the registration no longer needs
to ship in the global JavaScript bundle.

## Test plan

- Confirmed there are no remaining `actionPlanPage` references outside the
  archive.
- Ran `git diff --check`.

This PR was prepared with AI assistance and validated with the checks above.
