### PR TITLE
chore(urls): explain unprefixed English routes

### DIFF
--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -116,7 +116,7 @@ urlpatterns = [
             "",
             include((app_patterns, "litigant_portal.app"), namespace="pages"),
         ),
-        prefix_default_language=False,
+        prefix_default_language=False,  # Keep English URLs unprefixed (/chat/ not /en/chat/)
     ),
     # Assistant API Endpoints
     path(


### PR DESCRIPTION
## Summary

Document why the default language intentionally remains unprefixed in the
localized URL configuration. The inline example makes the compatibility impact
clear: existing `/chat/` links must not become `/en/chat/`.

Closes #158

## Validation

- all pre-commit hooks passed
- `litigant_portal/app/urls.py` compiles successfully
- `git diff --check` passed

The full test suite requires the project's Docker/PostgreSQL environment; Docker
is not running locally. This comment-only change does not alter executable
behavior.
