### PR TITLE
docs: add CLA section and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,112 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action
+in response to any behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public
+spaces, such as using an official e-mail address or acting as an appointed
+representative at an event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+conduct@free.law. All complaints will be reviewed and
+investigated promptly and fairly, and reporter privacy will be respected.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time,
+including in community spaces and external channels like social media.
+Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. Violating
+these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,22 @@ Commits follow [Conventional Commits](https://www.conventionalcommits.org/): `ty
 
 `make lint` and `make test` before pushing (`make pre-commit` runs both; pre-commit hooks also run on every commit). `make test` execs into the Django container, so `make docker` needs to be running first. What "done" actually requires — testing philosophy, WCAG/CSP/progressive-enhancement gates, content style, component discipline — lives in [docs/wiki/definition-of-done.md](docs/wiki/definition-of-done.md); that's the canonical bar for every PR and issue.
 
+## Contributor License Agreement (CLA)
+
+Free Law Project requires a signed CLA before a PR can be merged. A bot checks this automatically on every PR.
+
+- **Sign here:** [cla-assistant.io/freelawproject/litigant-portal](https://cla-assistant.io/freelawproject/litigant-portal) — one click via GitHub OAuth.
+- **Already signed but the check still shows pending?** The CLA Assistant bot's comment on your PR includes a "Let us recheck it" link — click it to re-verify your signature against that PR.
+- **What it is:** the [Apache Individual Contributor License Agreement V2.0](https://www.apache.org/licenses/icla.pdf), adapted with FLP's names. In return, FLP makes a public-benefit covenant: it "shall not use Your Contributions in a way that is contrary to the public benefit or inconsistent with universal access to public court documents."
+- **You keep your copyright.** This is a license grant, not a copyright assignment — you're licensing FLP to use your contribution, not signing ownership over.
+- **One signature, every FLP repo.** Sign once and it covers all `freelawproject` projects going forward, not just this one.
+
+**Contributing on behalf of an employer?** The ICLA references an employer having "executed a separate Corporate CLA with the Project," but the repo has no documented contact or process for that path yet. If this applies to you, flag it on your PR or issue and we'll get you an answer before merge.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Participation in this repo — issues, PRs, discussions — means agreeing to abide by it.
+
 ## Security
 
 Report vulnerabilities through our [vulnerability disclosure policy](https://free.law/vulnerability-disclosure-policy/) (see [SECURITY.md](SECURITY.md)), not public issues.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Visit: http://localhost (Caddy serves on port 80).
 
 ## Contributing
 
-Issue-first workflow, Conventional Commits, WCAG AA floor — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Issue-first workflow, Conventional Commits, WCAG AA floor — see [CONTRIBUTING.md](CONTRIBUTING.md). A signed [CLA](https://cla-assistant.io/freelawproject/litigant-portal) is required before merge (one click, covers all FLP repos); see the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
A new contributor's first contact with the CLA requirement was a red check and bot comment after they'd already written the code (#708), with nothing in the repo explaining the gate exists up front.

- CONTRIBUTING.md: add a CLA section covering the requirement, what the ICLA + public-benefit covenant is, copyright retention, the one-signature-covers-all-FLP-repos scope, the signing link, and the recheck link. Corporate CLA path is flagged as an open question pending an owner (Mike/Jessica) since the ICLA text references a separate Corporate CLA process the repo doesn't yet document.
- CONTRIBUTING.md: add a Code of Conduct section pointing to CODE_OF_CONDUCT.md.
- CODE_OF_CONDUCT.md: add Contributor Covenant v2.1 at repo root so GitHub's community-standards checklist recognizes it.
- README.md: surface the CLA requirement and Code of Conduct link in the Contributing section so they're visible before a contributor opens a PR.