### PR TITLE
fix(topic-flow): don't leak cached answers

### DIFF
--- a/litigant_portal/app/templates/cotton/atoms/input.html
+++ b/litigant_portal/app/templates/cotton/atoms/input.html
@@ -8,6 +8,7 @@
        {% if id %}id="{{ id }}"{% endif %}
        {% if value %}value="{{ value }}"{% endif %}
        {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
+       {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
        {% if disabled %}disabled{% endif %}
        {% if readonly %}readonly{% endif %}
        {% if required %}required{% endif %}

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
@@ -29,6 +29,7 @@
     name="{{ q.id }}"
     id="{{ q.id }}"
     value="{{ q.value }}"
+    autocomplete="off"
     help_text="{{ q.help_text|default:'' }}"
     :required="q.required"
     :autofocus="q.autofocus"

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -91,6 +91,23 @@ def test_fact_gather_unanswered_question_prefills_empty():
     assert q["value"] == ""
 
 
+def test_fact_gather_never_prefills_publication_date():
+    # #638: unlike other fields, publication_date must never echo a stored
+    # answer back into the form.
+    section = _fg(
+        [
+            Question(
+                id="publication_date", label="Publication date", type="date"
+            )
+        ]
+    )
+    rendered = render_section(
+        section, _corpus(section), {"publication_date": "2026-05-01"}
+    )
+    (q,) = rendered.context["questions"]
+    assert q["value"] == ""
+
+
 def test_fact_gather_carries_choice_metadata():
     section = _fg(
         [

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -203,6 +203,28 @@ def test_summary_omits_unanswered_questions():
     ]
 
 
+def test_summary_never_prefills_publication_date():
+    # #638: the recap reads the same session-backed answers as the fact_gather
+    # form — a prior guest's publication_date can't leak in here either.
+    fg = _fg(
+        [
+            Question(
+                id="publication_date", label="Publication date", type="date"
+            ),
+            Question(id="filing_county", label="County"),
+        ]
+    )
+    summary = SummaryOutput(
+        kind="output", output_type="summary", id="recap", heading="Recap"
+    )
+    rendered = render_section(
+        summary,
+        _corpus(fg, summary),
+        {"publication_date": "2026-05-01", "filing_county": "Cass"},
+    )
+    assert rendered.context["items"] == [{"label": "County", "value": "Cass"}]
+
+
 # --- packet -----------------------------------------------------------------
 
 

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -448,6 +448,25 @@ def test_get_prefills_form_from_existing_session_answers(client, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_recap_never_shows_publication_date(client, monkeypatch):
+    # #638: the recap reads the same session-backed answers as the fact_gather
+    # form above it — a prior guest's publication_date can't surface there
+    # either, even though filing_county (unaffected by the fix) still shows.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    session = client.session
+    session["topic_flow"] = {
+        f"{COURT}/{TOPIC}/{ROLE}": {
+            "publication_date": "2026-03-15",
+            "filing_county": "Cass",
+        }
+    }
+    session.save()
+    html = client.get(URL).content.decode()
+    assert "2026-03-15" not in html
+    assert "Cass" in html
+
+
+@pytest.mark.django_db
 def test_post_stores_only_known_question_ids(client, monkeypatch):
     # The handler accepts only the corpus's question ids — csrf tokens and any
     # stray/injected POST keys must not land in the answer store.

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -339,6 +339,18 @@ def test_fact_gather_marks_required_questions_and_leaves_optional_unmarked(
 
 
 @pytest.mark.django_db
+def test_fact_gather_date_field_disables_browser_autocomplete(
+    client, monkeypatch
+):
+    # #638: on a shared/public terminal, Chrome's own autofill could otherwise
+    # suggest a prior user's typed date from its own memory, independent of
+    # our session. autocomplete="off" should stop that.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    html = client.get(URL).content.decode()
+    assert 'autocomplete="off"' in _field_tag(html, "publication_date")
+
+
+@pytest.mark.django_db
 def test_headingless_fact_gather_skipped_in_toc_but_body_still_renders(
     client, monkeypatch
 ):
@@ -402,30 +414,37 @@ def test_post_redirects_to_the_saved_section_anchor(client, monkeypatch):
 
 @pytest.mark.django_db
 def test_posted_answers_prefill_on_the_redirected_get(client, monkeypatch):
-    # The whole point: what you submitted comes back filled in. Text echoes its
-    # value; the choice marks its option selected.
+    # What you submitted comes back filled in: the choice marks its option
+    # selected. publication_date is the exception (#638) — it never echoes
+    # back, even right after you just submitted it.
     monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
     client.post(
         URL, {"publication_date": "2026-02-01", "filing_county": "Cass"}
     )
     html = client.get(URL).content.decode()
     flat = re.sub(r"\s+", " ", html)
-    assert 'value="2026-02-01"' in _field_tag(html, "publication_date")
+    assert 'value="2026-02-01"' not in _field_tag(html, "publication_date")
     assert re.search(r'<option value="Cass"[^>]*selected', flat)
 
 
 @pytest.mark.django_db
 def test_get_prefills_form_from_existing_session_answers(client, monkeypatch):
-    # Answers already in the session (e.g. a returning guest) prefill on a plain
-    # GET — the AnswerStore is the source, not just the immediately-prior POST.
+    # Answers already in the session (e.g. a returning guest) prefill on a
+    # plain GET — the AnswerStore is the source, not just the
+    # immediately-prior POST. publication_date is exempt from this (#638).
     monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
     session = client.session
     session["topic_flow"] = {
-        f"{COURT}/{TOPIC}/{ROLE}": {"publication_date": "2026-03-15"}
+        f"{COURT}/{TOPIC}/{ROLE}": {
+            "publication_date": "2026-03-15",
+            "filing_county": "Cass",
+        }
     }
     session.save()
     html = client.get(URL).content.decode()
-    assert 'value="2026-03-15"' in _field_tag(html, "publication_date")
+    flat = re.sub(r"\s+", " ", html)
+    assert 'value="2026-03-15"' not in _field_tag(html, "publication_date")
+    assert re.search(r'<option value="Cass"[^>]*selected', flat)
 
 
 @pytest.mark.django_db

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -91,6 +91,13 @@ def _render_info(section, corpus, answers):
     )
 
 
+# publication_date is the one field left cached across sessions on a shared
+# terminal (#621 already pruned the riskier name/county questions) (#638).
+# It's still saved to AnswerStore for deadline computation — just never
+# echoed back into the form.
+_NEVER_PREFILL = {"publication_date"}
+
+
 @renderer("fact_gather")
 def _render_fact_gather(section, corpus, answers):
     questions = [
@@ -101,7 +108,7 @@ def _render_fact_gather(section, corpus, answers):
             "required": q.required,
             "choices": q.choices,
             "help_text": q.help_text,
-            "value": answers.get(q.id, ""),
+            "value": "" if q.id in _NEVER_PREFILL else answers.get(q.id, ""),
             "errors": [],
             "autofocus": False,
         }

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -162,9 +162,14 @@ def submitted_section_anchor(corpus, submitted_ids):
 
 
 def _answered_in_corpus_order(corpus, answers):
-    """Yield ``{label, value}`` for answered questions, in corpus order."""
+    """Yield ``{label, value}`` for answered questions, in corpus order.
+
+    Same leak vector as the fact_gather form: skip anything in
+    ``_NEVER_PREFILL`` so a prior guest's answer can't surface in the recap
+    either (#638).
+    """
     for question in _fact_gather_questions(corpus):
-        if question.id in answers:
+        if question.id in answers and question.id not in _NEVER_PREFILL:
             yield {"label": question.label, "value": answers[question.id]}
 
 


### PR DESCRIPTION
Browser autofill and the flow's own session prefill both echoed a prior user's answers back into the form on a shared/public terminal (#638). The #621 prune already removed the riskier name/county questions, so publication_date was the one field still exposed.

- atoms/input.html was silently dropping the autocomplete prop that form_field.html already forwarded to it — wire it through, and set autocomplete="off" on fact_gather's text fields.
- renderer.py never echoes publication_date's stored value into the form; it's still saved to AnswerStore for deadline computation, just not re-displayed.

Per-field clearing is a bigger, separate change (#515) — this targets the one field actually affected today.