### PR TITLE
Make Site a singleton model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,9 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **Naming:** services and selectors are `{model_name}_{action}` — `site_get_active`, `topic_create`, `user_identity_merge`, `user_upload_llm_parts`. Allow some liberty when a utility genuinely implicates two models equally. Anything not part of a module's public surface takes a leading underscore.
 
-**Reads are selectors, writes are services.** `user_list` reads, so it's a selector; `user_developer_toggle` writes, so it's a service. A cache key lives in the selector module that reads through it, and whoever invalidates it imports it from there.
+**Reads are selectors, writes are services.** `user_list` reads, so it's a selector; `user_developer_toggle` writes, so it's a service.
+
+**Cross-layer constants get their own module**, so no domain module has to import a constant out of another one: cache keys in `app/cache.py`, group and permission names in `app/permissions.py`. Each is read, written, and invalidated from a different layer, and anchoring one to any single consumer makes the other two reach sideways for it.
 
 **Permissions.** Admin access is the `app.manage_site` and `app.manage_developers` permissions, carried by the `Admins` and `Developers` groups (provisioned by a `post_migrate` receiver in `signals.py`). Check them with `request.user.has_perm(...)` in views and `{% if perms.app.manage_site %}` in templates — don't wrap either in a selector. Page views use Django's `@permission_required(..., raise_exception=True)`; the JSON API keeps its own `manage_site_required` / `manage_developers_required` decorators, because the built-in renders an HTML 403 where those endpoints must return a JSON body. These are deliberately separate from the auto-generated `add/change/delete/view` permissions that gate Django admin. Full reference: [`docs/wiki/permissions.md`](docs/wiki/permissions.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **Cross-layer constants get their own module**, so no domain module has to import a constant out of another one: cache keys in `app/cache.py`, group and permission names in `app/permissions.py`. Each is read, written, and invalidated from a different layer, and anchoring one to any single consumer makes the other two reach sideways for it.
 
-**Cached reads are invalidated at commit, never before.** A selector that caches wears a `timeout=None`, and every service that writes the same rows wears `@busts(KEY)` from `services/utils.py`. Deferring the delete to commit is the whole point: an immediate delete lets a reader on another connection repopulate the key with the pre-commit value, and nothing busts it a second time, so the stale copy is permanent. The same rule binds management commands — `transaction.on_commit`, not a bare `cache.delete`. Cached values are pickled model instances, so the keys carry a version suffix to bump whenever the model's fields change.
+**Cached reads are invalidated at commit, never before.** A selector that caches wears a `timeout=None`, and every service that writes the same rows wears `@busts_cache(KEY)` from `services/utils.py`. Deferring the delete to commit is the whole point: an immediate delete lets a reader on another connection repopulate the key with the pre-commit value, and nothing busts it a second time, so the stale copy is permanent. The same rule binds management commands — `transaction.on_commit`, not a bare `cache.delete`.
 
 **Permissions.** Admin access is the `app.manage_site` and `app.manage_developers` permissions, carried by the `Admins` and `Developers` groups (provisioned by a `post_migrate` receiver in `signals.py`). Check them with `request.user.has_perm(...)` in views and `{% if perms.app.manage_site %}` in templates — don't wrap either in a selector. Page views use Django's `@permission_required(..., raise_exception=True)`; the JSON API keeps its own `manage_site_required` / `manage_developers_required` decorators, because the built-in renders an HTML 403 where those endpoints must return a JSON body. These are deliberately separate from the auto-generated `add/change/delete/view` permissions that gate Django admin. Full reference: [`docs/wiki/permissions.md`](docs/wiki/permissions.md).
 
@@ -306,7 +306,7 @@ No WebSockets, no Django Channels - just SSE over standard HTTP.
 
 ### LLM Provider
 
-Using **LiteLLM**. The assistant's model resolves from the active Site's admin config (`site_get_model(role="assistant")`), falling back to the `CHAT_MODEL` env var (local dev default: `openai/gpt-4o-mini`, set in docker-compose.yml). To switch providers, change the model string (LiteLLM format).
+Using **LiteLLM**. The assistant's model resolves from the Site's admin config (`site_get_model(role="assistant")`), falling back to the `CHAT_MODEL` env var (local dev default: `openai/gpt-4o-mini`, set in docker-compose.yml). To switch providers, change the model string (LiteLLM format).
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,11 +162,13 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **Never name a data-layer module after the page that consumes it.** Site settings apply app-wide; topic utilities serve both the admin editor and the public flow page. Naming either one `admin` mislocates it the moment a second caller shows up — which is exactly what happened to the module this layout replaced.
 
-**Naming:** services and selectors are `{model_name}_{action}` — `site_get_active`, `topic_create`, `user_identity_merge`, `user_upload_llm_parts`. Allow some liberty when a utility genuinely implicates two models equally. Anything not part of a module's public surface takes a leading underscore.
+**Naming:** services and selectors are `{model_name}_{action}` — `site_get`, `topic_create`, `user_identity_merge`, `user_upload_llm_parts`. Allow some liberty when a utility genuinely implicates two models equally. Anything not part of a module's public surface takes a leading underscore.
 
 **Reads are selectors, writes are services.** `user_list` reads, so it's a selector; `user_developer_toggle` writes, so it's a service.
 
 **Cross-layer constants get their own module**, so no domain module has to import a constant out of another one: cache keys in `app/cache.py`, group and permission names in `app/permissions.py`. Each is read, written, and invalidated from a different layer, and anchoring one to any single consumer makes the other two reach sideways for it.
+
+**Cached reads are invalidated at commit, never before.** A selector that caches wears a `timeout=None`, and every service that writes the same rows wears `@busts(KEY)` from `services/utils.py`. Deferring the delete to commit is the whole point: an immediate delete lets a reader on another connection repopulate the key with the pre-commit value, and nothing busts it a second time, so the stale copy is permanent. The same rule binds management commands — `transaction.on_commit`, not a bare `cache.delete`. Cached values are pickled model instances, so the keys carry a version suffix to bump whenever the model's fields change.
 
 **Permissions.** Admin access is the `app.manage_site` and `app.manage_developers` permissions, carried by the `Admins` and `Developers` groups (provisioned by a `post_migrate` receiver in `signals.py`). Check them with `request.user.has_perm(...)` in views and `{% if perms.app.manage_site %}` in templates — don't wrap either in a selector. Page views use Django's `@permission_required(..., raise_exception=True)`; the JSON API keeps its own `manage_site_required` / `manage_developers_required` decorators, because the built-in renders an HTML 403 where those endpoints must return a JSON body. These are deliberately separate from the auto-generated `add/change/delete/view` permissions that gate Django admin. Full reference: [`docs/wiki/permissions.md`](docs/wiki/permissions.md).
 

--- a/docs/ai-tooling/AGENT_DEV_GUIDE.md
+++ b/docs/ai-tooling/AGENT_DEV_GUIDE.md
@@ -84,7 +84,7 @@ completion_args = {"max_tokens": 1000}
 ```
 
 These are spread into `litellm.completion(...)`. **Don't put `model` here** — you'll get an error if you try.
-The model is supplied to the engine by the endpoint (from the active site's
+The model is supplied to the engine by the endpoint (from the site's
 model config via `site_get_model`), not the agent, and setting it in
 `completion_args` raises.
 

--- a/litigant_portal/app/apps.py
+++ b/litigant_portal/app/apps.py
@@ -11,4 +11,5 @@ class AppConfig(DjangoAppConfig):
         import litigant_portal.app.topic_flow.checks  # noqa: F401
         from litigant_portal.app import signals
 
+        post_migrate.connect(signals.ensure_site_row, sender=self)
         post_migrate.connect(signals.ensure_permission_groups, sender=self)

--- a/litigant_portal/app/apps.py
+++ b/litigant_portal/app/apps.py
@@ -13,3 +13,4 @@ class AppConfig(DjangoAppConfig):
 
         post_migrate.connect(signals.ensure_site_row, sender=self)
         post_migrate.connect(signals.ensure_permission_groups, sender=self)
+        post_migrate.connect(signals.clear_data_model_cache, sender=self)

--- a/litigant_portal/app/cache.py
+++ b/litigant_portal/app/cache.py
@@ -1,0 +1,7 @@
+# The singleton Site row. Read through site_get, dropped on commit by
+# busts_site_cache, and cleared after migrate by ensure_site_row.
+SITE_CACHE_KEY = "site"
+
+# Every Topic in display order. Read through topic_list, dropped on commit
+# by busts_topic_list_cache.
+TOPIC_LIST_CACHE_KEY = "topic_list"

--- a/litigant_portal/app/cache.py
+++ b/litigant_portal/app/cache.py
@@ -1,7 +1,7 @@
-# The singleton Site row. Read through site_get, dropped on commit by
-# busts_site_cache, and cleared after migrate by ensure_site_row.
+# The singleton Site row. Read through site_get, dropped on commit by the
+# busts_cache on the site services, and cleared after migrate by ensure_site_row.
 SITE_CACHE_KEY = "site"
 
 # Every Topic in display order. Read through topic_list, dropped on commit
-# by busts_topic_list_cache.
+# by the busts_cache on the topic services.
 TOPIC_LIST_CACHE_KEY = "topic_list"

--- a/litigant_portal/app/cache.py
+++ b/litigant_portal/app/cache.py
@@ -1,7 +1,10 @@
 # The singleton Site row. Read through site_get, dropped on commit by the
-# busts_cache on the site services, and cleared after migrate by ensure_site_row.
+# busts_cache on the site services.
 SITE_CACHE_KEY = "site"
 
 # Every Topic in display order. Read through topic_list, dropped on commit
 # by the busts_cache on the topic services.
 TOPIC_LIST_CACHE_KEY = "topic_list"
+
+# Keys holding cached model rows.
+DATA_MODEL_CACHE_KEYS = [SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY]

--- a/litigant_portal/app/management/commands/seed_data.py
+++ b/litigant_portal/app/management/commands/seed_data.py
@@ -2,11 +2,8 @@ from django.core.cache import cache
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from litigant_portal.app.models import Site, Topic
-from litigant_portal.app.selectors.site import ACTIVE_SITE_CACHE_KEY
-from litigant_portal.app.selectors.topic_flow import (
-    ACTIVE_SITE_TOPICS_CACHE_KEY,
-)
+from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
+from litigant_portal.app.models import Topic
 
 SEED_TOPICS = [
     {
@@ -71,21 +68,16 @@ SEED_TOPICS = [
 
 
 class Command(BaseCommand):
-    help = "Seed app with an initial site and topics."
+    help = "Seed app with the initial topics."
 
     @transaction.atomic
     def handle(self, *args, **options):
-        if Site.objects.exists():
-            self.stdout.write("Site rows already exist — nothing to seed.")
+        if Topic.objects.exists():
+            self.stdout.write("Topics already exist — nothing to seed.")
             return
-        site = Site.objects.create(name="default", active=True)
         for order, data in enumerate(SEED_TOPICS):
-            Topic.objects.create(site=site, order=order, **data)
-        cache.delete(ACTIVE_SITE_CACHE_KEY)
-        cache.delete(ACTIVE_SITE_TOPICS_CACHE_KEY)
+            Topic.objects.create(order=order, **data)
+        cache.delete(TOPIC_LIST_CACHE_KEY)
         self.stdout.write(
-            self.style.SUCCESS(
-                f"Created active site '{site.name}' "
-                f"with {len(SEED_TOPICS)} topics."
-            )
+            self.style.SUCCESS(f"Created {len(SEED_TOPICS)} topics.")
         )

--- a/litigant_portal/app/management/commands/seed_data.py
+++ b/litigant_portal/app/management/commands/seed_data.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
             return
         for order, data in enumerate(SEED_TOPICS):
             Topic.objects.create(order=order, **data)
-        cache.delete(TOPIC_LIST_CACHE_KEY)
+        transaction.on_commit(lambda: cache.delete(TOPIC_LIST_CACHE_KEY))
         self.stdout.write(
             self.style.SUCCESS(f"Created {len(SEED_TOPICS)} topics.")
         )

--- a/litigant_portal/app/migrations/0012_site_singleton.py
+++ b/litigant_portal/app/migrations/0012_site_singleton.py
@@ -1,0 +1,121 @@
+# Hand-written: Site becomes a singleton (#731). makemigrations produces the
+# schema operations but not the two data steps between them, and without
+# those `migrate` aborts — an environment carrying more than one Site row, or
+# one row whose id is not SITE_ID, fails validating the new check constraint.
+# seed_data mints a random uuid4 on every fresh startup, so every existing
+# environment is in that state.
+
+import uuid
+
+from django.db import migrations, models
+
+SITE_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _prune_extra_sites(apps, schema_editor):
+    """Keep one site — the active one, falling back to the oldest — and
+    cascade-delete the rest with their scoped topics.
+
+    Runs while ``active`` still exists, so before it is removed below.
+    """
+    Site = apps.get_model("app", "Site")
+    sites = Site.objects.using(schema_editor.connection.alias)
+    keeper = (
+        sites.filter(active=True).first()
+        or sites.order_by("created_at").first()
+    )
+    if keeper is None:
+        return
+    deleted, _ = sites.exclude(pk=keeper.pk).delete()
+    # The cascade queues deferred FK trigger events on app_site, and Postgres
+    # refuses to ALTER a table with those pending — which a later operation
+    # does. Flush them inside this transaction.
+    if deleted and schema_editor.connection.vendor == "postgresql":
+        schema_editor.execute("SET CONSTRAINTS ALL IMMEDIATE")
+
+
+def _pin_site_pk(apps, schema_editor):
+    """Move the surviving row onto the fixed singleton id.
+
+    Ordering is load-bearing: this runs after ``Topic.site`` is dropped,
+    otherwise the update trips that foreign key.
+    """
+    Site = apps.get_model("app", "Site")
+    Site.objects.using(schema_editor.connection.alias).update(id=SITE_ID)
+
+
+def _ensure_site_row(apps, schema_editor):
+    """Create the singleton row if the database has none.
+
+    The post_migrate receiver does this too, but a migration that runs with
+    ``run_syncdb`` disabled or inside a test fixture may not fire it, and
+    every read assumes the row exists.
+    """
+    Site = apps.get_model("app", "Site")
+    sites = Site.objects.using(schema_editor.connection.alias)
+    if not sites.exists():
+        sites.create(id=SITE_ID)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('app', '0011_site_permissions_delete_sitemembership'),
+    ]
+
+    operations = [
+        # 1. Collapse to one row while `active` is still available to pick it.
+        migrations.RunPython(
+            _prune_extra_sites, migrations.RunPython.noop, elidable=True
+        ),
+        # 2. Drop the per-site scoping.
+        migrations.RemoveConstraint(
+            model_name='topic',
+            name='unique_site_topic_slug',
+        ),
+        migrations.RemoveField(
+            model_name='topic',
+            name='site',
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='slug',
+            field=models.SlugField(max_length=64, unique=True),
+        ),
+        # 3. Drop the multi-site fields.
+        migrations.RemoveConstraint(
+            model_name='site',
+            name='unique_active_site',
+        ),
+        migrations.RemoveField(
+            model_name='site',
+            name='active',
+        ),
+        migrations.RemoveField(
+            model_name='site',
+            name='name',
+        ),
+        # 4. Pin the survivor onto the fixed id, then enforce it.
+        migrations.RunPython(
+            _pin_site_pk, migrations.RunPython.noop, elidable=True
+        ),
+        migrations.AlterField(
+            model_name='site',
+            name='id',
+            field=models.UUIDField(
+                default=uuid.UUID('00000000-0000-0000-0000-000000000001'),
+                editable=False,
+                primary_key=True,
+                serialize=False,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='site',
+            constraint=models.CheckConstraint(
+                condition=models.Q(('id', SITE_ID)), name='single_site_row'
+            ),
+        ),
+        migrations.RunPython(
+            _ensure_site_row, migrations.RunPython.noop, elidable=True
+        ),
+    ]

--- a/litigant_portal/app/models/site.py
+++ b/litigant_portal/app/models/site.py
@@ -5,13 +5,13 @@ from django.db import models
 from .base import BaseModel
 from .choices import AI_MODEL_CHOICES, JurisdictionLevel, State
 
+SITE_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
 
 class Site(BaseModel):
-    """Site-wide settings. Exactly one row is `active` at a time."""
+    """Site-wide settings. Constrained to a single row."""
 
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    name = models.CharField(max_length=255)
-    active = models.BooleanField(default=False)
+    id = models.UUIDField(primary_key=True, default=SITE_ID, editable=False)
     court_name = models.CharField(max_length=255, blank=True)
     jurisdiction_level = models.CharField(
         max_length=16, blank=True, choices=JurisdictionLevel.choices
@@ -34,10 +34,8 @@ class Site(BaseModel):
 
     class Meta:
         constraints = [
-            models.UniqueConstraint(
-                fields=["active"],
-                condition=models.Q(active=True),
-                name="unique_active_site",
+            models.CheckConstraint(
+                condition=models.Q(id=SITE_ID), name="single_site_row"
             )
         ]
         permissions = [

--- a/litigant_portal/app/models/topic_flow.py
+++ b/litigant_portal/app/models/topic_flow.py
@@ -3,19 +3,13 @@ import uuid
 from django.db import models
 
 from .base import BaseModel
-from .site import Site
 
 
 class Topic(BaseModel):
     """A legal topic the app supports."""
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    site = models.ForeignKey(
-        Site,
-        on_delete=models.CASCADE,
-        related_name="topics",
-    )
-    slug = models.SlugField(max_length=64)
+    slug = models.SlugField(max_length=64, unique=True)
     title = models.CharField(max_length=255)
     subtitle = models.CharField(max_length=255, blank=True)
     description = models.CharField(max_length=255, blank=True)
@@ -26,8 +20,3 @@ class Topic(BaseModel):
 
     class Meta:
         ordering = ["order", "created_at"]
-        constraints = [
-            models.UniqueConstraint(
-                fields=["site", "slug"], name="unique_site_topic_slug"
-            )
-        ]

--- a/litigant_portal/app/selectors/site.py
+++ b/litigant_portal/app/selectors/site.py
@@ -1,41 +1,23 @@
 from django.core.cache import cache
-from django.db.models import QuerySet
-from django.forms.models import model_to_dict
 
+from litigant_portal.app.cache import SITE_CACHE_KEY
 from litigant_portal.app.models import Site
 from litigant_portal.app.models.choices import get_default_model
 
-ACTIVE_SITE_CACHE_KEY = "active_site_data"
 
-
-def site_get_active_data() -> dict | None:
-    """The cached active site's settings."""
-    data = cache.get(ACTIVE_SITE_CACHE_KEY)
-    if data is None:
-        site = Site.objects.filter(active=True).first()
-        if site is None:
-            return None
-        data = {"id": str(site.id)} | model_to_dict(site)
-        cache.set(ACTIVE_SITE_CACHE_KEY, data, timeout=None)
-    return data
+def site_get() -> Site:
+    """The singleton settings row, served from cache."""
+    site = cache.get(SITE_CACHE_KEY)
+    if site is None:
+        site = Site.objects.get()
+        cache.set(SITE_CACHE_KEY, site, timeout=None)
+    return site
 
 
 def site_get_model(*, role: str) -> str:
-    """The active site's AI model for a pipeline role."""
-    data = site_get_active_data() or {}
-    return data.get(f"{role}_model") or get_default_model()
-
-
-def site_list() -> QuerySet[Site]:
-    """Site rows, oldest first."""
-    return Site.objects.order_by("created_at")
-
-
-def site_get(*, site_id) -> Site:
-    """A single site row by id (raises Site.DoesNotExist)."""
-    return Site.objects.get(id=site_id)
-
-
-def site_get_active() -> Site:
-    """The active site row (raises Site.DoesNotExist)."""
-    return Site.objects.get(active=True)
+    """The site's AI model for a pipeline role."""
+    try:
+        site = site_get()
+    except Site.DoesNotExist:
+        return get_default_model()
+    return getattr(site, f"{role}_model") or get_default_model()

--- a/litigant_portal/app/selectors/site.py
+++ b/litigant_portal/app/selectors/site.py
@@ -16,8 +16,4 @@ def site_get() -> Site:
 
 def site_get_model(*, role: str) -> str:
     """The site's AI model for a pipeline role."""
-    try:
-        site = site_get()
-    except Site.DoesNotExist:
-        return get_default_model()
-    return getattr(site, f"{role}_model") or get_default_model()
+    return getattr(site_get(), f"{role}_model") or get_default_model()

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -1,34 +1,18 @@
 from django.core.cache import cache
-from django.db.models import QuerySet
-from django.forms.models import model_to_dict
 
-from litigant_portal.app.models import Site, Topic
-
-ACTIVE_SITE_TOPICS_CACHE_KEY = "active_site_topics"
+from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
+from litigant_portal.app.models import Topic
 
 
-def topic_list(*, site: Site) -> QuerySet[Topic]:
-    """A site's topics in display order (the model's default ordering)."""
-    return site.topics.all()
+def topic_list() -> list[Topic]:
+    """Topics in display order, served from cache."""
+    topics = cache.get(TOPIC_LIST_CACHE_KEY)
+    if topics is None:
+        topics = list(Topic.objects.all())
+        cache.set(TOPIC_LIST_CACHE_KEY, topics, timeout=None)
+    return topics
 
 
-def topic_list_active() -> list[dict]:
-    """The active site's cached topics as plain dicts in display order."""
-    data = cache.get(ACTIVE_SITE_TOPICS_CACHE_KEY)
-    if data is None:
-        site = Site.objects.filter(active=True).first()
-        if site is None:
-            return []
-        data = [
-            {"id": str(topic.id)}
-            | model_to_dict(topic)
-            | {"site": str(site.id)}
-            for topic in topic_list(site=site)
-        ]
-        cache.set(ACTIVE_SITE_TOPICS_CACHE_KEY, data, timeout=None)
-    return data
-
-
-def topic_get(*, site: Site, topic_id) -> Topic:
-    """A single topic within ``site`` (raises Topic.DoesNotExist)."""
-    return site.topics.get(id=topic_id)
+def topic_get(*, topic_id) -> Topic:
+    """A single topic (raises Topic.DoesNotExist)."""
+    return Topic.objects.get(id=topic_id)

--- a/litigant_portal/app/services/site.py
+++ b/litigant_portal/app/services/site.py
@@ -22,7 +22,6 @@ def busts_site_cache(fn):
 @busts_site_cache
 def site_update(
     *,
-    site: Site,
     court_name: str = "",
     jurisdiction_level: str = "",
     state: str = "",
@@ -32,6 +31,7 @@ def site_update(
     assistant_model: str = "",
 ) -> Site:
     """Update the site's editable fields."""
+    site = site_get()
     site.court_name = court_name
     site.jurisdiction_level = jurisdiction_level
     site.state = state

--- a/litigant_portal/app/services/site.py
+++ b/litigant_portal/app/services/site.py
@@ -1,25 +1,11 @@
-from functools import wraps
-
-from django.core.cache import cache
-from django.db import transaction
-
 from litigant_portal.app.cache import SITE_CACHE_KEY
 from litigant_portal.app.models import Site
+from litigant_portal.app.selectors.site import site_get
+
+from .utils import busts_cache
 
 
-def busts_site_cache(fn):
-    """Drop the cached site row once the surrounding transaction commits."""
-
-    @wraps(fn)
-    def wrapped(*args, **kwargs):
-        result = fn(*args, **kwargs)
-        transaction.on_commit(lambda: cache.delete(SITE_CACHE_KEY))
-        return result
-
-    return wrapped
-
-
-@busts_site_cache
+@busts_cache(SITE_CACHE_KEY)
 def site_update(
     *,
     court_name: str = "",

--- a/litigant_portal/app/services/site.py
+++ b/litigant_portal/app/services/site.py
@@ -1,31 +1,28 @@
+from functools import wraps
+
 from django.core.cache import cache
 from django.db import transaction
 
+from litigant_portal.app.cache import SITE_CACHE_KEY
 from litigant_portal.app.models import Site
-from litigant_portal.app.selectors.site import ACTIVE_SITE_CACHE_KEY
-from litigant_portal.app.selectors.topic_flow import (
-    ACTIVE_SITE_TOPICS_CACHE_KEY,
-)
 
 
-def site_activate(*, site: Site) -> Site:
-    """Make ``site`` the single active site row."""
-    with transaction.atomic():
-        Site.objects.filter(active=True).exclude(id=site.id).update(
-            active=False
-        )
-        if not site.active:
-            site.active = True
-            site.save(update_fields=["active", "updated_at"])
-    cache.delete(ACTIVE_SITE_CACHE_KEY)
-    cache.delete(ACTIVE_SITE_TOPICS_CACHE_KEY)
-    return site
+def busts_site_cache(fn):
+    """Drop the cached site row once the surrounding transaction commits."""
+
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        result = fn(*args, **kwargs)
+        transaction.on_commit(lambda: cache.delete(SITE_CACHE_KEY))
+        return result
+
+    return wrapped
 
 
+@busts_site_cache
 def site_update(
     *,
     site: Site,
-    name: str,
     court_name: str = "",
     jurisdiction_level: str = "",
     state: str = "",
@@ -34,8 +31,7 @@ def site_update(
     fast_model: str = "",
     assistant_model: str = "",
 ) -> Site:
-    """Update a site row's editable fields."""
-    site.name = name
+    """Update the site's editable fields."""
     site.court_name = court_name
     site.jurisdiction_level = jurisdiction_level
     site.state = state
@@ -45,7 +41,6 @@ def site_update(
     site.assistant_model = assistant_model
     site.save(
         update_fields=[
-            "name",
             "court_name",
             "jurisdiction_level",
             "state",
@@ -56,5 +51,4 @@ def site_update(
             "updated_at",
         ]
     )
-    cache.delete(ACTIVE_SITE_CACHE_KEY)
     return site

--- a/litigant_portal/app/services/topic_flow.py
+++ b/litigant_portal/app/services/topic_flow.py
@@ -1,24 +1,10 @@
-from functools import wraps
-
-from django.core.cache import cache
-from django.db import transaction
 from django.db.models import Max
 from django.utils.text import slugify
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
 from litigant_portal.app.models import Topic
 
-
-def busts_topic_list_cache(fn):
-    """Drop the cached topic list once the surrounding transaction commits."""
-
-    @wraps(fn)
-    def wrapped(*args, **kwargs):
-        result = fn(*args, **kwargs)
-        transaction.on_commit(lambda: cache.delete(TOPIC_LIST_CACHE_KEY))
-        return result
-
-    return wrapped
+from .utils import busts_cache
 
 
 def _topic_unique_slug(*, title: str) -> str:
@@ -30,7 +16,7 @@ def _topic_unique_slug(*, title: str) -> str:
     return slug
 
 
-@busts_topic_list_cache
+@busts_cache(TOPIC_LIST_CACHE_KEY)
 def topic_create(**fields) -> Topic:
     """Create a topic, appended to the display order."""
     last = Topic.objects.aggregate(m=Max("order"))["m"]
@@ -41,7 +27,7 @@ def topic_create(**fields) -> Topic:
     )
 
 
-@busts_topic_list_cache
+@busts_cache(TOPIC_LIST_CACHE_KEY)
 def topic_update(*, topic: Topic, **fields) -> Topic:
     """Update a topic's editable fields."""
     for name, value in fields.items():
@@ -50,6 +36,6 @@ def topic_update(*, topic: Topic, **fields) -> Topic:
     return topic
 
 
-@busts_topic_list_cache
+@busts_cache(TOPIC_LIST_CACHE_KEY)
 def topic_delete(*, topic: Topic) -> None:
     topic.delete()

--- a/litigant_portal/app/services/topic_flow.py
+++ b/litigant_portal/app/services/topic_flow.py
@@ -1,44 +1,55 @@
+from functools import wraps
+
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Max
 from django.utils.text import slugify
 
-from litigant_portal.app.models import Site, Topic
-from litigant_portal.app.selectors.topic_flow import (
-    ACTIVE_SITE_TOPICS_CACHE_KEY,
-)
+from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
+from litigant_portal.app.models import Topic
 
 
-def _topic_unique_slug(*, site: Site, title: str) -> str:
+def busts_topic_list_cache(fn):
+    """Drop the cached topic list once the surrounding transaction commits."""
+
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        result = fn(*args, **kwargs)
+        transaction.on_commit(lambda: cache.delete(TOPIC_LIST_CACHE_KEY))
+        return result
+
+    return wrapped
+
+
+def _topic_unique_slug(*, title: str) -> str:
     base = slugify(title)[:64] or "topic"
     slug, n = base, 2
-    while Topic.objects.filter(site=site, slug=slug).exists():
+    while Topic.objects.filter(slug=slug).exists():
         suffix = f"-{n}"
         slug, n = base[: 64 - len(suffix)] + suffix, n + 1
     return slug
 
 
-def topic_create(*, site: Site, **fields) -> Topic:
-    """Create a topic in ``site``."""
-    last = site.topics.aggregate(m=Max("order"))["m"]
-    topic = Topic.objects.create(
-        site=site,
-        slug=_topic_unique_slug(site=site, title=fields["title"]),
+@busts_topic_list_cache
+def topic_create(**fields) -> Topic:
+    """Create a topic, appended to the display order."""
+    last = Topic.objects.aggregate(m=Max("order"))["m"]
+    return Topic.objects.create(
+        slug=_topic_unique_slug(title=fields["title"]),
         order=0 if last is None else last + 1,
         **fields,
     )
-    cache.delete(ACTIVE_SITE_TOPICS_CACHE_KEY)
-    return topic
 
 
+@busts_topic_list_cache
 def topic_update(*, topic: Topic, **fields) -> Topic:
     """Update a topic's editable fields."""
     for name, value in fields.items():
         setattr(topic, name, value)
     topic.save(update_fields=[*fields, "updated_at"])
-    cache.delete(ACTIVE_SITE_TOPICS_CACHE_KEY)
     return topic
 
 
+@busts_topic_list_cache
 def topic_delete(*, topic: Topic) -> None:
     topic.delete()
-    cache.delete(ACTIVE_SITE_TOPICS_CACHE_KEY)

--- a/litigant_portal/app/services/utils.py
+++ b/litigant_portal/app/services/utils.py
@@ -1,0 +1,25 @@
+from functools import wraps
+
+from django.core.cache import cache
+from django.db import transaction
+
+
+def busts_cache(*keys: str):
+    """Drop ``keys`` once the surrounding transaction commits.
+
+    Deferring to commit is the point. An immediate delete lets a reader on
+    another connection repopulate the key with the pre-commit value, and
+    nothing busts it a second time — the stale copy is then permanent,
+    because these keys are cached with no timeout.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapped(*args, **kwargs):
+            result = fn(*args, **kwargs)
+            transaction.on_commit(lambda: cache.delete_many(keys))
+            return result
+
+        return wrapped
+
+    return decorator

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -20,19 +20,6 @@ def ensure_site_row(sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs):
     site_model.objects.using(using).get_or_create()
 
 
-def clear_data_model_cache(sender, **kwargs):
-    """Drop the cached model rows after migrate."""
-    try:
-        cache.delete_many(DATA_MODEL_CACHE_KEYS)
-    except Exception:
-        logger.warning(
-            "Could not clear %s after migrate; stale values may be served "
-            "until the next write.",
-            DATA_MODEL_CACHE_KEYS,
-            exc_info=True,
-        )
-
-
 def ensure_permission_groups(
     sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs
 ):
@@ -65,6 +52,19 @@ def ensure_permission_groups(
             )
         # add() already skips rows the group has, and is a no-op when empty.
         group.permissions.add(*permissions)
+
+
+def clear_data_model_cache(sender, **kwargs):
+    """Drop the cached model rows after migrate."""
+    try:
+        cache.delete_many(DATA_MODEL_CACHE_KEYS)
+    except Exception:
+        logger.warning(
+            "Could not clear %s after migrate; stale values may be served "
+            "until the next write.",
+            DATA_MODEL_CACHE_KEYS,
+            exc_info=True,
+        )
 
 
 @receiver(user_logged_in)

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.db import DEFAULT_DB_ALIAS
 from django.dispatch import receiver
 
-from .cache import SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY
+from .cache import DATA_MODEL_CACHE_KEYS
 from .models import Site
 from .permissions import GROUP_PERMISSIONS
 from .services.user import user_identity_merge_anonymous
@@ -15,19 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_site_row(sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs):
-    """Guarantee the singleton site row exists, and drop the cached pickles."""
-    keys = [SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY]
+    """Guarantee the singleton site row exists."""
+    site_model = apps.get_model("app", "Site") if apps else Site
+    site_model.objects.using(using).get_or_create()
+
+
+def clear_data_model_cache(sender, **kwargs):
+    """Drop the cached model rows after migrate."""
     try:
-        cache.delete_many(keys)
+        cache.delete_many(DATA_MODEL_CACHE_KEYS)
     except Exception:
         logger.warning(
             "Could not clear %s after migrate; stale values may be served "
             "until the next write.",
-            keys,
+            DATA_MODEL_CACHE_KEYS,
             exc_info=True,
         )
-    site_model = apps.get_model("app", "Site") if apps else Site
-    site_model.objects.using(using).get_or_create()
 
 
 def ensure_permission_groups(

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -23,6 +23,7 @@ def ensure_site_row(sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs):
             "Could not clear %r after migrate; a stale site may be served "
             "until the next write.",
             SITE_CACHE_KEY,
+            exc_info=True,
         )
     site_model = apps.get_model("app", "Site") if apps else Site
     site_model.objects.using(using).get_or_create()

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -2,13 +2,30 @@ import logging
 
 from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.signals import user_logged_in
+from django.core.cache import cache
 from django.db import DEFAULT_DB_ALIAS
 from django.dispatch import receiver
 
+from .cache import SITE_CACHE_KEY
+from .models import Site
 from .permissions import GROUP_PERMISSIONS
 from .services.user import user_identity_merge_anonymous
 
 logger = logging.getLogger(__name__)
+
+
+def ensure_site_row(sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs):
+    """Guarantee the singleton site row exists, and drop any cached copy."""
+    try:
+        cache.delete(SITE_CACHE_KEY)
+    except Exception:
+        logger.warning(
+            "Could not clear %r after migrate; a stale site may be served "
+            "until the next write.",
+            SITE_CACHE_KEY,
+        )
+    site_model = apps.get_model("app", "Site") if apps else Site
+    site_model.objects.using(using).get_or_create()
 
 
 def ensure_permission_groups(

--- a/litigant_portal/app/signals.py
+++ b/litigant_portal/app/signals.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from django.db import DEFAULT_DB_ALIAS
 from django.dispatch import receiver
 
-from .cache import SITE_CACHE_KEY
+from .cache import SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY
 from .models import Site
 from .permissions import GROUP_PERMISSIONS
 from .services.user import user_identity_merge_anonymous
@@ -15,14 +15,15 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_site_row(sender, using=DEFAULT_DB_ALIAS, apps=None, **kwargs):
-    """Guarantee the singleton site row exists, and drop any cached copy."""
+    """Guarantee the singleton site row exists, and drop the cached pickles."""
+    keys = [SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY]
     try:
-        cache.delete(SITE_CACHE_KEY)
+        cache.delete_many(keys)
     except Exception:
         logger.warning(
-            "Could not clear %r after migrate; a stale site may be served "
+            "Could not clear %s after migrate; stale values may be served "
             "until the next write.",
-            SITE_CACHE_KEY,
+            keys,
             exc_info=True,
         )
     site_model = apps.get_model("app", "Site") if apps else Site

--- a/litigant_portal/app/static/js/admin.js
+++ b/litigant_portal/app/static/js/admin.js
@@ -54,9 +54,6 @@ document.addEventListener('alpine:init', () => {
     showKnowledge: false,
     showSimulate: false,
     // Site settings
-    sites: [],
-    siteId: null,
-    siteName: '',
     siteCourtName: '',
     siteJurisdictionLevel: '',
     siteState: '',
@@ -64,8 +61,6 @@ document.addEventListener('alpine:init', () => {
     siteOfficialResourcesUrl: '',
     siteFastModel: '',
     siteAssistantModel: '',
-    activeSiteName: '',
-    siteMenuOpen: false,
     siteSaved: false,
     siteError: '',
     // Knowledge base tab
@@ -95,7 +90,7 @@ document.addEventListener('alpine:init', () => {
     usersFetchSeq: 0,
 
     init() {
-      this.loadSites()
+      this.loadSite()
       this.loadUsers()
       this.loadTopics()
     },
@@ -118,27 +113,20 @@ document.addEventListener('alpine:init', () => {
 
     // --- Site settings ---
 
-    async loadSites() {
+    async loadSite() {
       try {
-        const res = await fetch('/api/admin/sites/', {
+        const res = await fetch('/api/admin/site/', {
           headers: { Accept: 'application/json' },
         })
         if (!res.ok) throw new Error('Request failed: ' + res.status)
-        const data = await res.json()
-        this.sites = data.sites || []
-        const active = this.sites.find((s) => s.active)
-        this.siteId = active ? active.id : null
-        this.siteName = active ? active.name : ''
-        this.siteCourtName = active ? active.court_name : ''
-        this.siteJurisdictionLevel = active ? active.jurisdiction_level : ''
-        this.siteState = active ? active.state : ''
-        this.siteOfficialUrl = active ? active.official_url : ''
-        this.siteOfficialResourcesUrl = active
-          ? active.official_resources_url
-          : ''
-        this.siteFastModel = (active && active.fast_model) || ''
-        this.siteAssistantModel = (active && active.assistant_model) || ''
-        this.activeSiteName = active ? active.name : ''
+        const site = await res.json()
+        this.siteCourtName = site.court_name
+        this.siteJurisdictionLevel = site.jurisdiction_level
+        this.siteState = site.state
+        this.siteOfficialUrl = site.official_url
+        this.siteOfficialResourcesUrl = site.official_resources_url
+        this.siteFastModel = site.fast_model
+        this.siteAssistantModel = site.assistant_model
       } catch (e) {
         console.error('Failed to load site settings:', e)
       }
@@ -153,10 +141,8 @@ document.addEventListener('alpine:init', () => {
     },
 
     async saveSite() {
-      if (!this.siteId || !this.siteName.trim()) return
       try {
         const body = new FormData()
-        body.append('name', this.siteName.trim())
         body.append('court_name', this.siteCourtName.trim())
         body.append('jurisdiction_level', this.siteJurisdictionLevel)
         body.append('state', this.siteState.trim().toUpperCase())
@@ -168,10 +154,10 @@ document.addEventListener('alpine:init', () => {
         body.append('fast_model', this.siteFastModel)
         body.append('assistant_model', this.siteAssistantModel)
         body.append('csrfmiddlewaretoken', this.csrfToken())
-        const res = await fetch(
-          '/api/admin/sites/' + this.siteId + '/update/',
-          { method: 'POST', body }
-        )
+        const res = await fetch('/api/admin/site/update/', {
+          method: 'POST',
+          body,
+        })
         if (!res.ok) {
           // Surface the server's validation message next to Save.
           const data = await res.json().catch(() => ({}))
@@ -179,40 +165,10 @@ document.addEventListener('alpine:init', () => {
         }
         this.siteSaved = true
         this.siteError = ''
-        await this.loadSites()
+        await this.loadSite()
       } catch (e) {
         console.error('Failed to save site settings:', e)
         this.siteError = e.message
-      }
-    },
-
-    toggleSiteMenu() {
-      this.siteMenuOpen = !this.siteMenuOpen
-    },
-
-    closeSiteMenu() {
-      this.siteMenuOpen = false
-    },
-
-    // Click handler for a switcher row — the site id rides on the element.
-    async activateSite(e) {
-      const siteId = e.currentTarget.dataset.siteId
-      this.siteMenuOpen = false
-      if (!siteId || siteId === this.siteId) return
-      try {
-        const body = new FormData()
-        body.append('csrfmiddlewaretoken', this.csrfToken())
-        const res = await fetch('/api/admin/sites/' + siteId + '/activate/', {
-          method: 'POST',
-          body,
-        })
-        if (!res.ok) throw new Error('Request failed: ' + res.status)
-        this.siteSaved = false
-        await this.loadSites()
-        // Topics belong to the active site — refresh the knowledge base.
-        await this.loadTopics()
-      } catch (e) {
-        console.error('Failed to activate site:', e)
       }
     },
 

--- a/litigant_portal/app/templates/pages/admin/settings.html
+++ b/litigant_portal/app/templates/pages/admin/settings.html
@@ -1,53 +1,11 @@
 {% load i18n %}
 
 <div class="max-w-2xl">
-  {# Header row — title on the left, site switcher on the right #}
   <div class="flex items-center justify-between gap-2 mb-4">
     <h3 class="text-base font-semibold text-greyscale-900">{% trans "Settings" %}</h3>
-    {% if perms.app.manage_developers %}
-    <div class="relative">
-      <button type="button"
-              x-on:click="toggleSiteMenu"
-              x-bind:aria-expanded="siteMenuOpen"
-              aria-haspopup="true"
-              class="inline-flex items-center gap-1.5 rounded-lg border border-greyscale-300 bg-white px-3 py-1.5 text-sm text-greyscale-700 hover:bg-greyscale-100 cursor-pointer transition-colors">
-        <c-atoms.icon name="arrows-right-left" class="w-4 h-4 text-greyscale-500" />
-        <span x-text="activeSiteName"></span>
-        <c-atoms.icon name="chevron-down" class="w-4 h-4 text-greyscale-400" />
-      </button>
-      <div x-show="siteMenuOpen"
-           x-cloak
-           x-on:click.outside="closeSiteMenu"
-           x-on:keydown.escape.window="closeSiteMenu"
-           x-transition
-           class="absolute right-0 top-full mt-1 w-56 bg-white rounded-lg shadow-lg border border-greyscale-200 py-1 z-50"
-           role="menu">
-        <template x-for="site in sites" :key="site.id">
-          <button type="button"
-                  role="menuitem"
-                  x-bind:data-site-id="site.id"
-                  x-on:click="activateSite"
-                  class="flex items-center justify-between gap-2 w-full px-3 py-2 text-sm text-greyscale-700 hover:bg-greyscale-100 cursor-pointer">
-            <span class="truncate" x-text="site.name"></span>
-            <c-atoms.icon name="check" class="w-4 h-4 text-primary-600 flex-shrink-0" x-show="site.active" />
-          </button>
-        </template>
-      </div>
-    </div>
-    {% endif %}
   </div>
-  {# Active site form #}
   <form x-on:submit.prevent="saveSite" class="space-y-4">
     {% csrf_token %}
-    <div>
-      <label for="site-name" class="block text-sm font-medium text-greyscale-700 mb-1">{% trans "Name" %}</label>
-      <input id="site-name"
-             type="text"
-             data-field="siteName"
-             x-bind:value="siteName"
-             x-on:input="updateSiteField"
-             class="block w-full rounded-lg border border-greyscale-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-600">
-    </div>
     {# ------- Court details ------- #}
     <div class="border-t border-greyscale-200 pt-4">
       <h4 class="text-sm font-semibold text-greyscale-900">{% trans "Court details" %}</h4>

--- a/litigant_portal/app/tests/conftest.py
+++ b/litigant_portal/app/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.cache import cache
 
 
 @pytest.fixture(autouse=True)
@@ -10,6 +11,9 @@ def test_cache(settings):
         }
     }
     settings.RATELIMIT_ENABLE = False
+    cache.clear()
+    yield
+    cache.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/litigant_portal/app/tests/test_busts_cache.py
+++ b/litigant_portal/app/tests/test_busts_cache.py
@@ -1,0 +1,76 @@
+"""Tests for the busts_cache decorator itself.
+
+Its callers cover the happy path. What they can't show is the failure side:
+a service that raises must not schedule the delete, and a delete scheduled
+inside a transaction that rolls back must not fire. Both are true by reading
+the code; these pin them.
+
+Dedicated keys rather than the real ones, so nothing here depends on the
+app's own cached state.
+"""
+
+import pytest
+from django.core.cache import cache
+from django.db import transaction
+from django.test import TestCase
+
+from litigant_portal.app.services.utils import busts_cache
+
+KEY_A = "test_busts_a"
+KEY_B = "test_busts_b"
+
+
+@busts_cache(KEY_A, KEY_B)
+def _write():
+    return "written"
+
+
+@busts_cache(KEY_A, KEY_B)
+def _write_then_fail():
+    raise ValueError("service blew up")
+
+
+def _warm():
+    cache.set(KEY_A, "warm", timeout=None)
+    cache.set(KEY_B, "warm", timeout=None)
+
+
+@pytest.mark.postgres
+class BustsCacheTests(TestCase):
+    def test_a_committed_call_drops_every_key(self):
+        _warm()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.assertEqual(_write(), "written")
+        self.assertIsNone(cache.get(KEY_A))
+        self.assertIsNone(cache.get(KEY_B))
+
+    def test_the_delete_waits_for_the_commit(self):
+        _warm()
+        with self.captureOnCommitCallbacks() as callbacks:
+            _write()
+            self.assertEqual(cache.get(KEY_A), "warm")
+        self.assertEqual(len(callbacks), 1)
+
+    def test_a_raising_service_schedules_nothing(self):
+        _warm()
+        with (
+            self.captureOnCommitCallbacks(execute=True) as callbacks,
+            self.assertRaises(ValueError),
+        ):
+            _write_then_fail()
+        self.assertEqual(callbacks, [])
+        self.assertEqual(cache.get(KEY_A), "warm")
+        self.assertEqual(cache.get(KEY_B), "warm")
+
+    def test_a_rolled_back_transaction_leaves_the_cache_warm(self):
+        _warm()
+        with (
+            self.captureOnCommitCallbacks(execute=True) as callbacks,
+            self.assertRaises(ValueError),
+            transaction.atomic(),
+        ):
+            _write()
+            raise ValueError("caller blew up after the service returned")
+        # The write never landed, so the warm copy is still the truth.
+        self.assertEqual(callbacks, [])
+        self.assertEqual(cache.get(KEY_A), "warm")

--- a/litigant_portal/app/tests/test_permissions.py
+++ b/litigant_portal/app/tests/test_permissions.py
@@ -176,14 +176,14 @@ class AdminApiGuardTests(TestCase):
         self.nobody = User.objects.create_user(username="n", password="p")
 
     def test_manage_site_endpoints_reject_users_without_permission(self):
-        for path in ("/api/admin/users/", "/api/admin/sites/"):
+        for path in ("/api/admin/users/", "/api/admin/site/"):
             with self.subTest(path=path):
                 response = client_for(self.nobody).get(path)
                 self.assertEqual(response.status_code, 403)
                 self.assertEqual(response.json()["error"], "Forbidden")
 
     def test_manage_site_endpoints_allow_admins(self):
-        for path in ("/api/admin/users/", "/api/admin/sites/"):
+        for path in ("/api/admin/users/", "/api/admin/site/"):
             with self.subTest(path=path):
                 self.assertEqual(
                     client_for(self.admin).get(path).status_code, 200

--- a/litigant_portal/app/tests/test_signals.py
+++ b/litigant_portal/app/tests/test_signals.py
@@ -1,0 +1,65 @@
+"""Tests for the post_migrate receivers."""
+
+import weakref
+from unittest import mock
+
+import pytest
+from django.core.cache import cache
+from django.db.models.signals import post_migrate
+from django.test import SimpleTestCase, TestCase
+
+from litigant_portal.app.cache import DATA_MODEL_CACHE_KEYS, SITE_CACHE_KEY
+from litigant_portal.app.models import Site
+from litigant_portal.app.signals import clear_data_model_cache, ensure_site_row
+
+
+def _connected_receivers() -> list[str]:
+    """Names of everything wired to post_migrate, in dispatch order."""
+    names = []
+    for entry in post_migrate.receivers:
+        ref = entry[1]
+        fn = ref() if isinstance(ref, weakref.ReferenceType) else ref
+        if fn is not None:
+            names.append(fn.__name__)
+    return names
+
+
+class ClearDataModelCacheTests(SimpleTestCase):
+    def test_every_registered_key_is_dropped(self):
+        for key in DATA_MODEL_CACHE_KEYS:
+            cache.set(key, "stale", timeout=None)
+
+        clear_data_model_cache(sender=None)
+
+        for key in DATA_MODEL_CACHE_KEYS:
+            self.assertIsNone(cache.get(key), key)
+
+    def test_an_unreachable_cache_does_not_abort_the_migrate(self):
+        # Redis may be down when migrate runs, and CI has none at all.
+        with mock.patch("litigant_portal.app.signals.cache") as fake_cache:
+            fake_cache.delete_many.side_effect = ConnectionError("redis down")
+            with self.assertLogs("litigant_portal.app.signals", "WARNING"):
+                clear_data_model_cache(sender=None)
+
+    def test_it_is_wired_to_run_after_the_row_is_ensured(self):
+        # Order matters: the clear has to see whatever the receivers above
+        # it wrote. Checks the wiring, not that migrate dispatches it.
+        connected = _connected_receivers()
+        self.assertIn("clear_data_model_cache", connected)
+        self.assertGreater(
+            connected.index("clear_data_model_cache"),
+            connected.index("ensure_site_row"),
+        )
+
+
+@pytest.mark.postgres
+class EnsureSiteRowTests(TestCase):
+    def test_it_only_touches_the_row(self):
+        # The cache work lives in clear_data_model_cache now.
+        cache.set(SITE_CACHE_KEY, "warm", timeout=None)
+        Site.objects.all().delete()
+
+        ensure_site_row(sender=None, using="default", apps=None)
+
+        self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(cache.get(SITE_CACHE_KEY), "warm")

--- a/litigant_portal/app/tests/test_site_singleton.py
+++ b/litigant_portal/app/tests/test_site_singleton.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 
 from litigant_portal.app.cache import SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY
 from litigant_portal.app.models import Site, Topic
+from litigant_portal.app.models.choices import OpenAIModel, get_default_model
 from litigant_portal.app.models.site import SITE_ID
 from litigant_portal.app.selectors.site import site_get, site_get_model
 from litigant_portal.app.selectors.topic_flow import topic_list
@@ -45,8 +46,9 @@ class SingletonRowTests(TestCase):
 
 @pytest.mark.postgres
 class SiteCacheTests(TestCase):
-    def setUp(self):
-        cache.delete(SITE_CACHE_KEY)
+    # No setUp clearing the key: the autouse test_cache fixture calls
+    # cache.clear() before each test, and pytest sets fixtures up before
+    # unittest's setUp runs.
 
     def test_site_get_populates_the_cache(self):
         self.assertIsNone(cache.get(SITE_CACHE_KEY))
@@ -59,30 +61,39 @@ class SiteCacheTests(TestCase):
         # transaction that never commits, so on_commit hooks would otherwise
         # never run and this would pass for the wrong reason.
         with self.captureOnCommitCallbacks(execute=True):
-            site_update(site=Site.objects.get(), court_name="Cass County")
+            site_update(court_name="Cass County")
         self.assertIsNone(cache.get(SITE_CACHE_KEY))
         self.assertEqual(site_get().court_name, "Cass County")
 
     def test_invalidation_is_deferred_until_commit(self):
         site_get()
         with self.captureOnCommitCallbacks() as callbacks:
-            site_update(site=Site.objects.get(), court_name="Pending")
-            # Queued, not run: a reader racing this transaction must not be
-            # able to repopulate the cache from an uncommitted row.
+            site_update(court_name="Pending")
+            # Queued, not run. Deleting here instead would let a reader on
+            # another connection refill the key with the pre-commit row, and
+            # nothing would bust it again — the keys have no timeout, so that
+            # stale copy would be permanent.
             self.assertIsNotNone(cache.get(SITE_CACHE_KEY))
         self.assertEqual(len(callbacks), 1)
 
     def test_site_get_model_falls_back_when_unset(self):
-        site_update(site=Site.objects.get(), assistant_model="")
-        self.assertTrue(site_get_model(role="assistant"))
+        with self.captureOnCommitCallbacks(execute=True):
+            site_update(assistant_model="")
+        self.assertEqual(site_get_model(role="assistant"), get_default_model())
+
+    def test_site_get_model_prefers_the_configured_model(self):
+        # Not the smallest model of either provider, so it can never be what
+        # get_default_model() would have returned — the assertion below would
+        # otherwise pass on a broken fallback.
+        model = OpenAIModel.GPT_5_5
+        with self.captureOnCommitCallbacks(execute=True):
+            site_update(assistant_model=model)
+        self.assertEqual(site_get_model(role="assistant"), model)
 
 
 @pytest.mark.postgres
 class TopicScopingTests(TestCase):
     """Topics are no longer scoped to a site."""
-
-    def setUp(self):
-        cache.delete(TOPIC_LIST_CACHE_KEY)
 
     def test_topic_needs_no_site(self):
         topic = topic_create(title="Evictions")

--- a/litigant_portal/app/tests/test_site_singleton.py
+++ b/litigant_portal/app/tests/test_site_singleton.py
@@ -1,0 +1,108 @@
+"""Tests for the Site singleton and its cache.
+
+Three invariants: the row always exists, a second row is impossible, and
+the cached copy never outlives a committed write. The last one is the
+subtle case — invalidation is deferred to commit, so the cache stays warm
+inside an open transaction and is dropped only once it lands.
+"""
+
+import uuid
+
+import pytest
+from django.core.cache import cache
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from litigant_portal.app.cache import SITE_CACHE_KEY, TOPIC_LIST_CACHE_KEY
+from litigant_portal.app.models import Site, Topic
+from litigant_portal.app.models.site import SITE_ID
+from litigant_portal.app.selectors.site import site_get, site_get_model
+from litigant_portal.app.selectors.topic_flow import topic_list
+from litigant_portal.app.services.site import site_update
+from litigant_portal.app.services.topic_flow import topic_create
+
+
+@pytest.mark.postgres
+class SingletonRowTests(TestCase):
+    def test_the_row_exists_and_is_pinned(self):
+        # Created by the post_migrate receiver, not by any test fixture.
+        self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Site.objects.get().id, SITE_ID)
+
+    def test_a_second_row_is_rejected_by_the_database(self):
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            Site.objects.create(id=uuid.uuid4())
+
+    def test_a_second_row_is_rejected_even_at_the_pinned_id(self):
+        # The primary key blocks this one rather than the check constraint,
+        # but the outcome callers depend on is the same.
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            Site.objects.create(id=SITE_ID)
+
+    def test_site_get_needs_no_arguments(self):
+        self.assertEqual(site_get().id, SITE_ID)
+
+
+@pytest.mark.postgres
+class SiteCacheTests(TestCase):
+    def setUp(self):
+        cache.delete(SITE_CACHE_KEY)
+
+    def test_site_get_populates_the_cache(self):
+        self.assertIsNone(cache.get(SITE_CACHE_KEY))
+        site_get()
+        self.assertIsNotNone(cache.get(SITE_CACHE_KEY))
+
+    def test_a_committed_write_drops_the_cached_copy(self):
+        site_get()
+        # captureOnCommitCallbacks is required: TestCase wraps each test in a
+        # transaction that never commits, so on_commit hooks would otherwise
+        # never run and this would pass for the wrong reason.
+        with self.captureOnCommitCallbacks(execute=True):
+            site_update(site=Site.objects.get(), court_name="Cass County")
+        self.assertIsNone(cache.get(SITE_CACHE_KEY))
+        self.assertEqual(site_get().court_name, "Cass County")
+
+    def test_invalidation_is_deferred_until_commit(self):
+        site_get()
+        with self.captureOnCommitCallbacks() as callbacks:
+            site_update(site=Site.objects.get(), court_name="Pending")
+            # Queued, not run: a reader racing this transaction must not be
+            # able to repopulate the cache from an uncommitted row.
+            self.assertIsNotNone(cache.get(SITE_CACHE_KEY))
+        self.assertEqual(len(callbacks), 1)
+
+    def test_site_get_model_falls_back_when_unset(self):
+        site_update(site=Site.objects.get(), assistant_model="")
+        self.assertTrue(site_get_model(role="assistant"))
+
+
+@pytest.mark.postgres
+class TopicScopingTests(TestCase):
+    """Topics are no longer scoped to a site."""
+
+    def setUp(self):
+        cache.delete(TOPIC_LIST_CACHE_KEY)
+
+    def test_topic_needs_no_site(self):
+        topic = topic_create(title="Evictions")
+        self.assertEqual(topic.slug, "evictions")
+
+    def test_slug_is_globally_unique(self):
+        topic_create(title="Evictions")
+        second = topic_create(title="Evictions")
+        self.assertEqual(second.slug, "evictions-2")
+
+    def test_duplicate_slug_is_rejected_by_the_database(self):
+        topic_create(title="Evictions")
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            Topic.objects.create(slug="evictions", title="Clash")
+
+    def test_topic_list_is_cached_and_busted_by_writes(self):
+        topic_list()
+        self.assertIsNotNone(cache.get(TOPIC_LIST_CACHE_KEY))
+
+        with self.captureOnCommitCallbacks(execute=True):
+            topic_create(title="Small Claims")
+        self.assertIsNone(cache.get(TOPIC_LIST_CACHE_KEY))
+        self.assertEqual(len(topic_list()), 1)

--- a/litigant_portal/app/tests/test_site_singleton_migration.py
+++ b/litigant_portal/app/tests/test_site_singleton_migration.py
@@ -1,0 +1,110 @@
+"""Tests for migration 0012, which collapses Site to a single row.
+
+_prune_extra_sites and _pin_site_pk are the only new logic in 0012, and
+test_site_singleton.py checks the state they leave behind rather than the
+steps themselves. These drive the migration for real.
+
+TransactionTestCase because migrating is DDL and cannot be rolled back.
+Each test rewinds to 0011, plants rows, migrates forward, asserts. tearDown
+always returns to head -- it runs before the flush, so the flush and its
+post_migrate receivers see the current schema.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from litigant_portal.app.models import Site, Topic
+from litigant_portal.app.models.site import SITE_ID
+
+MIGRATE_FROM = ("app", "0011_site_permissions_delete_sitemembership")
+MIGRATE_TO = ("app", "0012_site_singleton")
+
+
+@pytest.mark.postgres
+class SiteSingletonMigrationTests(TransactionTestCase):
+    def tearDown(self):
+        self._migrate(MIGRATE_TO)
+
+    def _migrate(self, target):
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate([target])
+        return executor
+
+    def _rewind(self):
+        """Unapply 0012 and hand back the historical models at 0011.
+
+        Emptying first is required, not tidiness. Reversing 0012 re-adds
+        Site.name (NOT NULL, blank=False, so the schema editor substitutes
+        NULL rather than "") and Topic.site (NOT NULL FK), and both ALTERs
+        fail on a table with rows. ensure_site_row plants a Site row on every
+        migrate and on every TransactionTestCase flush, so there is always
+        one waiting.
+        """
+        Topic.objects.all().delete()
+        Site.objects.all().delete()
+        executor = self._migrate(MIGRATE_FROM)
+        apps = executor.loader.project_state([MIGRATE_FROM]).apps
+        return apps.get_model("app", "Site"), apps.get_model("app", "Topic")
+
+    def _backdate(self, model, pk, days):
+        """created_at is auto_now_add, so it can only be set after the fact."""
+        model.objects.filter(pk=pk).update(
+            created_at=timezone.now() - timedelta(days=days)
+        )
+
+    def test_the_active_site_survives_and_takes_the_singleton_id(self):
+        old_site, old_topic = self._rewind()
+        stale = old_site.objects.create(name="stale", active=False)
+        old_topic.objects.create(
+            site=stale, slug="eviction", title="Stale Evictions", order=0
+        )
+        live = old_site.objects.create(name="live", active=True)
+        old_topic.objects.create(
+            site=live, slug="eviction", title="Live Evictions", order=0
+        )
+        # The uuid4 that seed_data minted, which 0012 has to repoint.
+        self.assertNotEqual(live.id, SITE_ID)
+
+        self._migrate(MIGRATE_TO)
+
+        self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Site.objects.get().id, SITE_ID)
+        # The slug collided across the two sites, so this also pins the
+        # ordering: pruning has to happen before slug goes unique.
+        self.assertEqual(
+            list(Topic.objects.values_list("title", flat=True)),
+            ["Live Evictions"],
+        )
+
+    def test_the_oldest_site_wins_when_none_is_active(self):
+        old_site, old_topic = self._rewind()
+        first = old_site.objects.create(name="first", active=False)
+        old_topic.objects.create(
+            site=first, slug="eviction", title="First", order=0
+        )
+        second = old_site.objects.create(name="second", active=False)
+        old_topic.objects.create(
+            site=second, slug="eviction", title="Second", order=0
+        )
+        self._backdate(old_site, first.pk, days=2)
+        self._backdate(old_site, second.pk, days=1)
+
+        self._migrate(MIGRATE_TO)
+
+        self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Topic.objects.get().title, "First")
+
+    def test_an_empty_table_gets_the_singleton_row(self):
+        old_site, _ = self._rewind()
+        self.assertEqual(old_site.objects.count(), 0)
+
+        self._migrate(MIGRATE_TO)
+
+        self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Site.objects.get().id, SITE_ID)

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -72,16 +72,11 @@ assistant_patterns = [
 ]
 
 admin_api_patterns = [
-    path("sites/", admin_views.site_list_view, name="site_list"),
+    path("site/", admin_views.site_view, name="site"),
     path(
-        "sites/<uuid:site_id>/update/",
+        "site/update/",
         admin_views.site_update_view,
         name="site_update",
-    ),
-    path(
-        "sites/<uuid:site_id>/activate/",
-        admin_views.site_activate_view,
-        name="site_activate",
     ),
     path("topics/", admin_views.topic_list_view, name="topic_list"),
     path(

--- a/litigant_portal/app/views/admin.py
+++ b/litigant_portal/app/views/admin.py
@@ -95,7 +95,6 @@ def site_update_view(request: HttpRequest) -> JsonResponse:
     return JsonResponse(
         _site_payload(
             site_update(
-                site=site_get(),
                 court_name=court_name,
                 jurisdiction_level=jurisdiction_level,
                 state=state,

--- a/litigant_portal/app/views/admin.py
+++ b/litigant_portal/app/views/admin.py
@@ -16,14 +16,10 @@ from litigant_portal.app.models.choices import (
     OpenAIModel,
     State,
 )
-from litigant_portal.app.selectors.site import (
-    site_get,
-    site_get_active,
-    site_list,
-)
+from litigant_portal.app.selectors.site import site_get
 from litigant_portal.app.selectors.topic_flow import topic_get, topic_list
 from litigant_portal.app.selectors.user import user_get, user_list
-from litigant_portal.app.services.site import site_activate, site_update
+from litigant_portal.app.services.site import site_update
 from litigant_portal.app.services.topic_flow import (
     topic_create,
     topic_delete,
@@ -43,9 +39,6 @@ USERS_PER_PAGE = 20
 
 def _site_payload(site: Site) -> dict:
     return {
-        "id": str(site.id),
-        "name": site.name,
-        "active": site.active,
         "court_name": site.court_name,
         "jurisdiction_level": site.jurisdiction_level,
         "state": site.state,
@@ -59,19 +52,16 @@ def _site_payload(site: Site) -> dict:
 @require_GET
 @ratelimit(key="ip", rate="60/m", method="GET", block=True)
 @manage_site_required
-def site_list_view(request: HttpRequest) -> JsonResponse:
-    """Site rows for the admin settings tab."""
-    return JsonResponse({"sites": [_site_payload(s) for s in site_list()]})
+def site_view(request: HttpRequest) -> JsonResponse:
+    """The site's settings for the admin settings tab."""
+    return JsonResponse(_site_payload(site_get()))
 
 
 @require_POST
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 @manage_site_required
-def site_update_view(request: HttpRequest, site_id) -> JsonResponse:
-    """Update a site row's editable fields."""
-    name = (request.POST.get("name") or "").strip()
-    if not name:
-        return JsonResponse({"error": _("Name is required")}, status=400)
+def site_update_view(request: HttpRequest) -> JsonResponse:
+    """Update the site's editable fields."""
     court_name = (request.POST.get("court_name") or "").strip()
     jurisdiction_level = (request.POST.get("jurisdiction_level") or "").strip()
     if jurisdiction_level and jurisdiction_level not in (
@@ -102,15 +92,10 @@ def site_update_view(request: HttpRequest, site_id) -> JsonResponse:
         if model and model not in valid_models:
             return JsonResponse({"error": _("Invalid model")}, status=400)
         ai_models[field] = model
-    try:
-        site = site_get(site_id=site_id)
-    except Site.DoesNotExist:
-        return JsonResponse({"error": _("Site not found")}, status=404)
     return JsonResponse(
         _site_payload(
             site_update(
-                site=site,
-                name=name,
+                site=site_get(),
                 court_name=court_name,
                 jurisdiction_level=jurisdiction_level,
                 state=state,
@@ -119,18 +104,6 @@ def site_update_view(request: HttpRequest, site_id) -> JsonResponse:
             )
         )
     )
-
-
-@require_POST
-@ratelimit(key="ip", rate="30/m", method="POST", block=True)
-@manage_developers_required
-def site_activate_view(request: HttpRequest, site_id) -> JsonResponse:
-    """Make a site row the single active one. Developers only."""
-    try:
-        site = site_get(site_id=site_id)
-    except Site.DoesNotExist:
-        return JsonResponse({"error": _("Site not found")}, status=404)
-    return JsonResponse(_site_payload(site_activate(site=site)))
 
 
 def _topic_payload(topic: Topic) -> dict:
@@ -178,29 +151,19 @@ def _topic_fields(request: HttpRequest) -> tuple[dict | None, str | None]:
 @ratelimit(key="ip", rate="120/m", method="GET", block=True)
 @manage_site_required
 def topic_list_view(request: HttpRequest) -> JsonResponse:
-    """The active site's topics for the knowledge base tab."""
-    try:
-        site = site_get_active()
-    except Site.DoesNotExist:
-        return JsonResponse({"topics": []})
-    return JsonResponse(
-        {"topics": [_topic_payload(t) for t in topic_list(site=site)]}
-    )
+    """Topics for the knowledge base tab."""
+    return JsonResponse({"topics": [_topic_payload(t) for t in topic_list()]})
 
 
 @require_POST
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 @manage_site_required
 def topic_create_view(request: HttpRequest) -> JsonResponse:
-    """Create a topic in the active site."""
+    """Create a topic."""
     fields, error = _topic_fields(request)
     if error:
         return JsonResponse({"error": error}, status=400)
-    try:
-        site = site_get_active()
-    except Site.DoesNotExist:
-        return JsonResponse({"error": _("No active site")}, status=409)
-    return JsonResponse(_topic_payload(topic_create(site=site, **fields)))
+    return JsonResponse(_topic_payload(topic_create(**fields)))
 
 
 @require_POST
@@ -212,8 +175,8 @@ def topic_update_view(request: HttpRequest, topic_id) -> JsonResponse:
     if error:
         return JsonResponse({"error": error}, status=400)
     try:
-        topic = topic_get(site=site_get_active(), topic_id=topic_id)
-    except (Site.DoesNotExist, Topic.DoesNotExist):
+        topic = topic_get(topic_id=topic_id)
+    except Topic.DoesNotExist:
         return JsonResponse({"error": _("Topic not found")}, status=404)
     return JsonResponse(_topic_payload(topic_update(topic=topic, **fields)))
 
@@ -222,10 +185,10 @@ def topic_update_view(request: HttpRequest, topic_id) -> JsonResponse:
 @ratelimit(key="ip", rate="30/m", method="POST", block=True)
 @manage_site_required
 def topic_delete_view(request: HttpRequest, topic_id) -> JsonResponse:
-    """Delete a topic from the active site."""
+    """Delete a topic."""
     try:
-        topic = topic_get(site=site_get_active(), topic_id=topic_id)
-    except (Site.DoesNotExist, Topic.DoesNotExist):
+        topic = topic_get(topic_id=topic_id)
+    except Topic.DoesNotExist:
         return JsonResponse({"error": _("Topic not found")}, status=404)
     topic_delete(topic=topic)
     return JsonResponse({"deleted": True, "id": str(topic_id)})

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -19,7 +19,7 @@ from litigant_portal.app.models.choices import (
     State,
     get_default_model,
 )
-from litigant_portal.app.selectors.topic_flow import topic_list_active
+from litigant_portal.app.selectors.topic_flow import topic_list
 from litigant_portal.app.topic_flow.answer_store import AnswerStore
 from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
@@ -32,7 +32,7 @@ from litigant_portal.app.topic_flow.validation import validate_answers
 
 def home(request):
     """Home page - dashboard with hero and topic grid."""
-    topics = {t["slug"]: t for t in topic_list_active()}
+    topics = {t.slug: t for t in topic_list()}
     return render(request, "pages/home.html", {"topics": topics})
 
 
@@ -163,7 +163,7 @@ def accessibility(request):
 
 def style_guide(request):
     """Design tokens and component library"""
-    topics = {t["slug"]: t for t in topic_list_active()}
+    topics = {t.slug: t for t in topic_list()}
     return render(request, "pages/style_guide.html", {"topics": topics})
 
 


### PR DESCRIPTION
Fixes #731

This PR does a few things:
- Enforces the existence of exactly one row for the Site model, also removes `name` and `active` from Site (since there's only one now)
- Adds a migration to handle deletion of extra old site rows
- Adds a signal to ensure an initial site row exists (this logic is removed from the `seed_data` command, as this command will be deleted once the topic library #741 lands)
- Removes UI components and endpoints related to toggling the active site.
- Simplified site-related selectors and services to those that deal with a single site.
- Drops the `site` field from the Topic model. All related selectors and services are no longer scoped by site.
- Makes a `cache` module as a place to store cache keys, used by `topic_list` and `site_get`. And adds a decorator pattern for to the topic and site services that can be used to wrap services that modify those objects and therefor need to bust the cache.