### PR TITLE
Add CODEOWNERS, a PR template, and CLA attestation language

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners for litigant-portal.
+#
+# The `main: review + CI` ruleset sets require_code_owner_review, so at least one
+# person listed here must approve before a PR can merge. Any single owner
+# satisfies the requirement, and GitHub requests review from all of them.
+#
+# Two owners minimum, always: GitHub won't let anyone approve their own PR, so a
+# single-owner file would block every PR that owner opens. Admins can bypass;
+# everyone else just gets stuck.
+#
+# Owners must have write access to the repo, and unmatched usernames are ignored
+# silently, which leaves the gate switched on and inert. Verify a change here
+# against a real PR rather than assuming it took.
+#
+# Last matching pattern wins, so any narrower rule added below the catch-all
+# replaces it for those paths instead of adding to it.
+
+* @mitch-mitchel @nicolearagao

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,5 @@
 # Last matching pattern wins, so any narrower rule added below the catch-all
 # replaces it for those paths instead of adding to it.
 
-* @mitch-mitchel @nicolearagao
+* @mitch-mitchel @nicolearagao @nadahlberg
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What changed
+
+<!-- What this PR does. The issue holds the background; keep this to the change itself. -->
+
+Closes #
+
+## Test plan
+
+<!-- How you verified it. Add the checks that matter for this change. -->
+
+- [ ] `make pre-commit` green (lint + full suite)
+
+---
+
+The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Free Law Project requires a signed CLA before a PR can be merged. A bot checks t
 - **Sign here:** [cla-assistant.io/freelawproject/litigant-portal](https://cla-assistant.io/freelawproject/litigant-portal) — one click via GitHub OAuth.
 - **Already signed but the check still shows pending?** The CLA Assistant bot's comment on your PR includes a "Let us recheck it" link — click it to re-verify your signature against that PR.
 - **What it is:** the [Apache Individual Contributor License Agreement V2.0](https://www.apache.org/licenses/icla.pdf), adapted with FLP's names. In return, FLP makes a public-benefit covenant: it "shall not use Your Contributions in a way that is contrary to the public benefit or inconsistent with universal access to public court documents."
+- **What you're asserting.** Signing represents that each contribution is your own work and that you have the right to license it.
 - **You keep your copyright.** This is a license grant, not a copyright assignment — you're licensing FLP to use your contribution, not signing ownership over.
 - **One signature, every FLP repo.** Sign once and it covers all `freelawproject` projects going forward, not just this one.
 


### PR DESCRIPTION
Activates the `require_code_owner_review` gate that the `main` ruleset already had switched on but which matched nobody, adds the repo's first PR template, and states what signing the CLA represents.

The template links the Definition of Done rather than restating the quality bar. The CLA section previously covered signing, copyright retention, and org-wide scope but never what a signature asserts — ICLA §5 lives only in the linked PDF.

Closes #727

Test plan:

- [ ] All three owners spelled correctly and holding write access — unmatched usernames are ignored silently, which would leave the gate inert with no warning
- [ ] Post-merge check: GitHub resolves both CODEOWNERS and the PR template from the **base** branch, so neither can be verified on this PR. The next PR opened after merge is the real test — it should render the template and request code-owner review.