### PR TITLE
feat: audit transcript admin + retention guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ OPENAI_API_KEY=your-openai-api-key-here
 # Chat model (LiteLLM format)
 # CHAT_MODEL=openai/gpt-4o-mini
 
+# Audit retention window in days — cleanup_sessions keeps chat activity this long
+# AUDIT_RETENTION_DAYS=30
+
 # PostgreSQL connection details
 # POSTGRES_HOST=localhost
 # POSTGRES_PORT=5432

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ The repo's reference shelf: material you reach for when you need it. Day-to-day 
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | [SECURITY.md](./wiki/SECURITY.md)                   | Security architecture: production headers, secrets, CSP                                                           |
 | [ai-tone-guide.md](./wiki/ai-tone-guide.md)         | Tone and philosophy for AI-generated user-facing output                                                           |
+| [audit-transcripts.md](./wiki/audit-transcripts.md) | How staff pull AI conversation transcripts, plus the retention policy                                             |
 | [issue-conventions.md](./wiki/issue-conventions.md) | Issue templates, labels, and the reasoning behind them                                                            |
 | [permissions.md](./wiki/permissions.md)             | Admin panel permissions: the two permissions, the two groups, and how to check them                               |
 | [translation.md](./wiki/translation.md)             | gettext infrastructure reference (strategy: [#704](https://github.com/freelawproject/litigant-portal/issues/704)) |

--- a/docs/wiki/audit-transcripts.md
+++ b/docs/wiki/audit-transcripts.md
@@ -1,0 +1,34 @@
+# Pulling AI conversation transcripts (audit log)
+
+Who this is for: FLP staff who need to review AI conversations, for the pilot spot-check or after an incident. No database access or developer help is needed once your account is set up.
+
+## One-time setup
+
+You need a portal account with **staff status**. A developer grants this once (in the Django admin, check "Staff status" on your user). After that, everything below is self-service.
+
+## Pull a transcript
+
+1. Go to `/django-admin/` on the portal and log in.
+2. Click **Chat threads**. Every AI conversation on the site is listed here, newest first.
+3. Find the conversation you need. You can:
+   - **Search** by the user's email address, by session key (for anonymous users), by words in the thread description, or by pasting a full thread ID.
+   - **Filter** by date or thread type using the sidebar.
+4. Click the thread to open it. The page shows who the conversation belongs to, when it started, and the full transcript: user messages, AI answers, tool calls the AI made, and tool results. Rows marked `[hidden]` or `[meta]` were not visible to the user; they are included because an audit needs the complete record.
+5. To save a copy, use the **Downloads** links on the same page:
+   - **Markdown**: a readable transcript, good for review and sharing.
+   - **JSON**: the raw record with timestamps, token counts, and cost, good for deeper analysis or archiving.
+
+Everything is read-only. You cannot change or delete a conversation from this screen.
+
+## Retention
+
+Anonymous conversations are kept for at least **30 days** after their last activity (the `AUDIT_RETENTION_DAYS` setting). The `cleanup_sessions` job never deletes a conversation with activity inside that window. Conversations belonging to logged-in accounts are not deleted by the cleanup job at all. If you need a transcript preserved past the window, download it.
+
+A spot-check has to happen inside that 30-day window, or the transcript has to be downloaded before it closes. Nothing warns you that a conversation is about to age out.
+
+## Known limits
+
+- **Users can delete their own conversations.** The delete button in the portal removes a thread and all its messages immediately and permanently, at any time. The retention window above only protects against the automatic cleanup job, not against the user's own delete. If a transcript matters, download it early. Changing this behavior (for example, hiding a deleted conversation from the user but keeping it for audit) is an open team decision, deliberately deferred.
+- **The system prompt is not stored.** Transcripts show what the user and the AI said, but not the behind-the-scenes instructions the AI had at the time. Those instructions live in code and change with releases.
+- **Session keys are lost at login.** If an anonymous user later logs in, their conversations move to their account and the old session key is discarded. The transcript survives; searching by the old session key will not find it, but searching by their email will.
+- **The whole transcript loads at once.** The page renders every message, with no paging or cap, so a very long conversation makes for a slow page. Use the Markdown download instead if a thread is unwieldy on screen.

--- a/litigant_portal/app/admin.py
+++ b/litigant_portal/app/admin.py
@@ -1,8 +1,22 @@
+import uuid
+
 from django.contrib import admin
+from django.core.exceptions import PermissionDenied
+from django.db.models import Count
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.urls import path, reverse
+from django.utils.html import format_html
 
 from .models import (
+    ChatThread,
     UserIdentity,
     UserProfile,
+)
+from .selectors.chat_engine import (
+    chat_thread_export_data,
+    chat_thread_export_markdown,
+    chat_thread_owner_label,
 )
 
 
@@ -18,3 +32,133 @@ class UserIdentityAdmin(admin.ModelAdmin):
     list_filter = ["created_at"]
     search_fields = ["user__email", "session_key"]
     readonly_fields = ["id", "created_at"]
+
+
+@admin.register(ChatThread)
+class ChatThreadAdmin(admin.ModelAdmin):
+    """Read-only audit surface for AI conversation transcripts."""
+
+    list_display = [
+        "id",
+        "owner",
+        "thread_type",
+        "description",
+        "message_count",
+        "created_at",
+    ]
+    list_filter = ["thread_type", "created_at"]
+    search_fields = [
+        "identity__session_key",
+        "identity__user__email",
+        "description",
+    ]
+    ordering = ["-created_at"]
+    fields = [
+        "id",
+        "owner",
+        "thread_type",
+        "description",
+        "created_at",
+        "updated_at",
+        "downloads",
+        "transcript",
+    ]
+    readonly_fields = fields
+
+    class Media:
+        css = {"all": ["css/audit_admin.css"]}
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("identity__user")
+            .annotate(message_total=Count("messages"))
+        )
+
+    def get_search_results(self, request, queryset, search_term):
+        # UUIDField doesn't support icontains, so match thread ids here.
+        try:
+            return queryset.filter(pk=uuid.UUID(search_term.strip())), False
+        except ValueError:
+            return super().get_search_results(request, queryset, search_term)
+
+    @admin.display(description="Owner")
+    def owner(self, obj):
+        return chat_thread_owner_label(thread=obj)
+
+    @admin.display(description="Messages", ordering="message_total")
+    def message_count(self, obj):
+        return obj.message_total
+
+    @admin.display(description="Downloads")
+    def downloads(self, obj):
+        return format_html(
+            '<a href="{}">Markdown</a> | <a href="{}">JSON</a>',
+            reverse("admin:app_chatthread_transcript_md", args=[obj.pk]),
+            reverse("admin:app_chatthread_transcript_json", args=[obj.pk]),
+        )
+
+    @admin.display(description="Transcript")
+    def transcript(self, obj):
+        return format_html(
+            '<pre class="audit-transcript">{}</pre>',
+            chat_thread_export_markdown(thread=obj),
+        )
+
+    def get_urls(self):
+        custom = [
+            path(
+                "<uuid:pk>/transcript.md",
+                self.admin_site.admin_view(self.transcript_markdown_view),
+                name="app_chatthread_transcript_md",
+            ),
+            path(
+                "<uuid:pk>/transcript.json",
+                self.admin_site.admin_view(self.transcript_json_view),
+                name="app_chatthread_transcript_json",
+            ),
+        ]
+        return custom + super().get_urls()
+
+    def transcript_markdown_view(self, request, pk):
+        thread = get_object_or_404(ChatThread, pk=pk)
+        if not self.has_view_permission(request, thread):
+            raise PermissionDenied
+        response = HttpResponse(
+            chat_thread_export_markdown(thread=thread),
+            content_type="text/markdown; charset=utf-8",
+        )
+        response["Content-Disposition"] = (
+            f'attachment; filename="transcript-{pk}.md"'
+        )
+        return response
+
+    def transcript_json_view(self, request, pk):
+        thread = get_object_or_404(ChatThread, pk=pk)
+        if not self.has_view_permission(request, thread):
+            raise PermissionDenied
+        response = JsonResponse(
+            chat_thread_export_data(thread=thread),
+            json_dumps_params={"indent": 2, "ensure_ascii": False},
+        )
+        response["Content-Disposition"] = (
+            f'attachment; filename="transcript-{pk}.json"'
+        )
+        return response
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    # Transcript review is open to all staff, no per-model perms needed.
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_staff
+
+    def has_module_permission(self, request):
+        return request.user.is_staff

--- a/litigant_portal/app/admin.py
+++ b/litigant_portal/app/admin.py
@@ -121,10 +121,16 @@ class ChatThreadAdmin(admin.ModelAdmin):
         ]
         return custom + super().get_urls()
 
-    def transcript_markdown_view(self, request, pk):
-        thread = get_object_or_404(ChatThread, pk=pk)
+    def _get_thread_or_403(self, request, pk):
+        thread = get_object_or_404(
+            ChatThread.objects.select_related("identity__user"), pk=pk
+        )
         if not self.has_view_permission(request, thread):
             raise PermissionDenied
+        return thread
+
+    def transcript_markdown_view(self, request, pk):
+        thread = self._get_thread_or_403(request, pk)
         response = HttpResponse(
             chat_thread_export_markdown(thread=thread),
             content_type="text/markdown; charset=utf-8",
@@ -135,9 +141,7 @@ class ChatThreadAdmin(admin.ModelAdmin):
         return response
 
     def transcript_json_view(self, request, pk):
-        thread = get_object_or_404(ChatThread, pk=pk)
-        if not self.has_view_permission(request, thread):
-            raise PermissionDenied
+        thread = self._get_thread_or_403(request, pk)
         response = JsonResponse(
             chat_thread_export_data(thread=thread),
             json_dumps_params={"indent": 2, "ensure_ascii": False},

--- a/litigant_portal/app/management/commands/cleanup_sessions.py
+++ b/litigant_portal/app/management/commands/cleanup_sessions.py
@@ -1,14 +1,19 @@
 """
 Management command to clean up old anonymous identities and their associated data.
 
+Identities with chat activity inside the audit retention window
+(settings.AUDIT_RETENTION_DAYS) are never deleted, even with a smaller
+--days, so AI conversation transcripts stay reviewable for that long.
+
 Usage:
-    python manage.py cleanup_sessions           # Dry run (default)
-    python manage.py cleanup_sessions --delete  # Actually delete
-    python manage.py cleanup_sessions --days=7  # Identities older than 7 days
+    python manage.py cleanup_sessions             # Dry run (default)
+    python manage.py cleanup_sessions --delete    # Actually delete
+    python manage.py cleanup_sessions --days=60   # Delete identities older than 60 days
 """
 
 from datetime import timedelta
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -16,14 +21,21 @@ from litigant_portal.app.models import UserIdentity
 
 
 class Command(BaseCommand):
-    help = "Clean up old anonymous user identities (and their chat threads and uploads)"
+    help = (
+        "Clean up anonymous user identities (and their chat threads and "
+        "uploads) outside the audit retention window"
+    )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--days",
             type=int,
-            default=30,
-            help="Delete identities older than this many days (default: 30)",
+            default=None,
+            help=(
+                "Delete identities older than this many days "
+                "(default: settings.AUDIT_RETENTION_DAYS). Never shrinks "
+                "the audit guard on chat activity below that setting."
+            ),
         )
         parser.add_argument(
             "--delete",
@@ -33,20 +45,32 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         days = options["days"]
+        if days is None:
+            days = settings.AUDIT_RETENTION_DAYS
         delete = options["delete"]
-        cutoff = timezone.now() - timedelta(days=days)
+        now = timezone.now()
+        cutoff = now - timedelta(days=days)
+        guard_days = max(days, settings.AUDIT_RETENTION_DAYS)
+        guard_cutoff = now - timedelta(days=guard_days)
+        if guard_days > days:
+            self.stdout.write(
+                f"--days={days} is below AUDIT_RETENTION_DAYS="
+                f"{settings.AUDIT_RETENTION_DAYS}; identities with chat "
+                f"activity in the last {guard_days} days are kept."
+            )
 
         old_identities = UserIdentity.objects.filter(
             user__isnull=True,
             created_at__lt=cutoff,
-        )
+        ).exclude(chat_threads__messages__created_at__gte=guard_cutoff)
 
         count = old_identities.count()
 
         if count == 0:
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"No anonymous identities older than {days} days found."
+                    f"No anonymous identities outside the {days}-day "
+                    f"retention window."
                 )
             )
             return
@@ -63,7 +87,7 @@ class Command(BaseCommand):
                 self.style.WARNING(
                     f"DRY RUN: Would delete {count} anonymous identities "
                     f"({thread_count} chat threads, {upload_count} uploads) "
-                    f"older than {days} days.\n"
+                    f"outside the {days}-day retention window.\n"
                     f"Run with --delete to actually remove them."
                 )
             )

--- a/litigant_portal/app/selectors/chat_engine.py
+++ b/litigant_portal/app/selectors/chat_engine.py
@@ -72,6 +72,7 @@ def chat_thread_export_data(*, thread: ChatThread) -> dict:
         "updated_at": thread.updated_at.isoformat(),
         "owner": {
             "user_email": identity.user.email if identity.user_id else None,
+            "username": identity.user.username if identity.user_id else None,
             "session_key": identity.session_key,
         },
         "messages": [

--- a/litigant_portal/app/selectors/chat_engine.py
+++ b/litigant_portal/app/selectors/chat_engine.py
@@ -49,6 +49,90 @@ def chat_message_list(
     return messages
 
 
+def chat_thread_owner_label(*, thread: ChatThread) -> str:
+    """The review label for a thread's owner: email or session key."""
+    identity = thread.identity
+    if identity.user_id:
+        return identity.user.email or identity.user.username
+    return f"anonymous (session {identity.session_key})"
+
+
+def chat_thread_export_data(*, thread: ChatThread) -> dict:
+    """Full-fidelity audit export: thread metadata plus every message row.
+
+    Built from raw ChatMessage.data with hidden and meta rows included. The
+    frontend render path (thread_render_items) is lossy and unsuitable here.
+    """
+    identity = thread.identity
+    return {
+        "thread_id": str(thread.id),
+        "thread_type": thread.thread_type,
+        "description": thread.description,
+        "created_at": thread.created_at.isoformat(),
+        "updated_at": thread.updated_at.isoformat(),
+        "owner": {
+            "user_email": identity.user.email if identity.user_id else None,
+            "session_key": identity.session_key,
+        },
+        "messages": [
+            {
+                "id": str(m.id),
+                "created_at": m.created_at.isoformat(),
+                "hidden": m.hidden,
+                "meta": m.meta,
+                "num_tokens": m.num_tokens,
+                "cost": m.cost,
+                "data": dict(m.data),
+            }
+            for m in chat_message_list(thread=thread)
+        ],
+    }
+
+
+def chat_thread_export_markdown(*, thread: ChatThread) -> str:
+    """Human-readable audit transcript of every message row."""
+    export = chat_thread_export_data(thread=thread)
+    lines = [
+        f"# Chat transcript {export['thread_id']}",
+        "",
+        f"- Owner: {chat_thread_owner_label(thread=thread)}",
+        f"- Started: {export['created_at']}",
+        f"- Description: {export['description'] or '(none)'}",
+    ]
+    for msg in export["messages"]:
+        lines.append("")
+        lines.extend(_message_lines(msg))
+    return "\n".join(lines) + "\n"
+
+
+def _message_lines(msg: dict) -> list[str]:
+    data = msg["data"]
+    role = data.get("role", "unknown")
+    heading = role
+    if role == "tool":
+        heading = f"tool result: {data.get('name', 'unknown')}"
+    elif role == "meta":
+        heading = f"meta: {data.get('kind', 'unknown')}"
+    flags = [flag for flag in ("hidden", "meta") if msg[flag]]
+    if flags:
+        heading += " [" + ", ".join(flags) + "]"
+    lines = [f"## {heading} ({msg['created_at']})"]
+    if data.get("content"):
+        lines += ["", data["content"]]
+    for call in data.get("tool_calls") or []:
+        function = call.get("function", {})
+        name = function.get("name", "unknown")
+        lines += ["", f"Tool call: {name}({function.get('arguments', '')})"]
+    if data.get("attachments"):
+        lines += ["", f"Attachments: {', '.join(data['attachments'])}"]
+    if role == "meta":
+        lines += [
+            "",
+            f"(accounting only: {msg['num_tokens']} tokens, cost {msg['cost']})",
+        ]
+    return lines
+
+
 def chat_thread_usage(*, thread: ChatThread) -> dict:
     """Total tokens and cost across all of a thread's messages (incl.
     hidden and meta)."""

--- a/litigant_portal/app/static/css/audit_admin.css
+++ b/litigant_portal/app/static/css/audit_admin.css
@@ -1,0 +1,8 @@
+/* Transcript block on the read-only ChatThread admin page. */
+.audit-transcript {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 40em;
+  overflow-y: auto;
+  margin: 0;
+}

--- a/litigant_portal/app/tests/test_audit_admin.py
+++ b/litigant_portal/app/tests/test_audit_admin.py
@@ -1,0 +1,155 @@
+"""Tests for the read-only audit transcript surface in the Django admin."""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+
+from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+
+User = get_user_model()
+
+
+@pytest.mark.postgres
+class AuditAdminTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.staff = User.objects.create_user(
+            username="staff", password="pw", is_staff=True
+        )
+        self.identity = UserIdentity.objects.create(session_key="anon-key-1")
+        self.thread = ChatThread.objects.create(
+            identity=self.identity, description="Eviction help"
+        )
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "I got an eviction notice"},
+        )
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={
+                "role": "assistant",
+                "content": "Let me look that up.",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_topics",
+                            "arguments": '{"query": "eviction"}',
+                        },
+                    }
+                ],
+            },
+        )
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "name": "search_topics",
+                "content": "Found the housing topic.",
+                "data": {},
+            },
+        )
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "injected context"},
+            hidden=True,
+        )
+        self.base_url = f"/django-admin/app/chatthread/{self.thread.pk}"
+        self.client.login(username="staff", password="pw")
+
+    def test_admin_index_links_to_chat_threads_for_bare_staff(self):
+        response = self.client.get("/django-admin/")
+        self.assertContains(response, "/django-admin/app/chatthread/")
+
+    def test_changelist_lists_thread_with_owner(self):
+        response = self.client.get("/django-admin/app/chatthread/")
+        self.assertContains(response, "Eviction help")
+        self.assertContains(response, "anon-key-1")
+
+    def test_view_page_renders_full_transcript(self):
+        response = self.client.get(f"{self.base_url}/change/")
+        self.assertContains(response, "I got an eviction notice")
+        self.assertContains(response, "Tool call: search_topics")
+        self.assertContains(response, "Found the housing topic.")
+        self.assertContains(response, "[hidden]")
+        self.assertContains(response, "injected context")
+
+    def test_search_finds_threads_by_email_and_session_key(self):
+        owner = User.objects.create_user(
+            username="litigant", email="litigant@example.com", password="pw"
+        )
+        ChatThread.objects.create(
+            identity=UserIdentity.objects.create(user=owner),
+            description="Account holder thread",
+        )
+        changelist = "/django-admin/app/chatthread/"
+
+        by_email = self.client.get(changelist, {"q": "litigant@example.com"})
+        self.assertContains(by_email, "Account holder thread")
+        self.assertNotContains(by_email, "Eviction help")
+
+        by_session = self.client.get(changelist, {"q": "anon-key-1"})
+        self.assertContains(by_session, "Eviction help")
+        self.assertNotContains(by_session, "Account holder thread")
+
+    def test_search_finds_thread_by_uuid(self):
+        response = self.client.get(
+            "/django-admin/app/chatthread/", {"q": str(self.thread.pk)}
+        )
+        self.assertContains(response, "Eviction help")
+
+    def test_markdown_download(self):
+        response = self.client.get(f"{self.base_url}/transcript.md")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("attachment", response["Content-Disposition"])
+        content = response.content.decode()
+        self.assertIn("anonymous (session anon-key-1)", content)
+        self.assertIn("Tool call: search_topics", content)
+        self.assertIn("[hidden]", content)
+
+    def test_json_download_is_full_fidelity(self):
+        response = self.client.get(f"{self.base_url}/transcript.json")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("attachment", response["Content-Disposition"])
+        export = json.loads(response.content)
+        self.assertEqual(export["thread_id"], str(self.thread.pk))
+        self.assertEqual(export["owner"]["session_key"], "anon-key-1")
+        roles = [m["data"]["role"] for m in export["messages"]]
+        self.assertEqual(roles, ["user", "assistant", "tool", "user"])
+        self.assertTrue(export["messages"][3]["hidden"])
+        self.assertTrue(all("created_at" in m for m in export["messages"]))
+        tool_calls = export["messages"][1]["data"]["tool_calls"]
+        self.assertEqual(tool_calls[0]["function"]["name"], "search_topics")
+
+    def test_json_download_keeps_non_ascii_text_readable(self):
+        ChatMessage.objects.create(
+            thread=self.thread,
+            data={"role": "user", "content": "¿Cómo respondo al desalojo?"},
+        )
+        response = self.client.get(f"{self.base_url}/transcript.json")
+        self.assertIn("¿Cómo respondo al desalojo?", response.content.decode())
+
+    def test_thread_is_read_only(self):
+        response = self.client.post(
+            f"{self.base_url}/change/", {"description": "edited"}
+        )
+        self.assertEqual(response.status_code, 403)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.description, "Eviction help")
+
+    def test_non_staff_is_rejected(self):
+        User.objects.create_user(username="litigant", password="pw")
+        self.client.logout()
+        self.client.login(username="litigant", password="pw")
+        for url in [
+            "/django-admin/app/chatthread/",
+            f"{self.base_url}/transcript.md",
+            f"{self.base_url}/transcript.json",
+        ]:
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("/django-admin/login/", response["Location"])

--- a/litigant_portal/app/tests/test_audit_export.py
+++ b/litigant_portal/app/tests/test_audit_export.py
@@ -122,6 +122,15 @@ class ThreadExportTests(TestCase):
             export["updated_at"], self.thread.updated_at.isoformat()
         )
 
+    def test_json_owner_carries_username_when_email_is_blank(self):
+        user = User.objects.create_user(username="no-email", password="pw")
+        thread = ChatThread.objects.create(
+            identity=UserIdentity.objects.create(user=user)
+        )
+        owner = chat_thread_export_data(thread=thread)["owner"]
+        self.assertEqual(owner["user_email"], "")
+        self.assertEqual(owner["username"], "no-email")
+
     def test_json_export_carries_token_and_cost_fields(self):
         self._message(
             {"role": "assistant", "content": "Here is what to do."},

--- a/litigant_portal/app/tests/test_audit_export.py
+++ b/litigant_portal/app/tests/test_audit_export.py
@@ -1,0 +1,135 @@
+"""Tests for the audit transcript export functions."""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+from litigant_portal.app.selectors.chat_engine import (
+    chat_thread_export_data,
+    chat_thread_export_markdown,
+    chat_thread_owner_label,
+)
+
+User = get_user_model()
+
+
+@pytest.mark.postgres
+class ThreadOwnerLabelTests(TestCase):
+    def _thread_for(self, identity):
+        return ChatThread.objects.create(identity=identity)
+
+    def test_uses_email_for_a_logged_in_owner(self):
+        user = User.objects.create_user(
+            username="litigant", email="litigant@example.com", password="pw"
+        )
+        thread = self._thread_for(UserIdentity.objects.create(user=user))
+        self.assertEqual(
+            chat_thread_owner_label(thread=thread), "litigant@example.com"
+        )
+
+    def test_falls_back_to_username_when_email_is_blank(self):
+        user = User.objects.create_user(username="no-email", password="pw")
+        thread = self._thread_for(UserIdentity.objects.create(user=user))
+        self.assertEqual(chat_thread_owner_label(thread=thread), "no-email")
+
+    def test_labels_an_anonymous_owner_by_session_key(self):
+        identity = UserIdentity.objects.create(session_key="anon-key-1")
+        thread = self._thread_for(identity)
+        self.assertEqual(
+            chat_thread_owner_label(thread=thread),
+            "anonymous (session anon-key-1)",
+        )
+
+
+@pytest.mark.postgres
+class ThreadExportTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="anon-key-1")
+        self.thread = ChatThread.objects.create(
+            identity=self.identity, description="Eviction help"
+        )
+
+    def _message(self, data, **kwargs):
+        return ChatMessage.objects.create(
+            thread=self.thread, data=data, **kwargs
+        )
+
+    def test_markdown_renders_meta_rows_with_accounting(self):
+        self._message(
+            {"role": "meta", "kind": "thread_description"},
+            meta=True,
+            num_tokens=42,
+            cost=0.0007,
+        )
+        markdown = chat_thread_export_markdown(thread=self.thread)
+        self.assertIn("## meta: thread_description [meta]", markdown)
+        self.assertIn("(accounting only: 42 tokens, cost 0.0007)", markdown)
+
+    def test_markdown_lists_user_attachments(self):
+        self._message(
+            {
+                "role": "user",
+                "content": "here is my notice",
+                "attachments": ["notice.pdf", "lease.pdf"],
+            }
+        )
+        markdown = chat_thread_export_markdown(thread=self.thread)
+        self.assertIn("Attachments: notice.pdf, lease.pdf", markdown)
+
+    def test_markdown_renders_a_tool_call_with_empty_content(self):
+        self._message(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "search_topics",
+                            "arguments": '{"query": "eviction"}',
+                        },
+                    }
+                ],
+            }
+        )
+        markdown = chat_thread_export_markdown(thread=self.thread)
+        self.assertIn("## assistant (", markdown)
+        self.assertIn(
+            'Tool call: search_topics({"query": "eviction"})', markdown
+        )
+
+    def test_markdown_names_the_tool_behind_a_result_row(self):
+        self._message(
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "name": "search_topics",
+                "content": "Found the housing topic.",
+                "data": {},
+            }
+        )
+        markdown = chat_thread_export_markdown(thread=self.thread)
+        self.assertIn("## tool result: search_topics", markdown)
+
+    def test_export_carries_thread_timestamps(self):
+        export = chat_thread_export_data(thread=self.thread)
+        self.assertEqual(
+            export["created_at"], self.thread.created_at.isoformat()
+        )
+        self.assertEqual(
+            export["updated_at"], self.thread.updated_at.isoformat()
+        )
+
+    def test_json_export_carries_token_and_cost_fields(self):
+        self._message(
+            {"role": "assistant", "content": "Here is what to do."},
+            num_tokens=120,
+            cost=0.0031,
+        )
+        message = chat_thread_export_data(thread=self.thread)["messages"][0]
+        self.assertEqual(message["num_tokens"], 120)
+        self.assertEqual(message["cost"], 0.0031)
+        self.assertFalse(message["hidden"])
+        self.assertFalse(message["meta"])

--- a/litigant_portal/app/tests/test_cleanup_sessions.py
+++ b/litigant_portal/app/tests/test_cleanup_sessions.py
@@ -4,11 +4,17 @@ from datetime import timedelta
 from io import StringIO
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from litigant_portal.app.models import ChatThread, UserIdentity, UserUpload
+from litigant_portal.app.models import (
+    ChatMessage,
+    ChatThread,
+    UserIdentity,
+    UserUpload,
+)
 
 
 def _run(*args):
@@ -34,12 +40,22 @@ class CleanupSessionsTests(TestCase):
         )
         self.fresh = UserIdentity.objects.create(session_key="fresh")
 
+    def _add_message(self, days_ago=0):
+        message = ChatMessage.objects.create(
+            thread=self.thread, data={"role": "user", "content": "hi"}
+        )
+        ChatMessage.objects.filter(pk=message.pk).update(
+            created_at=timezone.now() - timedelta(days=days_ago)
+        )
+        return message
+
     def test_dry_run_reports_counts_without_deleting(self):
         output = _run()
         self.assertIn("DRY RUN", output)
         self.assertIn("1 anonymous identities", output)
         self.assertIn("1 chat threads", output)
         self.assertIn("1 uploads", output)
+        self.assertIn("30-day retention window", output)
         self.assertTrue(UserIdentity.objects.filter(pk=self.stale.pk).exists())
 
     def test_delete_removes_stale_identity_and_data(self):
@@ -55,3 +71,51 @@ class CleanupSessionsTests(TestCase):
         UserIdentity.objects.filter(pk=self.stale.pk).delete()
         output = _run()
         self.assertIn("No anonymous identities", output)
+
+    def test_recent_chat_activity_keeps_old_identity(self):
+        self._add_message(days_ago=1)
+        _run("--delete")
+        self.assertTrue(UserIdentity.objects.filter(pk=self.stale.pk).exists())
+        self.assertTrue(ChatThread.objects.filter(pk=self.thread.pk).exists())
+
+    def test_old_chat_activity_does_not_keep_identity(self):
+        self._add_message(days_ago=45)
+        _run("--delete")
+        self.assertFalse(
+            UserIdentity.objects.filter(pk=self.stale.pk).exists()
+        )
+
+    def test_identity_with_a_user_is_never_deleted(self):
+        user = get_user_model().objects.create_user(
+            username="litigant", password="pw"
+        )
+        owned = UserIdentity.objects.create(user=user)
+        UserIdentity.objects.filter(pk=owned.pk).update(
+            created_at=timezone.now() - timedelta(days=365)
+        )
+        _run("--delete")
+        self.assertTrue(UserIdentity.objects.filter(pk=owned.pk).exists())
+
+    def test_days_flag_cannot_shrink_the_audit_window(self):
+        self._add_message(days_ago=10)
+        output = _run("--days=7", "--delete")
+        self.assertIn("below AUDIT_RETENTION_DAYS", output)
+        self.assertTrue(UserIdentity.objects.filter(pk=self.stale.pk).exists())
+        self.assertTrue(ChatThread.objects.filter(pk=self.thread.pk).exists())
+
+    def test_small_days_flag_still_deletes_quiet_identities(self):
+        self._add_message(days_ago=40)
+        _run("--days=7", "--delete")
+        self.assertFalse(
+            UserIdentity.objects.filter(pk=self.stale.pk).exists()
+        )
+
+    def test_default_window_comes_from_settings(self):
+        with override_settings(AUDIT_RETENTION_DAYS=15):
+            output = _run()
+        self.assertIn("15-day retention window", output)
+
+    def test_days_flag_overrides_settings(self):
+        output = _run("--days=200")
+        self.assertIn("No anonymous identities", output)
+        self.assertIn("200-day retention window", output)

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -351,3 +351,6 @@ DEFAULT_CHAT_AGENT = os.environ.get(
 CHAT_MODEL = os.environ.get(
     "CHAT_MODEL", "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
 )
+
+# Audit window: cleanup_sessions keeps chat activity this many days.
+AUDIT_RETENTION_DAYS = int(os.environ.get("AUDIT_RETENTION_DAYS", "30"))


### PR DESCRIPTION
Makes AI conversation transcripts retrievable by FLP staff before the September pilot, per the decisions posted on the issue:

- **Read-only "Chat threads" section in the Django admin.** Lists every AI conversation, searchable by user email, session key, thread description, or thread ID, filterable by date and thread type. The detail page shows the full transcript inline (user messages, AI answers, tool calls, tool results, and `[hidden]`/`[meta]` rows) with Markdown and JSON downloads. Any `is_staff` account can view; add/change/delete are blocked.
- **Export selectors** (`chat_thread_export_data`, `chat_thread_export_markdown`, `chat_thread_owner_label` in `selectors/chat_engine.py`), built from raw `ChatMessage.data` rather than the lossy frontend render path. JSON is the full-fidelity record (timestamps, token counts, cost, structured tool data); Markdown is the readable view.
- **Retention guard.** New `AUDIT_RETENTION_DAYS` setting (default 30, matching the command's previous default, so no privacy regression). `cleanup_sessions` never deletes an anonymous identity with chat activity inside the window, even when run with a smaller `--days`.
- **Staff doc**: `docs/wiki/audit-transcripts.md` covers pulling a transcript step by step, the retention policy, and known limits (user-initiated hard delete is deliberately deferred; prompts are not stored; session keys are lost at login merge).

## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

Part of # 745

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)
- [ ] Catie or Jessica pulls one transcript end-to-end using the wiki steps (issue DoD, before go/no-go)
<img width="1240" height="326" alt="Screenshot From 2026-08-11 17-15-20" src="https://github.com/user-attachments/assets/36cdb760-7f03-4560-b02e-f1f4a58e136a" />
<img width="1417" height="886" alt="Screenshot From 2026-08-11 17-15-40" src="https://github.com/user-attachments/assets/c181b130-dff8-43a8-944f-2833f385a41d" />

Json/Markdown files exports Examples
[transcript-2fa19002-9396-4237-8d89-bb6f51d7d5cf.json](https://github.com/user-attachments/files/30952457/transcript-2fa19002-9396-4237-8d89-bb6f51d7d5cf.json)
[transcript-2fa19002-9396-4237-8d89-bb6f51d7d5cf.md](https://github.com/user-attachments/files/30952458/transcript-2fa19002-9396-4237-8d89-bb6f51d7d5cf.md)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.

## Review notes

- Session keys of anonymous users appear in full in the admin and in downloaded exports; whether to truncate them is an open decision for the demo (see the known-limits comment on #745).
- User-initiated deletion still hard-deletes threads at any time; the guard only covers the cleanup job. Team decision pending, documented in the wiki page.
