### PR TITLE
docs(ci): name pinned and the assignee exemption in stale messages

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
           stale-issue-label: 'stale'
           stale-issue-message: >
             This issue has had no activity for 90 days. It will be
-            closed in 14 days unless there is new activity or it is
-            explicitly marked to keep open.
+            closed in 14 days unless there is new activity, it is
+            assigned to someone, or it is labeled `pinned`.
           close-issue-message: >
             Closed due to inactivity. Feel free to reopen if this is
             still relevant.
@@ -33,7 +33,8 @@ jobs:
           stale-pr-label: 'stale'
           stale-pr-message: >
             This PR has had no activity for 30 days. It will be closed
-            in 7 days unless updated.
+            in 7 days unless it is updated, it is assigned to someone,
+            or it is labeled `pinned`.
           close-pr-message: >
             Closed due to inactivity. Feel free to reopen if you'd
             like to continue this work.


### PR DESCRIPTION
The stale bot told people to mark an issue "explicitly marked to keep open," but no such label exists in `exempt-issue-labels`. Both messages now name `pinned`, and the issue message also names the assignee exemption, which `exempt-all-assignees: true` provides but nothing advertised.

Wording only. Thresholds, `exempt-issue-labels`, and `exempt-pr-labels` are untouched, so no issue or PR changes its stale posture.

Closes #793

Test plan:

- No behavior change to verify — the diff touches only `stale-issue-message` and `stale-pr-message` string values
- `lint` covers YAML validity
- Next scheduled run (Mondays 9am CT) or a manual `workflow_dispatch` will show the new wording on any newly-marked item
