### PR TITLE
fix(audit): truncate anonymous session keys

### DIFF
--- a/docs/wiki/audit-transcripts.md
+++ b/docs/wiki/audit-transcripts.md
@@ -28,7 +28,7 @@ The reason is that a session key is the value of that visitor's browser cookie. 
 
 What this means in practice:
 
-- **Searching still works with the whole key.** If you already have a full session key, paste it into the search box and it will find the thread. Search matches the stored value; the page just never prints it.
+- **Searching still works with the whole key.** If you already have a full session key, paste it into the search box and it will find the thread. Search matches the stored value, and the box echoes back what you typed, but the key is never printed in a thread listing or a download.
 - **To tie several conversations to the same visitor, use the identity ID, not the shortened key.** The JSON download carries it as `owner.identity_id`. Matching identity IDs mean the same visitor. Matching 8-character keys are a hint, not proof.
 
 ## Retention

--- a/docs/wiki/audit-transcripts.md
+++ b/docs/wiki/audit-transcripts.md
@@ -11,7 +11,7 @@ You need a portal account with **staff status**. A developer grants this once (i
 1. Go to `/django-admin/` on the portal and log in.
 2. Click **Chat threads**. Every AI conversation on the site is listed here, newest first.
 3. Find the conversation you need. You can:
-   - **Search** by the user's email address, by session key (for anonymous users), by words in the thread description, or by pasting a full thread ID.
+   - **Search** by the user's email address, by session key (for anonymous users), by words in the thread description, or by pasting a full thread ID. Session key search matches the whole key, even though only the first 8 characters are ever displayed (see [Session keys](#session-keys)).
    - **Filter** by date or thread type using the sidebar.
 4. Click the thread to open it. The page shows who the conversation belongs to, when it started, and the full transcript: user messages, AI answers, tool calls the AI made, and tool results. Rows marked `[hidden]` or `[meta]` were not visible to the user; they are included because an audit needs the complete record.
 5. To save a copy, use the **Downloads** links on the same page:
@@ -19,6 +19,17 @@ You need a portal account with **staff status**. A developer grants this once (i
    - **JSON**: the raw record with timestamps, token counts, and cost, good for deeper analysis or archiving.
 
 Everything is read-only. You cannot change or delete a conversation from this screen.
+
+## Session keys
+
+Anonymous visitors have no email address, so a conversation of theirs is labeled by session key: `anonymous (session k3f9ab21)`. **Only the first 8 characters are shown**, everywhere: the thread list, the thread page, the User identities list, and both downloads.
+
+The reason is that a session key is the value of that visitor's browser cookie. While their session is still active, anyone holding the whole key could use it to take over the session, so a transcript you hand to court staff should not carry it.
+
+What this means in practice:
+
+- **Searching still works with the whole key.** If you already have a full session key, paste it into the search box and it will find the thread. Search matches the stored value; the page just never prints it.
+- **To tie several conversations to the same visitor, use the identity ID, not the shortened key.** The JSON download carries it as `owner.identity_id`. Matching identity IDs mean the same visitor. Matching 8-character keys are a hint, not proof.
 
 ## Retention
 

--- a/litigant_portal/app/admin.py
+++ b/litigant_portal/app/admin.py
@@ -18,6 +18,7 @@ from .selectors.chat_engine import (
     chat_thread_export_markdown,
     chat_thread_owner_label,
 )
+from .selectors.user import user_identity_session_key_short
 
 
 @admin.register(UserProfile)
@@ -28,10 +29,17 @@ class UserProfileAdmin(admin.ModelAdmin):
 
 @admin.register(UserIdentity)
 class UserIdentityAdmin(admin.ModelAdmin):
-    list_display = ["id", "user", "session_key", "created_at"]
+    list_display = ["id", "user", "session_key_short", "created_at"]
     list_filter = ["created_at"]
     search_fields = ["user__email", "session_key"]
-    readonly_fields = ["id", "created_at"]
+    # readonly_fields would still print session_key; only leaving it out of
+    # `fields` keeps the full value off the page.
+    fields = ["id", "user", "session_key_short", "created_at"]
+    readonly_fields = ["id", "session_key_short", "created_at"]
+
+    @admin.display(description="Session key", ordering="session_key")
+    def session_key_short(self, obj):
+        return user_identity_session_key_short(identity=obj)
 
 
 @admin.register(ChatThread)

--- a/litigant_portal/app/admin.py
+++ b/litigant_portal/app/admin.py
@@ -18,7 +18,6 @@ from .selectors.chat_engine import (
     chat_thread_export_markdown,
     chat_thread_owner_label,
 )
-from .selectors.user import user_identity_session_key_short
 
 
 @admin.register(UserProfile)
@@ -39,7 +38,7 @@ class UserIdentityAdmin(admin.ModelAdmin):
 
     @admin.display(description="Session key", ordering="session_key")
     def session_key_short(self, obj):
-        return user_identity_session_key_short(identity=obj)
+        return obj.session_key_short
 
 
 @admin.register(ChatThread)

--- a/litigant_portal/app/models/user.py
+++ b/litigant_portal/app/models/user.py
@@ -4,6 +4,8 @@ from django.utils.translation import gettext_lazy as _
 
 from .base import BaseModel
 
+SESSION_KEY_DISPLAY_CHARS = 8
+
 
 class UserIdentity(BaseModel):
     """Single identity row for either an authenticated user or an anonymous session."""
@@ -16,6 +18,18 @@ class UserIdentity(BaseModel):
         related_name="identity",
     )
     session_key = models.CharField(max_length=40, blank=True, db_index=True)
+
+    @property
+    def session_key_short(self) -> str:
+        """The session key, truncated for display.
+
+        ``session_key`` is the live value of the visitor's sessionid cookie, so
+        no audit surface renders it whole. The full value stays in the database
+        and in admin ``search_fields``, which is how staff already holding a key
+        look a thread up; 8 characters is a hint, not a usable handle. Use
+        ``UserIdentity.id`` to correlate threads to one visitor.
+        """
+        return self.session_key[:SESSION_KEY_DISPLAY_CHARS]
 
 
 class UserProfile(models.Model):

--- a/litigant_portal/app/selectors/chat_engine.py
+++ b/litigant_portal/app/selectors/chat_engine.py
@@ -1,7 +1,6 @@
 from django.db.models import OuterRef, QuerySet, Subquery, Sum
 
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
-from litigant_portal.app.selectors.user import user_identity_session_key_short
 
 
 def chat_thread_list(
@@ -55,8 +54,7 @@ def chat_thread_owner_label(*, thread: ChatThread) -> str:
     identity = thread.identity
     if identity.user_id:
         return identity.user.email or identity.user.username
-    short_key = user_identity_session_key_short(identity=identity)
-    return f"anonymous (session {short_key})"
+    return f"anonymous (session {identity.session_key_short})"
 
 
 def chat_thread_export_data(*, thread: ChatThread) -> dict:
@@ -77,7 +75,7 @@ def chat_thread_export_data(*, thread: ChatThread) -> dict:
             "identity_id": str(identity.id),
             "user_email": identity.user.email if identity.user_id else None,
             "username": identity.user.username if identity.user_id else None,
-            "session_key": user_identity_session_key_short(identity=identity),
+            "session_key": identity.session_key_short,
         },
         "messages": [
             {

--- a/litigant_portal/app/selectors/chat_engine.py
+++ b/litigant_portal/app/selectors/chat_engine.py
@@ -1,6 +1,7 @@
 from django.db.models import OuterRef, QuerySet, Subquery, Sum
 
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+from litigant_portal.app.selectors.user import user_identity_session_key_short
 
 
 def chat_thread_list(
@@ -50,11 +51,12 @@ def chat_message_list(
 
 
 def chat_thread_owner_label(*, thread: ChatThread) -> str:
-    """The review label for a thread's owner: email or session key."""
+    """The review label for a thread's owner: email or truncated session key."""
     identity = thread.identity
     if identity.user_id:
         return identity.user.email or identity.user.username
-    return f"anonymous (session {identity.session_key})"
+    short_key = user_identity_session_key_short(identity=identity)
+    return f"anonymous (session {short_key})"
 
 
 def chat_thread_export_data(*, thread: ChatThread) -> dict:
@@ -71,9 +73,11 @@ def chat_thread_export_data(*, thread: ChatThread) -> dict:
         "created_at": thread.created_at.isoformat(),
         "updated_at": thread.updated_at.isoformat(),
         "owner": {
+            # identity_id is the stable handle; the short key is only a hint.
+            "identity_id": str(identity.id),
             "user_email": identity.user.email if identity.user_id else None,
             "username": identity.user.username if identity.user_id else None,
-            "session_key": identity.session_key,
+            "session_key": user_identity_session_key_short(identity=identity),
         },
         "messages": [
             {

--- a/litigant_portal/app/selectors/user.py
+++ b/litigant_portal/app/selectors/user.py
@@ -1,22 +1,7 @@
 from django.contrib.auth.models import Group, User
 from django.db.models import Exists, OuterRef, QuerySet
 
-from litigant_portal.app.models import UserIdentity
 from litigant_portal.app.permissions import ADMINS_GROUP, DEVELOPERS_GROUP
-
-SESSION_KEY_DISPLAY_CHARS = 8
-
-
-def user_identity_session_key_short(*, identity: UserIdentity) -> str:
-    """An identity's session key, truncated for display.
-
-    ``session_key`` is the live value of the visitor's sessionid cookie, so no
-    audit surface renders it whole. The full value stays in the database and in
-    admin ``search_fields``, which is how staff already holding a key look a
-    thread up; 8 characters is a hint, not a usable handle. Use
-    ``UserIdentity.id`` to correlate threads to one visitor.
-    """
-    return identity.session_key[:SESSION_KEY_DISPLAY_CHARS]
 
 
 def user_get(*, user_id: int) -> User:

--- a/litigant_portal/app/selectors/user.py
+++ b/litigant_portal/app/selectors/user.py
@@ -1,7 +1,22 @@
 from django.contrib.auth.models import Group, User
 from django.db.models import Exists, OuterRef, QuerySet
 
+from litigant_portal.app.models import UserIdentity
 from litigant_portal.app.permissions import ADMINS_GROUP, DEVELOPERS_GROUP
+
+SESSION_KEY_DISPLAY_CHARS = 8
+
+
+def user_identity_session_key_short(*, identity: UserIdentity) -> str:
+    """An identity's session key, truncated for display.
+
+    ``session_key`` is the live value of the visitor's sessionid cookie, so no
+    audit surface renders it whole. The full value stays in the database and in
+    admin ``search_fields``, which is how staff already holding a key look a
+    thread up; 8 characters is a hint, not a usable handle. Use
+    ``UserIdentity.id`` to correlate threads to one visitor.
+    """
+    return identity.session_key[:SESSION_KEY_DISPLAY_CHARS]
 
 
 def user_get(*, user_id: int) -> User:

--- a/litigant_portal/app/tests/test_audit_admin.py
+++ b/litigant_portal/app/tests/test_audit_admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+from litigant_portal.app.tests.utils import SESSION_KEY, SHORT_KEY
 
 User = get_user_model()
 
@@ -18,7 +19,7 @@ class AuditAdminTests(TestCase):
         self.staff = User.objects.create_user(
             username="staff", password="pw", is_staff=True
         )
-        self.identity = UserIdentity.objects.create(session_key="anon-key-1")
+        self.identity = UserIdentity.objects.create(session_key=SESSION_KEY)
         self.thread = ChatThread.objects.create(
             identity=self.identity, description="Eviction help"
         )
@@ -65,10 +66,11 @@ class AuditAdminTests(TestCase):
         response = self.client.get("/django-admin/")
         self.assertContains(response, "/django-admin/app/chatthread/")
 
-    def test_changelist_lists_thread_with_owner(self):
+    def test_changelist_lists_thread_with_truncated_owner(self):
         response = self.client.get("/django-admin/app/chatthread/")
         self.assertContains(response, "Eviction help")
-        self.assertContains(response, "anon-key-1")
+        self.assertContains(response, f"anonymous (session {SHORT_KEY})")
+        self.assertNotContains(response, SESSION_KEY)
 
     def test_view_page_renders_full_transcript(self):
         response = self.client.get(f"{self.base_url}/change/")
@@ -77,8 +79,12 @@ class AuditAdminTests(TestCase):
         self.assertContains(response, "Found the housing topic.")
         self.assertContains(response, "[hidden]")
         self.assertContains(response, "injected context")
+        self.assertContains(response, f"anonymous (session {SHORT_KEY})")
+        self.assertNotContains(response, SESSION_KEY)
 
-    def test_search_finds_threads_by_email_and_session_key(self):
+    def test_search_finds_threads_by_email_and_full_session_key(self):
+        """Staff who already hold a key can still paste the whole thing in,
+        even though no surface renders it."""
         owner = User.objects.create_user(
             username="litigant", email="litigant@example.com", password="pw"
         )
@@ -92,7 +98,7 @@ class AuditAdminTests(TestCase):
         self.assertContains(by_email, "Account holder thread")
         self.assertNotContains(by_email, "Eviction help")
 
-        by_session = self.client.get(changelist, {"q": "anon-key-1"})
+        by_session = self.client.get(changelist, {"q": SESSION_KEY})
         self.assertContains(by_session, "Eviction help")
         self.assertNotContains(by_session, "Account holder thread")
 
@@ -107,7 +113,8 @@ class AuditAdminTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("attachment", response["Content-Disposition"])
         content = response.content.decode()
-        self.assertIn("anonymous (session anon-key-1)", content)
+        self.assertIn(f"anonymous (session {SHORT_KEY})", content)
+        self.assertNotIn(SESSION_KEY, content)
         self.assertIn("Tool call: search_topics", content)
         self.assertIn("[hidden]", content)
 
@@ -117,7 +124,9 @@ class AuditAdminTests(TestCase):
         self.assertIn("attachment", response["Content-Disposition"])
         export = json.loads(response.content)
         self.assertEqual(export["thread_id"], str(self.thread.pk))
-        self.assertEqual(export["owner"]["session_key"], "anon-key-1")
+        self.assertEqual(export["owner"]["session_key"], SHORT_KEY)
+        self.assertEqual(export["owner"]["identity_id"], str(self.identity.id))
+        self.assertNotIn(SESSION_KEY, response.content.decode())
         roles = [m["data"]["role"] for m in export["messages"]]
         self.assertEqual(roles, ["user", "assistant", "tool", "user"])
         self.assertTrue(export["messages"][3]["hidden"])
@@ -153,3 +162,34 @@ class AuditAdminTests(TestCase):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 302)
             self.assertIn("/django-admin/login/", response["Location"])
+
+
+@pytest.mark.postgres
+class UserIdentityAdminTests(TestCase):
+    """UserIdentityAdmin keeps Django's per-model permissions, so these need a
+    superuser rather than the bare staff account the transcript surface uses."""
+
+    def setUp(self):
+        self.client = Client()
+        User.objects.create_superuser(username="root", password="pw")
+        self.client.login(username="root", password="pw")
+        self.identity = UserIdentity.objects.create(session_key=SESSION_KEY)
+
+    def test_changelist_truncates_the_session_key(self):
+        response = self.client.get("/django-admin/app/useridentity/")
+        self.assertContains(response, SHORT_KEY)
+        self.assertNotContains(response, SESSION_KEY)
+
+    def test_change_form_neither_renders_nor_edits_the_session_key(self):
+        response = self.client.get(
+            f"/django-admin/app/useridentity/{self.identity.id}/change/"
+        )
+        self.assertContains(response, SHORT_KEY)
+        self.assertNotContains(response, SESSION_KEY)
+        self.assertNotContains(response, 'name="session_key"')
+
+    def test_changelist_still_finds_an_identity_by_full_session_key(self):
+        response = self.client.get(
+            "/django-admin/app/useridentity/", {"q": SESSION_KEY}
+        )
+        self.assertContains(response, str(self.identity.id))

--- a/litigant_portal/app/tests/test_audit_export.py
+++ b/litigant_portal/app/tests/test_audit_export.py
@@ -10,6 +10,7 @@ from litigant_portal.app.selectors.chat_engine import (
     chat_thread_export_markdown,
     chat_thread_owner_label,
 )
+from litigant_portal.app.tests.utils import SESSION_KEY, SHORT_KEY
 
 User = get_user_model()
 
@@ -33,19 +34,18 @@ class ThreadOwnerLabelTests(TestCase):
         thread = self._thread_for(UserIdentity.objects.create(user=user))
         self.assertEqual(chat_thread_owner_label(thread=thread), "no-email")
 
-    def test_labels_an_anonymous_owner_by_session_key(self):
-        identity = UserIdentity.objects.create(session_key="anon-key-1")
+    def test_labels_an_anonymous_owner_by_truncated_session_key(self):
+        identity = UserIdentity.objects.create(session_key=SESSION_KEY)
         thread = self._thread_for(identity)
-        self.assertEqual(
-            chat_thread_owner_label(thread=thread),
-            "anonymous (session anon-key-1)",
-        )
+        label = chat_thread_owner_label(thread=thread)
+        self.assertEqual(label, f"anonymous (session {SHORT_KEY})")
+        self.assertNotIn(SESSION_KEY, label)
 
 
 @pytest.mark.postgres
 class ThreadExportTests(TestCase):
     def setUp(self):
-        self.identity = UserIdentity.objects.create(session_key="anon-key-1")
+        self.identity = UserIdentity.objects.create(session_key=SESSION_KEY)
         self.thread = ChatThread.objects.create(
             identity=self.identity, description="Eviction help"
         )
@@ -121,6 +121,21 @@ class ThreadExportTests(TestCase):
         self.assertEqual(
             export["updated_at"], self.thread.updated_at.isoformat()
         )
+
+    def test_markdown_owner_line_truncates_the_session_key(self):
+        markdown = chat_thread_export_markdown(thread=self.thread)
+        self.assertIn(f"- Owner: anonymous (session {SHORT_KEY})", markdown)
+        self.assertNotIn(SESSION_KEY, markdown)
+
+    def test_json_owner_truncates_the_session_key(self):
+        owner = chat_thread_export_data(thread=self.thread)["owner"]
+        self.assertEqual(owner["session_key"], SHORT_KEY)
+
+    def test_json_owner_carries_the_identity_id(self):
+        """The truncated key is a hint; the identity id is the real handle for
+        correlating several threads to one visitor."""
+        owner = chat_thread_export_data(thread=self.thread)["owner"]
+        self.assertEqual(owner["identity_id"], str(self.identity.id))
 
     def test_json_owner_carries_username_when_email_is_blank(self):
         user = User.objects.create_user(username="no-email", password="pw")

--- a/litigant_portal/app/tests/utils.py
+++ b/litigant_portal/app/tests/utils.py
@@ -1,0 +1,6 @@
+# A full-length session key (32 chars, like request.session.session_key) and
+# the 8-char prefix that audit surfaces are allowed to show. SHORT_KEY is a
+# deliberate literal: deriving it from SESSION_KEY_DISPLAY_CHARS would make
+# the truncation tests circular.
+SESSION_KEY = "k3f9ab21c7de40118a5b6c9d2e7f0a1b"
+SHORT_KEY = "k3f9ab21"


### PR DESCRIPTION
UserIdentity.session_key is the literal value of the visitor's sessionid cookie, so for a live session the full key is a usable credential, not just an identifier. Transcript downloads also carry it past the admin's permission boundary to court staff.

Every audit surface now shows only the first 8 characters, through one helper (user_identity_session_key_short): the UserIdentity changelist, the ChatThread Owner column and detail page, the Markdown Owner line, and owner.session_key in the JSON export. The export also gains owner.identity_id, since 8 characters is a hint rather than a handle.

session_key also comes off the UserIdentityAdmin change form, a fifth surface the issue does not list, closed here for the same screen-share reason. It leaves the field out of fields rather than adding it to readonly_fields, because read-only fields still print the value.

Display-only: no migration, and the full key stays in search_fields, so staff who already hold one can still paste it into admin search.



## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

Closes #795

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
