### PR TITLE
ci: pin github actions to shas and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  # Version updates for GitHub Actions. Security updates already run without this
+  # file (they're driven by advisories + the dependency graph); version updates are
+  # what keep SHA-pinned actions from going stale.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    # One grouped PR per week instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+    commit-message:
+      prefix: build(deps)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         env:
           SKIP: uv-lock-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # Issues: warn at 90 days, close at 14 days after warning
           days-before-issue-stale: 90

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,10 @@ jobs:
           - '3.13'
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,15 @@ jobs:
           - '3.13'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

- **Pin and bump are separate commits.** `9e46a16` moves no versions at all: each SHA is the exact commit the floating tag already resolved to, so behavior is unchanged by construction. `e1583cb` then takes the upgrades. If CI had broken, the cause was attributable and the bump revertable without giving up the pins.
- **Upgrade only where a PR proves it.** `lint.yml` / `tests.yml` run on `pull_request`, so checkout v7 and setup-python v7 are exercised here. Everywhere else is pin-only, and Dependabot proposes upgrades in a reviewable PR instead.
- **`setup-uv` stays at v6.8.0.** v6 to v10 is four majors, and upstream stopped publishing major tags at v8 (citing tj-actions, same reasoning as this PR). Wants its own PR.
- **`actions/stale` stays at v9.1.0** though v11.0.0 exists — nothing here can exercise it.
- **`checkout` reconcile is deliberately incomplete.** v7.0.1 in CI, v6 in `deploy.yml`,
  v4.3.1 in the two Docker workflows. Finishing it would bump paths this PR can't test.
  Dependabot closes the gap.

Refs #726 

## Not in this PR

**`deploy.yml` — six floating actions, deliberately untouched.** It runs on neither
`pull_request` nor `push`, so nothing here could verify it, and it holds the AWS
credentials. It needs its own PR once we know how a deploy change gets exercised before
merge. #726 stays open for this.

**Enabling `sha_pinning_required`** — a setting, not a file, so it can't live in a commit.
See the sequencing note below.

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

CI green on this PR:

| Check | Result |
| --- | --- |
| `lint` | pass, 17s |
| `build (3.13)` | pass, 1m21s |
| Docker build validation | pass, 39s |

That covers all pins in `lint.yml` and `tests.yml` at their new versions. Before pushing, each pin was checked twice: the SHA exists upstream, **and** it matches the SHA of the version in its trailing comment. The second check matters more — a correct SHA with a lying comment survives review.

`stale.yml` is not exercised by CI (no matching trigger). It'll be confirmed by the next scheduled Monday 14:00 UTC run.

## Follow-ups

1. **`deploy.yml` pinning** — blocked on the deploy-verification question.
2. **Enable `sha_pinning_required`** — must come **after** (1), not after this PR. Turning it on while `deploy.yml` still has floating tags would fail the next deploy.
---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
