### PR TITLE
fix(migrations): merge the two 0014 leaf nodes

### DIFF
--- a/litigant_portal/app/migrations/0015_merge_20260824_1200.py
+++ b/litigant_portal/app/migrations/0015_merge_20260824_1200.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("app", "0014_chatmessage_git_sha"),
+        ("app", "0014_form_formfield_topicflowformcondition_and_more"),
+    ]
+
+    operations = []


### PR DESCRIPTION

## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

migration numbered 0014 against 0013 as its parent. Git merged them cleanly (different new files, no textual overlap), but the app was left with two leaf nodes in the migration graph. `migrate` refuses to run at all in that state, so every DB-backed test errored during `django_db_setup` rather than failing on its own terms.

Empty merge migration joining the chain back to a single leaf. Nothing to reconcile in `operations`: one 0014 adds `ChatMessage.git_sha`, the other creates the Form/Variable tables, so the two touch disjoint models. A database that already applied either one picks up the other plus this no-op, so no local or production reset is needed.

Guards to catch the next collision before it reaches main are tracked separately.

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
