### PR TITLE
docs: document runnable DB-free fast tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Chat model is configurable via `CHAT_MODEL` env var (LiteLLM format, e.g. `opena
 
 **`make lint`, `make test`, `make pre-commit`** — sandbox restrictions prevent Claude from running these Docker- and Postgres-backed targets. Mitch runs the full lint/test workflow as part of his own process. A single post-commit mention is plenty; don't re-prompt about it across the commit/PR steps.
 
-**DB-free fast tests** — when `.tox/fast` already exists, Claude can run a focused test directly with `.tox/fast/bin/pytest <path>`. Use that suite for a real RED→GREEN cycle on non-DB units: write the focused test, run it and confirm that it fails for the expected reason, implement the change, then rerun it to green. Postgres-marked tests and view tests still require `make test` and Docker, so Mitch runs those with the full workflow.
+**DB-free fast tests** — when `.tox/fast` already exists, Claude can run a focused test directly with `.tox/fast/bin/pytest <path>`. Use that suite for a real RED→GREEN cycle on non-DB units: write the focused test, run it and confirm that it fails for the expected reason, implement the change, then rerun it to green. Tests marked `postgres` require `make test` and Docker. The fast marker filter is not a complete database-isolation boundary: unmarked tests may still use Django's database, so run only focused tests already known to be DB-free through this path.
 
 ### Local Development (Docker)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@ Chat model is configurable via `CHAT_MODEL` env var (LiteLLM format, e.g. `opena
 
 ## Commands
 
-**`make lint`, `make test`, `make pre-commit`** — sandbox restrictions prevent Claude from running them. Never attempt to run them yourself. Mitch runs lint/test as part of his own workflow — a single post-commit mention is plenty; don't re-prompt about them across the commit/PR steps.
+**`make lint`, `make test`, `make pre-commit`** — sandbox restrictions prevent Claude from running these Docker- and Postgres-backed targets. Mitch runs the full lint/test workflow as part of his own process. A single post-commit mention is plenty; don't re-prompt about it across the commit/PR steps.
+
+**DB-free fast tests** — when `.tox/fast` already exists, Claude can run a focused test directly with `.tox/fast/bin/pytest <path>`. Use that suite for a real RED→GREEN cycle on non-DB units: write the focused test, run it and confirm that it fails for the expected reason, implement the change, then rerun it to green. Postgres-marked tests and view tests still require `make test` and Docker, so Mitch runs those with the full workflow.
 
 ### Local Development (Docker)
 


### PR DESCRIPTION
## What changed

- distinguish Docker and Postgres-backed `make` targets from the runnable DB-free fast suite
- document `.tox/fast/bin/pytest <path>` for a focused RED to GREEN cycle when the environment already exists
- clarify that the fast marker filter can still select unmarked tests that use Django's database

Closes #480

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run pre-commit run prettier --files CLAUDE.md`
- [x] `uv run pre-commit run --files CLAUDE.md` after the requested-change patch
- [x] `git diff --check origin/main...HEAD`
- [ ] `make pre-commit` green (GNU Make and Docker are unavailable on this Windows host; the draft PR's CI must run the full suite)

`uv run tox -e fast -- -q --tb=short` was also started, but it produced no terminal result after more than five minutes and was stopped. This pull request changes repository guidance only.

### AI assistance disclosure

I used OpenAI Codex with `5.6 Sol` (`gpt-5.6-sol`) to help inspect the public issue and repository guidance and to draft this small documentation change. I reviewed and understand every changed sentence and take responsibility for the contribution. No nonpublic personal information, sealed or restricted record, litigant data, credential, or private repository material was provided to the model. The AI service was used through a logged-in account with model-improvement data sharing disabled before this work.

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
