### PR TITLE
VariableAnswer service and selector layer 

### DIFF
--- a/litigant_portal/app/selectors/corpus.py
+++ b/litigant_portal/app/selectors/corpus.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import re
-from datetime import date, datetime
 from pathlib import Path
 from typing import Annotated, Literal
 
 import yaml
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -22,6 +22,7 @@ from litigant_portal.app.models.choices import (
     TopicFlowFormConditionOperator,
     VariableDataType,
 )
+from litigant_portal.app.services.topic_flow import variable_value_validate
 
 CORPUS_DIR = settings.BASE_DIR / "corpus"
 FORMS_DIR = CORPUS_DIR / "forms"
@@ -44,30 +45,22 @@ ValueType = bool | int | float | str
 
 
 def _variable_value_problem(value, variable) -> str | None:
-    """Why ``value`` is not a legal value for ``variable``, or None."""
-    data_type = variable.data_type
-    if data_type == "boolean":
-        return None if isinstance(value, bool) else "must be true or false"
-    if data_type == "number":
-        ok = isinstance(value, int | float) and not isinstance(value, bool)
-        return None if ok else "must be a number"
-    if data_type == "choice":
-        values = [c.value for c in variable.choices or []]
-        if isinstance(value, str) and value in values:
-            return None
-        return f"must be one of {values}"
-    if data_type in ("date", "datetime"):
-        parse = (
-            date.fromisoformat
-            if data_type == "date"
-            else datetime.fromisoformat
+    """Why ``value`` is not a legal value for ``variable``, or None.
+
+    Adapts ``variable_value_validate`` (the single source of truth for legal
+    values) to the message-string shape these validators embed in their own
+    errors. ``variable`` is a schema, so its choices are ChoiceSchema
+    objects; the service takes the stored {value, label} dict shape.
+    """
+    try:
+        variable_value_validate(
+            data_type=variable.data_type,
+            choices=[c.model_dump() for c in variable.choices or []],
+            value=value,
         )
-        try:
-            parse(value)
-        except (TypeError, ValueError):
-            return f"must be an ISO {data_type} string"
-        return None
-    return None if isinstance(value, str) else "must be a string"
+    except DjangoValidationError as exc:
+        return exc.messages[0]
+    return None
 
 
 class BaseSchema(BaseModel):

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -1,7 +1,7 @@
 from django.core.cache import cache
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
-from litigant_portal.app.models import Topic
+from litigant_portal.app.models import Topic, VariableAnswer
 
 
 def topic_list() -> list[Topic]:
@@ -16,3 +16,21 @@ def topic_list() -> list[Topic]:
 def topic_get(*, topic_id) -> Topic:
     """A single topic (raises Topic.DoesNotExist)."""
     return Topic.objects.get(id=topic_id)
+
+
+def variable_answer_list(*, identity) -> list[VariableAnswer]:
+    """An identity's answers, ordered by variable name."""
+    return list(
+        VariableAnswer.objects.filter(identity=identity)
+        .select_related("variable")
+        .order_by("variable__name")
+    )
+
+
+def variable_answer_map(*, identity, names: list[str]) -> dict:
+    """{variable_name: value} for the given names; names with no answer are omitted."""
+    return dict(
+        VariableAnswer.objects.filter(
+            identity=identity, variable__name__in=names
+        ).values_list("variable__name", "value")
+    )

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -19,18 +19,34 @@ def topic_get(*, topic_id) -> Topic:
 
 
 def variable_answer_list(*, identity) -> list[VariableAnswer]:
-    """An identity's answers, ordered by variable name."""
+    """An identity's answers, ordered by variable name.
+
+    Answers to variables the corpus no longer names (``in_schema=False``)
+    are left out: sync keeps those rows so a migration can move them, but
+    no form references them, so no surface should show them.
+    """
     return list(
-        VariableAnswer.objects.filter(identity=identity)
+        VariableAnswer.objects.filter(
+            identity=identity, variable__in_schema=True
+        )
         .select_related("variable")
         .order_by("variable__name")
     )
 
 
 def variable_answer_map(*, identity, names: list[str]) -> dict:
-    """{variable_name: value} for the given names; names with no answer are omitted."""
+    """{variable_name: value} for the given names; names with no answer are omitted.
+
+    A cleared answer (value None) counts as no answer: this map feeds
+    prefill and templates, where an absent key must stay absent rather
+    than fill a blank. Excludes out-of-schema variables, as
+    ``variable_answer_list`` does.
+    """
     return dict(
         VariableAnswer.objects.filter(
-            identity=identity, variable__name__in=names
+            identity=identity,
+            variable__name__in=names,
+            variable__in_schema=True,
+            value__isnull=False,
         ).values_list("variable__name", "value")
     )

--- a/litigant_portal/app/services/topic_flow.py
+++ b/litigant_portal/app/services/topic_flow.py
@@ -1,8 +1,12 @@
+from datetime import date, datetime
+
+from django.core.exceptions import ValidationError
 from django.db.models import Max
 from django.utils.text import slugify
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
 from litigant_portal.app.models import Topic
+from litigant_portal.app.models.choices import VariableDataType
 
 from .utils import busts_cache
 
@@ -39,3 +43,40 @@ def topic_update(*, topic: Topic, **fields) -> Topic:
 @busts_cache(TOPIC_LIST_CACHE_KEY)
 def topic_delete(*, topic: Topic) -> None:
     topic.delete()
+
+
+def variable_value_validate(*, data_type: str, choices: list, value):
+    """Check a raw value against a variable's data_type and choices.
+
+    Pure and DB-free so both the answer-writing path and the corpus loader
+    can call it. Returns the value unchanged when valid; None always passes
+    (it clears the answer). Raises ValidationError otherwise.
+    """
+    if value is None:
+        return None
+
+    if data_type == VariableDataType.TEXT:
+        if not isinstance(value, str):
+            raise ValidationError("Must be text.")
+    elif data_type == VariableDataType.NUMBER:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValidationError("Must be a number.")
+    elif data_type == VariableDataType.BOOLEAN:
+        if not isinstance(value, bool):
+            raise ValidationError("Must be true or false.")
+    elif data_type in (VariableDataType.DATE, VariableDataType.DATETIME):
+        parser = (
+            date.fromisoformat
+            if data_type == VariableDataType.DATE
+            else datetime.fromisoformat
+        )
+        try:
+            parser(value)
+        except (TypeError, ValueError) as exc:
+            raise ValidationError(f"Must be a valid ISO {data_type}.") from exc
+    elif data_type == VariableDataType.CHOICE and value not in {
+        c["value"] for c in choices
+    }:
+        raise ValidationError("Must be one of the declared choices.")
+
+    return value

--- a/litigant_portal/app/services/topic_flow.py
+++ b/litigant_portal/app/services/topic_flow.py
@@ -48,22 +48,23 @@ def topic_delete(*, topic: Topic) -> None:
 def variable_value_validate(*, data_type: str, choices: list, value):
     """Check a raw value against a variable's data_type and choices.
 
-    Pure and DB-free so both the answer-writing path and the corpus loader
-    can call it. Returns the value unchanged when valid; None always passes
-    (it clears the answer). Raises ValidationError otherwise.
+    The one place that decides whether a value is legal, for both the
+    answer-writing path and the corpus loader (``_variable_value_problem``
+    in selectors/corpus.py adapts this to a message string). Pure and
+    DB-free. ``choices`` is the stored shape, a list of {value, label}
+    dicts. Returns the value unchanged when valid; None always passes (it
+    clears the answer). Raises ValidationError otherwise, worded as a
+    fragment so callers can embed it in a fuller sentence.
     """
     if value is None:
         return None
 
-    if data_type == VariableDataType.TEXT:
-        if not isinstance(value, str):
-            raise ValidationError("Must be text.")
-    elif data_type == VariableDataType.NUMBER:
+    if data_type == VariableDataType.NUMBER:
         if isinstance(value, bool) or not isinstance(value, int | float):
-            raise ValidationError("Must be a number.")
+            raise ValidationError("must be a number")
     elif data_type == VariableDataType.BOOLEAN:
         if not isinstance(value, bool):
-            raise ValidationError("Must be true or false.")
+            raise ValidationError("must be true or false")
     elif data_type in (VariableDataType.DATE, VariableDataType.DATETIME):
         parser = (
             date.fromisoformat
@@ -73,11 +74,15 @@ def variable_value_validate(*, data_type: str, choices: list, value):
         try:
             parser(value)
         except (TypeError, ValueError) as exc:
-            raise ValidationError(f"Must be a valid ISO {data_type}.") from exc
-    elif data_type == VariableDataType.CHOICE and value not in {
-        c["value"] for c in choices
-    }:
-        raise ValidationError("Must be one of the declared choices.")
+            raise ValidationError(
+                f"must be an ISO {data_type} string"
+            ) from exc
+    elif data_type == VariableDataType.CHOICE:
+        values = [c["value"] for c in choices or []]
+        if value not in values:
+            raise ValidationError(f"must be one of {values}")
+    elif not isinstance(value, str):
+        raise ValidationError("must be a string")
 
     return value
 

--- a/litigant_portal/app/services/topic_flow.py
+++ b/litigant_portal/app/services/topic_flow.py
@@ -5,7 +5,7 @@ from django.db.models import Max
 from django.utils.text import slugify
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
-from litigant_portal.app.models import Topic
+from litigant_portal.app.models import Topic, Variable, VariableAnswer
 from litigant_portal.app.models.choices import VariableDataType
 
 from .utils import busts_cache
@@ -80,3 +80,29 @@ def variable_value_validate(*, data_type: str, choices: list, value):
         raise ValidationError("Must be one of the declared choices.")
 
     return value
+
+
+def variable_answer_set(
+    *, identity, variable: Variable, value, reviewed: bool = False
+) -> VariableAnswer:
+    """Upsert an identity's answer to a variable.
+
+    Validates against the variable's data_type/choices first — an invalid
+    value writes nothing. ``reviewed`` defaults to False (AI-written); pass
+    True only from the guided fact page after human confirmation. Only
+    reviewed=True answers may reach the docassemble prefill payload, since
+    prefilled variables skip their questions with no further human check.
+    Every unconfirmed write resets reviewed, even one that rewrites the
+    same value. Deliberately conservative: dropping a confirmation only
+    re-asks a question, while carrying a stale one forward would prefill
+    a court form unchecked.
+    """
+    value = variable_value_validate(
+        data_type=variable.data_type, choices=variable.choices, value=value
+    )
+    answer, _ = VariableAnswer.objects.update_or_create(
+        identity=identity,
+        variable=variable,
+        defaults={"value": value, "reviewed": reviewed},
+    )
+    return answer

--- a/litigant_portal/app/tests/test_variable_answer_selectors.py
+++ b/litigant_portal/app/tests/test_variable_answer_selectors.py
@@ -1,0 +1,111 @@
+"""Postgres tests: variable_answer_list/variable_answer_map read an identity's answers scoped to that identity and to the requested names."""
+
+import pytest
+from django.test import TestCase
+
+from litigant_portal.app.models import UserIdentity, Variable, VariableAnswer
+from litigant_portal.app.models.choices import VariableDataType
+from litigant_portal.app.selectors.topic_flow import (
+    variable_answer_list,
+    variable_answer_map,
+)
+
+
+@pytest.mark.postgres
+class VariableAnswerListTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="abc123")
+        self.other_identity = UserIdentity.objects.create(session_key="xyz789")
+        self.county = Variable.objects.create(
+            name="residence_county", data_type=VariableDataType.TEXT
+        )
+        self.city = Variable.objects.create(
+            name="residence_city", data_type=VariableDataType.TEXT
+        )
+
+    def test_returns_only_this_identitys_answers(self):
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        VariableAnswer.objects.create(
+            identity=self.other_identity, variable=self.city, value="Fargo"
+        )
+        answers = variable_answer_list(identity=self.identity)
+        self.assertEqual(
+            [a.variable.name for a in answers], ["residence_county"]
+        )
+
+    def test_returns_empty_list_when_no_answers(self):
+        self.assertEqual(variable_answer_list(identity=self.identity), [])
+
+    def test_ordered_by_variable_name(self):
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.city, value="Fargo"
+        )
+        answers = variable_answer_list(identity=self.identity)
+        self.assertEqual(
+            [a.variable.name for a in answers],
+            ["residence_city", "residence_county"],
+        )
+
+
+@pytest.mark.postgres
+class VariableAnswerMapTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="abc123")
+        self.other_identity = UserIdentity.objects.create(session_key="xyz789")
+        self.county = Variable.objects.create(
+            name="residence_county", data_type=VariableDataType.TEXT
+        )
+        self.city = Variable.objects.create(
+            name="residence_city", data_type=VariableDataType.TEXT
+        )
+
+    def test_maps_requested_names_to_values(self):
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.city, value="Fargo"
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county", "residence_city"],
+        )
+        self.assertEqual(
+            result, {"residence_county": "Cass", "residence_city": "Fargo"}
+        )
+
+    def test_omits_names_with_no_answer(self):
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county", "residence_city"],
+        )
+        self.assertEqual(result, {"residence_county": "Cass"})
+
+    def test_omits_names_not_requested(self):
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.city, value="Fargo"
+        )
+        result = variable_answer_map(
+            identity=self.identity, names=["residence_county"]
+        )
+        self.assertEqual(result, {"residence_county": "Cass"})
+
+    def test_scoped_to_this_identity_only(self):
+        VariableAnswer.objects.create(
+            identity=self.other_identity, variable=self.county, value="Cass"
+        )
+        result = variable_answer_map(
+            identity=self.identity, names=["residence_county"]
+        )
+        self.assertEqual(result, {})

--- a/litigant_portal/app/tests/test_variable_answer_selectors.py
+++ b/litigant_portal/app/tests/test_variable_answer_selectors.py
@@ -51,6 +51,25 @@ class VariableAnswerListTests(TestCase):
             ["residence_city", "residence_county"],
         )
 
+    def test_omits_answers_to_out_of_schema_variables(self):
+        # sync_corpus keeps the row so a migration can move the answer, but
+        # nothing references the variable anymore.
+        vestigial = Variable.objects.create(
+            name="old_county",
+            data_type=VariableDataType.TEXT,
+            in_schema=False,
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=vestigial, value="Stark"
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value="Cass"
+        )
+        answers = variable_answer_list(identity=self.identity)
+        self.assertEqual(
+            [a.variable.name for a in answers], ["residence_county"]
+        )
+
 
 @pytest.mark.postgres
 class VariableAnswerMapTests(TestCase):
@@ -89,6 +108,17 @@ class VariableAnswerMapTests(TestCase):
         )
         self.assertEqual(result, {"residence_county": "Cass"})
 
+    def test_omits_cleared_answers(self):
+        # A cleared answer counts as no answer: prefill must see an absent
+        # key, not fill a blank with None.
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=self.county, value=None
+        )
+        result = variable_answer_map(
+            identity=self.identity, names=["residence_county"]
+        )
+        self.assertEqual(result, {})
+
     def test_omits_names_not_requested(self):
         VariableAnswer.objects.create(
             identity=self.identity, variable=self.county, value="Cass"
@@ -107,5 +137,19 @@ class VariableAnswerMapTests(TestCase):
         )
         result = variable_answer_map(
             identity=self.identity, names=["residence_county"]
+        )
+        self.assertEqual(result, {})
+
+    def test_omits_out_of_schema_variables(self):
+        vestigial = Variable.objects.create(
+            name="old_county",
+            data_type=VariableDataType.TEXT,
+            in_schema=False,
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=vestigial, value="Stark"
+        )
+        result = variable_answer_map(
+            identity=self.identity, names=["old_county", "residence_county"]
         )
         self.assertEqual(result, {})

--- a/litigant_portal/app/tests/test_variable_answer_services.py
+++ b/litigant_portal/app/tests/test_variable_answer_services.py
@@ -1,0 +1,77 @@
+"""Fast, DB-free tests: variable_value_validate returns valid values unchanged (None always passes) and raises ValidationError otherwise."""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from litigant_portal.app.models.choices import VariableDataType
+from litigant_portal.app.services.topic_flow import variable_value_validate
+
+# Variable.choices is stored as the corpus writes it: {value, label} dicts.
+COUNTY_CHOICES = [
+    {"value": "cass", "label": "Cass County"},
+    {"value": "burleigh", "label": "Burleigh County"},
+]
+
+
+@pytest.mark.parametrize(
+    ("data_type", "choices", "value"),
+    [
+        (VariableDataType.TEXT, [], None),
+        (VariableDataType.TEXT, [], "Cass"),
+        (VariableDataType.NUMBER, [], 3),
+        (VariableDataType.NUMBER, [], 3.5),
+        (VariableDataType.BOOLEAN, [], True),
+        (VariableDataType.BOOLEAN, [], False),
+        (VariableDataType.DATE, [], "2026-02-01"),
+        (VariableDataType.DATETIME, [], "2026-02-01T10:30:00"),
+        (VariableDataType.CHOICE, COUNTY_CHOICES, "cass"),
+    ],
+    ids=[
+        "none-always-passes",
+        "text-accepts-string",
+        "number-accepts-int",
+        "number-accepts-float",
+        "boolean-accepts-true",
+        "boolean-accepts-false",
+        "date-accepts-iso-string",
+        "datetime-accepts-iso-string",
+        "choice-accepts-declared-value",
+    ],
+)
+def test_valid_values_pass_unchanged(data_type, choices, value):
+    assert (
+        variable_value_validate(
+            data_type=data_type, choices=choices, value=value
+        )
+        == value
+    )
+
+
+@pytest.mark.parametrize(
+    ("data_type", "choices", "value"),
+    [
+        (VariableDataType.TEXT, [], 42),
+        (VariableDataType.NUMBER, [], True),
+        (VariableDataType.NUMBER, [], "3"),
+        (VariableDataType.BOOLEAN, [], "true"),
+        (VariableDataType.DATE, [], "not-a-date"),
+        (VariableDataType.DATETIME, [], "not-a-datetime"),
+        (VariableDataType.CHOICE, COUNTY_CHOICES, "stark"),
+        (VariableDataType.CHOICE, COUNTY_CHOICES, "Cass County"),
+    ],
+    ids=[
+        "text-rejects-non-string",
+        "number-rejects-bool",
+        "number-rejects-numeric-string",
+        "boolean-rejects-non-bool",
+        "date-rejects-unparseable-string",
+        "datetime-rejects-unparseable-string",
+        "choice-rejects-undeclared-value",
+        "choice-rejects-label-instead-of-value",
+    ],
+)
+def test_invalid_values_raise(data_type, choices, value):
+    with pytest.raises(ValidationError):
+        variable_value_validate(
+            data_type=data_type, choices=choices, value=value
+        )

--- a/litigant_portal/app/tests/test_variable_answer_services.py
+++ b/litigant_portal/app/tests/test_variable_answer_services.py
@@ -1,10 +1,19 @@
-"""Fast, DB-free tests: variable_value_validate returns valid values unchanged (None always passes) and raises ValidationError otherwise."""
+"""Tests for the variable answer services.
+
+variable_value_validate tests are DB-free and run in the fast suite;
+the variable_answer_set tests are postgres-marked.
+"""
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 
+from litigant_portal.app.models import UserIdentity, Variable, VariableAnswer
 from litigant_portal.app.models.choices import VariableDataType
-from litigant_portal.app.services.topic_flow import variable_value_validate
+from litigant_portal.app.services.topic_flow import (
+    variable_answer_set,
+    variable_value_validate,
+)
 
 # Variable.choices is stored as the corpus writes it: {value, label} dicts.
 COUNTY_CHOICES = [
@@ -75,3 +84,109 @@ def test_invalid_values_raise(data_type, choices, value):
         variable_value_validate(
             data_type=data_type, choices=choices, value=value
         )
+
+
+@pytest.mark.postgres
+class VariableAnswerSetTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="abc123")
+        self.variable = Variable.objects.create(
+            name="favorite_county", data_type=VariableDataType.TEXT
+        )
+
+    def test_creates_answer_with_reviewed_false_by_default(self):
+        answer = variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Cass"
+        )
+        self.assertEqual(answer.value, "Cass")
+        self.assertFalse(answer.reviewed)
+
+    def test_upsert_updates_existing_row_instead_of_duplicating(self):
+        variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Cass"
+        )
+        variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Burleigh"
+        )
+        answers = VariableAnswer.objects.filter(
+            identity=self.identity, variable=self.variable
+        )
+        self.assertEqual(answers.count(), 1)
+        self.assertEqual(answers.get().value, "Burleigh")
+
+    def test_invalid_value_raises_and_writes_nothing(self):
+        with self.assertRaises(ValidationError):
+            variable_answer_set(
+                identity=self.identity, variable=self.variable, value=42
+            )
+        self.assertFalse(
+            VariableAnswer.objects.filter(
+                identity=self.identity, variable=self.variable
+            ).exists()
+        )
+
+    def test_invalid_value_does_not_overwrite_existing_answer(self):
+        variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Cass"
+        )
+        with self.assertRaises(ValidationError):
+            variable_answer_set(
+                identity=self.identity, variable=self.variable, value=42
+            )
+        answer = VariableAnswer.objects.get(
+            identity=self.identity, variable=self.variable
+        )
+        self.assertEqual(answer.value, "Cass")
+
+    def test_reviewed_true_when_explicitly_confirmed(self):
+        answer = variable_answer_set(
+            identity=self.identity,
+            variable=self.variable,
+            value="Cass",
+            reviewed=True,
+        )
+        self.assertTrue(answer.reviewed)
+
+    def test_new_value_resets_reviewed_to_false(self):
+        # A human confirmed "Cass"; an unconfirmed rewrite to "Burleigh" must
+        # not carry the old confirmation forward.
+        variable_answer_set(
+            identity=self.identity,
+            variable=self.variable,
+            value="Cass",
+            reviewed=True,
+        )
+        answer = variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Burleigh"
+        )
+        self.assertFalse(answer.reviewed)
+
+    def test_reconfirming_in_same_call_keeps_reviewed_true(self):
+        variable_answer_set(
+            identity=self.identity,
+            variable=self.variable,
+            value="Cass",
+            reviewed=True,
+        )
+        answer = variable_answer_set(
+            identity=self.identity,
+            variable=self.variable,
+            value="Burleigh",
+            reviewed=True,
+        )
+        self.assertTrue(answer.reviewed)
+
+    def test_unconfirmed_rewrite_of_same_value_resets_reviewed(self):
+        # Deliberately conservative: an AI re-writing the value a human
+        # already confirmed drops the confirmation, so the user re-confirms
+        # rather than a stale confirmation reaching the prefill payload.
+        variable_answer_set(
+            identity=self.identity,
+            variable=self.variable,
+            value="Cass",
+            reviewed=True,
+        )
+        answer = variable_answer_set(
+            identity=self.identity, variable=self.variable, value="Cass"
+        )
+        self.assertFalse(answer.reviewed)


### PR DESCRIPTION
## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->
Builds the data layer for storing answers to glossary variables, following the reads-are-selectors / writes-are-services split.

- **`variable_answer_set` service** — upserts an answer for (identity, variable), validating the value against the variable's `data_type` and `choices` first. An invalid value writes nothing.
- **Read selectors** — `variable_answer_list(identity)` and `variable_answer_map(identity, names)` in `selectors/topic_flow.py`.
- **`variable_value_validate`** — one pure, DB-free function that decides whether a value is legal. The corpus loader's `_variable_value_problem` now delegates to it, so corpus loading and answer writing can't drift apart.

## Decisions recorded

- **Reviewed is conservative.** Machine writes save `reviewed=False`; only an explicit confirmation (the guided fact page) passes `reviewed=True`. Every unconfirmed write resets the flag, even a rewrite of the same value: dropping a confirmation only re-asks a question, while a stale one would prefill a court form unchecked.
- **`in_schema` filtering implemented.** Both read selectors exclude answers to variables the corpus no longer names. Sync keeps those rows so a migration can move them, but no surface should show them. The write path is untouched, since a guard there would block that migration.
- **Cleared answers stay out of the map.** `variable_answer_map` omits `value=None` rows: prefill must see an absent key, not fill a blank with None. `variable_answer_list` keeps them for the fact page.
- **Open question for review:** `selectors/corpus.py` now imports the validator from `services/topic_flow.py`, which runs against the reads-are-selectors grain. The function only computes, never writes, but where the shared validator should live is worth settling (connects to the question of whether corpus loading belongs under `selectors/` at all).

Closes # 821

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
