### PR TITLE
Assistant can activate a guided topic flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,14 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **By domain** — `models/`, `selectors/`, and `services/` each carry one module per domain, and the three agree on module names:
 
-| Domain        | Holds                                                        |
-| ------------- | ------------------------------------------------------------ |
-| `site`        | Global site settings and court config                        |
-| `topic_flow`  | Topics and topic flow data (spans admin and public surfaces) |
-| `user`        | Identity, profile, and group membership toggles              |
-| `upload`      | Attachment upload and its helper logic                       |
-| `chat_engine` | Threads, messages, streaming                                 |
+| Domain        | Holds                                                             |
+| ------------- | ----------------------------------------------------------------- |
+| `site`        | Global site settings and court config                             |
+| `topic_flow`  | Topics and topic flow data (spans admin and public surfaces)      |
+| `corpus`      | Corpus schemas, YAML loading, and sync into `topic_flow` rows (selectors + services only; no models module) |
+| `user`        | Identity, profile, and group membership toggles                   |
+| `upload`      | Attachment upload and its helper logic                            |
+| `chat_engine` | Threads, messages, streaming                                      |
 
 **Never name a data-layer module after the page that consumes it.** Site settings apply app-wide; topic utilities serve both the admin editor and the public flow page. Naming either one `admin` mislocates it the moment a second caller shows up — which is exactly what happened to the module this layout replaced.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,14 +154,14 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **By domain** — `models/`, `selectors/`, and `services/` each carry one module per domain, and the three agree on module names:
 
-| Domain        | Holds                                                             |
-| ------------- | ----------------------------------------------------------------- |
-| `site`        | Global site settings and court config                             |
-| `topic_flow`  | Topics and topic flow data (spans admin and public surfaces)      |
+| Domain        | Holds                                                                                                       |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `site`        | Global site settings and court config                                                                       |
+| `topic_flow`  | Topics and topic flow data (spans admin and public surfaces)                                                |
 | `corpus`      | Corpus schemas, YAML loading, and sync into `topic_flow` rows (selectors + services only; no models module) |
-| `user`        | Identity, profile, and group membership toggles                   |
-| `upload`      | Attachment upload and its helper logic                            |
-| `chat_engine` | Threads, messages, streaming                                      |
+| `user`        | Identity, profile, and group membership toggles                                                             |
+| `upload`      | Attachment upload and its helper logic                                                                      |
+| `chat_engine` | Threads, messages, streaming                                                                                |
 
 **Never name a data-layer module after the page that consumes it.** Site settings apply app-wide; topic utilities serve both the admin editor and the public flow page. Naming either one `admin` mislocates it the moment a second caller shows up — which is exactly what happened to the module this layout replaced.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ The compact rules (board mechanics live at the org level; sizing history, anchor
 
 **Never name a data-layer module after the page that consumes it.** Site settings apply app-wide; topic utilities serve both the admin editor and the public flow page. Naming either one `admin` mislocates it the moment a second caller shows up — which is exactly what happened to the module this layout replaced.
 
-**Naming:** services and selectors are `{model_name}_{action}` — `site_get`, `topic_create`, `user_identity_merge`, `user_upload_llm_parts`. Allow some liberty when a utility genuinely implicates two models equally. Anything not part of a module's public surface takes a leading underscore.
+**Naming:** services and selectors are `{model_name}_{action}` — `site_get`, `topic_create`, `user_identity_merge`, `user_upload_llm_parts`. Allow some liberty when a utility genuinely implicates two models equally. Anything not part of a module's public surface takes a leading underscore. Single-row selector verbs encode miss behavior: `*_get` raises on a missing row, `*_find` returns None — pick the verb by how callers treat a miss.
 
 **Reads are selectors, writes are services.** `user_list` reads, so it's a selector; `user_developer_toggle` writes, so it's a service.
 

--- a/docs/ai-tooling/AGENT_DEV_GUIDE.md
+++ b/docs/ai-tooling/AGENT_DEV_GUIDE.md
@@ -21,6 +21,7 @@ frontend templates those tools render with). You build new behavior by
 | SSE events (`content_delta`, `tool_call`, …) | `generate_system_prompt(thread_id)`     |
 | Rendering tool templates → HTML              | `tools = [...]` (Tool subclasses)       |
 | Reloading a thread for the frontend          | tool templates under `templates/tools/` |
+| Calling the per-message lifecycle hook       | `prepare_thread(thread_id)` (optional)  |
 
 Engine code: [`services/chat_engine.py`](../../litigant_portal/app/services/chat_engine.py) ·
 Abstraction: [`agents/base.py`](../../litigant_portal/agents/base.py) ·
@@ -125,6 +126,17 @@ def generate_system_prompt(self, *, thread_id) -> str:
 > for every request (and again mid-turn whenever a tool sets
 > `refresh_system_prompt=True`). This is what lets state changes show up in the
 > model's instructions instantly.
+
+### Optional: the per-message hook — `prepare_thread(thread_id)`
+
+The engine calls `prepare_thread(thread_id=...)` **once per user message**,
+after the thread is resolved and before the message is stored or the first
+model call is made. The default is a no-op. Override it to reconcile state
+against the current world before the turn starts — e.g. the litigant
+assistant clears its `active_topic_flow` when the flow it names has been
+renamed, disabled, or deleted. This is the place for state writes with a
+per-turn cadence: `generate_system_prompt` can run several times per turn
+and should stay a pure read, while `prepare_thread` runs exactly once.
 
 ### 4. The tools — `tools = [...]`
 

--- a/litigant_portal/agents/__init__.py
+++ b/litigant_portal/agents/__init__.py
@@ -1,4 +1,4 @@
-from .assistant import LitigantAssistant
+from .assistant import LitigantAssistant, LitigantAssistantState
 from .base import Agent, AgentState, Field, Tool, ToolOutput
 from .weather import WeatherAgent, WeatherState
 
@@ -11,4 +11,5 @@ __all__ = [
     "WeatherAgent",
     "WeatherState",
     "LitigantAssistant",
+    "LitigantAssistantState",
 ]

--- a/litigant_portal/agents/assistant.py
+++ b/litigant_portal/agents/assistant.py
@@ -1,3 +1,5 @@
+from django.db import transaction
+
 from .base import Agent, AgentState
 from .tools.load_topic_flow import LoadTopicFlow, topic_flow_path
 from .tools.query_document import QueryDocument
@@ -71,13 +73,14 @@ class LitigantAssistant(Agent):
         from litigant_portal.app.models import ChatThread
         from litigant_portal.app.selectors.topic_flow import topic_flow_list
 
-        thread = ChatThread.objects.get(id=thread_id)
-        active = (thread.state or {}).get("active_topic_flow")
-        if active and active not in {
-            topic_flow_path(f) for f in topic_flow_list()
-        }:
-            thread.state = {**thread.state, "active_topic_flow": None}
-            thread.save(update_fields=["state", "updated_at"])
+        with transaction.atomic():
+            thread = ChatThread.objects.select_for_update().get(id=thread_id)
+            active = (thread.state or {}).get("active_topic_flow")
+            if active and active not in {
+                topic_flow_path(f) for f in topic_flow_list()
+            }:
+                thread.state = {**thread.state, "active_topic_flow": None}
+                thread.save(update_fields=["state", "updated_at"])
 
     def generate_system_prompt(self, *, thread_id) -> str:
         """Each prompt piece injected into PROMPT_TEMPLATE."""

--- a/litigant_portal/agents/assistant.py
+++ b/litigant_portal/agents/assistant.py
@@ -84,7 +84,14 @@ class LitigantAssistant(Agent):
         chat_thread_state_merge(thread_id=thread_id, updates=clear_if_stale)
 
     def generate_system_prompt(self, *, thread_id) -> str:
-        """Each prompt piece injected into PROMPT_TEMPLATE."""
+        """Each prompt piece injected into PROMPT_TEMPLATE.
+
+        The active topic flow is deliberately absent: the model learns it
+        from the LoadTopicFlow result in history, which only works while
+        the engine sends the full history. When we add automatic compaction,
+        we'll need to account for the active topic flow data being dropped from
+        history.
+        """
         return PROMPT_TEMPLATE.format(
             base=BASE_PROMPT,
             topic_flows=generate_topic_flows_prompt(),

--- a/litigant_portal/agents/assistant.py
+++ b/litigant_portal/agents/assistant.py
@@ -1,4 +1,5 @@
-from .base import Agent
+from .base import Agent, AgentState
+from .tools.load_topic_flow import LoadTopicFlow, topic_flow_path
 from .tools.query_document import QueryDocument
 
 BASE_PROMPT = """\
@@ -12,11 +13,75 @@ files appear directly in the conversation. A note reading [Attached file \
 tool with its upload_id to read or query it. Never guess at the contents \
 of a file you haven't seen."""
 
+TOPIC_FLOWS_PROMPT = """\
+## Guided topic flows
+
+The portal has guided topic flows: step-by-step guides for specific legal \
+situations, with local court information, deadlines, and forms. As soon as \
+the user's situation matches one, call the LoadTopicFlow tool with the \
+flow's path (the topic-slug/flow-slug before the colon in the list \
+below). The result names the conversation's active flow and gives you the \
+flow's full content; treat that content as your primary source while the \
+flow is active. Available flows:
+
+{flows}"""
+
+PROMPT_TEMPLATE = """\
+{base}
+
+{topic_flows}"""
+
+
+def generate_topic_flows_prompt() -> str:
+    """The guided-topic-flows section, or '' when no flows are enabled."""
+    from litigant_portal.app.selectors.topic_flow import topic_flow_list
+
+    flows = topic_flow_list()
+    if not flows:
+        return ""
+    return TOPIC_FLOWS_PROMPT.format(
+        flows="\n".join(
+            f"- {topic_flow_path(f)}: {f.name} ({f.topic.title})"
+            for f in flows
+        )
+    )
+
+
+class LitigantAssistantState(AgentState):
+    """Litigant assistant state."""
+
+    active_topic_flow: str | None = None
+
 
 class LitigantAssistant(Agent):
     """The user-facing assistant for self-represented litigants."""
 
-    tools = [QueryDocument]
+    state_schema = LitigantAssistantState
+    tools = [QueryDocument, LoadTopicFlow]
+
+    def prepare_thread(self, *, thread_id) -> None:
+        """Clear the thread's active topic flow when it no longer names an
+        enabled flow.
+
+        State stores a slug path, not a foreign key, so the flow may have
+        been renamed, disabled, or deleted since it was set. The engine
+        runs this once per user message, so a stale path never survives
+        into a turn.
+        """
+        from litigant_portal.app.models import ChatThread
+        from litigant_portal.app.selectors.topic_flow import topic_flow_list
+
+        thread = ChatThread.objects.get(id=thread_id)
+        active = (thread.state or {}).get("active_topic_flow")
+        if active and active not in {
+            topic_flow_path(f) for f in topic_flow_list()
+        }:
+            thread.state = {**thread.state, "active_topic_flow": None}
+            thread.save(update_fields=["state", "updated_at"])
 
     def generate_system_prompt(self, *, thread_id) -> str:
-        return BASE_PROMPT
+        """Each prompt piece injected into PROMPT_TEMPLATE."""
+        return PROMPT_TEMPLATE.format(
+            base=BASE_PROMPT,
+            topic_flows=generate_topic_flows_prompt(),
+        ).strip()

--- a/litigant_portal/agents/assistant.py
+++ b/litigant_portal/agents/assistant.py
@@ -1,5 +1,3 @@
-from django.db import transaction
-
 from .base import Agent, AgentState
 from .tools.load_topic_flow import LoadTopicFlow, topic_flow_path
 from .tools.query_document import QueryDocument
@@ -70,17 +68,20 @@ class LitigantAssistant(Agent):
         runs this once per user message, so a stale path never survives
         into a turn.
         """
-        from litigant_portal.app.models import ChatThread
         from litigant_portal.app.selectors.topic_flow import topic_flow_list
+        from litigant_portal.app.services.chat_engine import (
+            chat_thread_state_merge,
+        )
 
-        with transaction.atomic():
-            thread = ChatThread.objects.select_for_update().get(id=thread_id)
-            active = (thread.state or {}).get("active_topic_flow")
+        def clear_if_stale(state: dict) -> dict:
+            active = state.get("active_topic_flow")
             if active and active not in {
                 topic_flow_path(f) for f in topic_flow_list()
             }:
-                thread.state = {**thread.state, "active_topic_flow": None}
-                thread.save(update_fields=["state", "updated_at"])
+                return {"active_topic_flow": None}
+            return {}
+
+        chat_thread_state_merge(thread_id=thread_id, updates=clear_if_stale)
 
     def generate_system_prompt(self, *, thread_id) -> str:
         """Each prompt piece injected into PROMPT_TEMPLATE."""

--- a/litigant_portal/agents/base.py
+++ b/litigant_portal/agents/base.py
@@ -60,6 +60,15 @@ class Agent:
     state_schema: ClassVar[type[AgentState]] = AgentState
     tools: ClassVar[list[type[Tool]]] = []
 
+    def prepare_thread(self, *, thread_id) -> None:
+        """Reconcile thread state before a turn starts.
+
+        The engine calls this once per user message, after the thread is
+        resolved and before the message is stored or the first model call
+        is made. Override it to bring state in line with the current
+        world.
+        """
+
     def generate_system_prompt(self, *, thread_id) -> str:
         """Build the system prompt for ``thread_id`` from its state."""
         raise NotImplementedError

--- a/litigant_portal/agents/tools/check_weather.py
+++ b/litigant_portal/agents/tools/check_weather.py
@@ -15,17 +15,21 @@ class CheckWeather(Tool):
 
     def __call__(self, *, thread_id) -> ToolOutput:
         from litigant_portal.agents.weather import WeatherState
-        from litigant_portal.app.models import ChatThread
+        from litigant_portal.app.services.chat_engine import (
+            chat_thread_state_merge,
+        )
 
         # Artificial delay so the "checking weather" call card is visible.
         time.sleep(2)
 
-        thread = ChatThread.objects.get(id=thread_id)
-        state = WeatherState.model_validate(thread.state or {})
-        if self.location not in state.recent_locations:
+        def add_location(current: dict) -> dict:
+            state = WeatherState.model_validate(current)
+            if self.location in state.recent_locations:
+                return {}
             state.recent_locations.append(self.location)
-            thread.state = state.model_dump()
-            thread.save(update_fields=["state", "updated_at"])
+            return state.model_dump()
+
+        chat_thread_state_merge(thread_id=thread_id, updates=add_location)
 
         temp_f = 72
         return ToolOutput(

--- a/litigant_portal/agents/tools/load_topic_flow.py
+++ b/litigant_portal/agents/tools/load_topic_flow.py
@@ -1,0 +1,143 @@
+import json
+
+from litigant_portal.agents.base import Field, Tool, ToolOutput
+
+
+def topic_flow_path(flow) -> str:
+    """The slug path that names ``flow`` in agent state and tool calls."""
+    return f"{flow.topic.slug}/{flow.slug}"
+
+
+def topic_flow_from_path(path: str):
+    """The enabled TopicFlow at ``path`` (topic-slug/flow-slug), or None."""
+    from litigant_portal.app.selectors.topic_flow import topic_flow_find
+
+    topic_slug, sep, flow_slug = path.partition("/")
+    if not (sep and topic_slug and flow_slug):
+        return None
+    return topic_flow_find(topic_slug=topic_slug, flow_slug=flow_slug)
+
+
+def _variable_line(variable) -> str:
+    line = f"- {variable.name} ({variable.data_type})"
+    prompt = variable.question or variable.label
+    if prompt:
+        line += f": {prompt}"
+    if variable.choices:
+        values = ", ".join(c["value"] for c in variable.choices)
+        line += f" [choices: {values}]"
+    if variable.asked_when:
+        line += (
+            f" (asked when {variable.asked_when.name} = "
+            f"{json.dumps(variable.asked_when_value)})"
+        )
+    return line
+
+
+def topic_flow_markdown(flow) -> str:
+    """Everything the assistant should know about ``flow``, as markdown."""
+    lines = [f"# {flow.name}", f"Topic: {flow.topic.title}"]
+
+    for section in flow.sections.all():
+        lines += ["", f"## {section.heading}", section.content.strip()]
+
+    deadlines = list(flow.deadlines.all())
+    if deadlines:
+        lines += ["", "## Deadlines"]
+        for d in deadlines:
+            anchor = d.offset_from.label or d.offset_from.name
+            when = (
+                f"{d.offset_days} days after"
+                if d.offset_days >= 0
+                else f"{-d.offset_days} days before"
+            )
+            line = f"- {d.label}: {when} {anchor}"
+            if d.description:
+                line += f". {d.description}"
+            lines.append(line)
+
+    conditions = list(flow.form_conditions.all())
+    if conditions:
+        lines += ["", "## Form packet"]
+        for c in conditions:
+            line = f"- {c.form.name}"
+            if c.variable:
+                line += (
+                    f" (included when {c.variable.name} {c.operator} "
+                    f"{json.dumps(c.value)})"
+                )
+            lines.append(line)
+
+    pages = list(flow.interview_pages.all())
+    if pages:
+        lines += ["", "## Facts the guided interview collects"]
+        for page in pages:
+            if page.title:
+                lines += ["", f"### {page.title}"]
+            if page.description:
+                lines.append(page.description.strip())
+            lines += [
+                _variable_line(pv.variable) for pv in page.variables.all()
+            ]
+
+    links = list(flow.links.all())
+    if links:
+        lines += ["", "## Links"]
+        lines += [f"- {link.name}: {link.url}" for link in links]
+
+    return "\n".join(lines)
+
+
+class LoadTopicFlow(Tool):
+    """Load a guided topic flow and make it this conversation's active flow.
+
+    Call this as soon as the user's situation matches one of the available
+    topic flows listed in your instructions. The result contains the flow's
+    full content (its guidance, deadlines, forms, and the facts it
+    collects); ground your answers in that content while the flow is
+    active.
+    """
+
+    topic_flow: str = Field(
+        description=(
+            "The path of the flow to load: just the topic-slug/flow-slug "
+            "that starts its line in your instructions, e.g. "
+            "'eviction/tenant', with nothing after it"
+        )
+    )
+
+    def __call__(self, *, thread_id) -> ToolOutput:
+        from litigant_portal.app.models import ChatThread
+        from litigant_portal.app.selectors.topic_flow import topic_flow_list
+
+        flow = topic_flow_from_path(self.topic_flow)
+        if flow is None:
+            available = (
+                ", ".join(topic_flow_path(f) for f in topic_flow_list())
+                or "none"
+            )
+            return ToolOutput(
+                result=(
+                    f"Error: no topic flow named '{self.topic_flow}'. "
+                    f"Available flows: {available}."
+                )
+            )
+
+        thread = ChatThread.objects.get(id=thread_id)
+        thread.state = {
+            **(thread.state or {}),
+            "active_topic_flow": topic_flow_path(flow),
+        }
+        thread.save(update_fields=["state", "updated_at"])
+
+        return ToolOutput(
+            result=(
+                f"The active topic flow is now {topic_flow_path(flow)} "
+                f"({flow.name}).\n\n{topic_flow_markdown(flow)}"
+            ),
+            render_data={
+                "topic_flow": topic_flow_path(flow),
+                "name": flow.name,
+                "topic": flow.topic.title,
+            },
+        )

--- a/litigant_portal/agents/tools/load_topic_flow.py
+++ b/litigant_portal/agents/tools/load_topic_flow.py
@@ -1,5 +1,7 @@
 import json
 
+from django.db import transaction
+
 from litigant_portal.agents.base import Field, Tool, ToolOutput
 
 
@@ -123,12 +125,13 @@ class LoadTopicFlow(Tool):
                 )
             )
 
-        thread = ChatThread.objects.get(id=thread_id)
-        thread.state = {
-            **(thread.state or {}),
-            "active_topic_flow": topic_flow_path(flow),
-        }
-        thread.save(update_fields=["state", "updated_at"])
+        with transaction.atomic():
+            thread = ChatThread.objects.select_for_update().get(id=thread_id)
+            thread.state = {
+                **(thread.state or {}),
+                "active_topic_flow": topic_flow_path(flow),
+            }
+            thread.save(update_fields=["state", "updated_at"])
 
         return ToolOutput(
             result=(

--- a/litigant_portal/agents/tools/load_topic_flow.py
+++ b/litigant_portal/agents/tools/load_topic_flow.py
@@ -1,7 +1,5 @@
 import json
 
-from django.db import transaction
-
 from litigant_portal.agents.base import Field, Tool, ToolOutput
 
 
@@ -109,8 +107,10 @@ class LoadTopicFlow(Tool):
     )
 
     def __call__(self, *, thread_id) -> ToolOutput:
-        from litigant_portal.app.models import ChatThread
         from litigant_portal.app.selectors.topic_flow import topic_flow_list
+        from litigant_portal.app.services.chat_engine import (
+            chat_thread_state_merge,
+        )
 
         flow = topic_flow_from_path(self.topic_flow)
         if flow is None:
@@ -125,13 +125,10 @@ class LoadTopicFlow(Tool):
                 )
             )
 
-        with transaction.atomic():
-            thread = ChatThread.objects.select_for_update().get(id=thread_id)
-            thread.state = {
-                **(thread.state or {}),
-                "active_topic_flow": topic_flow_path(flow),
-            }
-            thread.save(update_fields=["state", "updated_at"])
+        chat_thread_state_merge(
+            thread_id=thread_id,
+            updates={"active_topic_flow": topic_flow_path(flow)},
+        )
 
         return ToolOutput(
             result=(

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -1,7 +1,7 @@
 from django.core.cache import cache
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
-from litigant_portal.app.models import Topic, VariableAnswer
+from litigant_portal.app.models import Topic, TopicFlow, VariableAnswer
 
 
 def topic_list() -> list[Topic]:
@@ -16,6 +16,35 @@ def topic_list() -> list[Topic]:
 def topic_get(*, topic_id) -> Topic:
     """A single topic (raises Topic.DoesNotExist)."""
     return Topic.objects.get(id=topic_id)
+
+
+def topic_flow_list() -> list[TopicFlow]:
+    """Enabled flows with their topics, in topic order then flow order."""
+    return list(
+        TopicFlow.objects.filter(enabled=True)
+        .select_related("topic")
+        .order_by("topic__order", "topic__created_at", "order", "created_at")
+    )
+
+
+def topic_flow_find(*, topic_slug: str, flow_slug: str) -> TopicFlow | None:
+    """The enabled flow at (topic_slug, flow_slug) with its whole content
+    graph prefetched, or None."""
+    return (
+        TopicFlow.objects.filter(
+            topic__slug=topic_slug, slug=flow_slug, enabled=True
+        )
+        .select_related("topic")
+        .prefetch_related(
+            "sections",
+            "links",
+            "deadlines__offset_from",
+            "form_conditions__form",
+            "form_conditions__variable",
+            "interview_pages__variables__variable__asked_when",
+        )
+        .first()
+    )
 
 
 def variable_answer_list(*, identity) -> list[VariableAnswer]:

--- a/litigant_portal/app/services/chat_engine.py
+++ b/litigant_portal/app/services/chat_engine.py
@@ -377,6 +377,8 @@ def chat_stream(
 
     def event_stream() -> Iterator[str]:
         yield _sse({"type": "thread", "thread_id": str(thread.id)})
+        thread.refresh_from_db(fields=["state"])
+        yield _sse({"type": "state", "state": thread.state})
 
         attachment_cache: dict = {}
 

--- a/litigant_portal/app/services/chat_engine.py
+++ b/litigant_portal/app/services/chat_engine.py
@@ -1,11 +1,12 @@
 import hashlib
 import json
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import litellm
 from django.conf import settings
+from django.db import transaction
 from django.http import StreamingHttpResponse
 from django.template.loader import render_to_string
 
@@ -105,6 +106,27 @@ def chat_thread_delete(
     chat_thread_get(
         identity=identity, thread_id=thread_id, thread_type=thread_type
     ).delete()
+
+
+StateUpdates = dict[str, Any] | Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def chat_thread_state_merge(*, thread_id, updates: StateUpdates) -> dict:
+    """Merge ``updates`` into a thread's state under a row lock.
+
+    ``updates`` is the dict to merge, or a callable given the locked
+    current state and returning that dict (return {} to skip the write).
+    Every thread-state write goes through here so no writer can race
+    another's read-modify-write.
+    """
+    with transaction.atomic():
+        thread = ChatThread.objects.select_for_update().get(id=thread_id)
+        state = thread.state or {}
+        merged = updates(state) if callable(updates) else updates
+        if merged:
+            thread.state = {**state, **merged}
+            thread.save(update_fields=["state", "updated_at"])
+        return thread.state
 
 
 def chat_message_inject_hidden(

--- a/litigant_portal/app/services/chat_engine.py
+++ b/litigant_portal/app/services/chat_engine.py
@@ -359,6 +359,8 @@ def chat_stream(
             "the model is passed to chat_stream by the caller."
         )
 
+    agent.prepare_thread(thread_id=thread.id)
+
     user_data: dict[str, Any] = {"role": "user", "content": message}
     if attachment_ids:
         user_data["attachments"] = [str(i) for i in attachment_ids]

--- a/litigant_portal/app/tests/test_assistant_topic_flow.py
+++ b/litigant_portal/app/tests/test_assistant_topic_flow.py
@@ -1,0 +1,258 @@
+"""Postgres tests: the assistant's active topic flow — the tool that loads
+it, the flow list injected into the system prompt, and stale-state
+clearing."""
+
+import pytest
+from django.test import TestCase
+
+from litigant_portal.agents.assistant import (
+    LitigantAssistant,
+    LitigantAssistantState,
+)
+from litigant_portal.agents.tools.load_topic_flow import (
+    LoadTopicFlow,
+    topic_flow_from_path,
+    topic_flow_markdown,
+    topic_flow_path,
+)
+from litigant_portal.app.models import (
+    ChatThread,
+    Form,
+    Topic,
+    TopicFlow,
+    TopicFlowDeadline,
+    TopicFlowFormCondition,
+    TopicFlowInterviewPage,
+    TopicFlowInterviewVariable,
+    TopicFlowLink,
+    TopicFlowSection,
+    UserIdentity,
+    Variable,
+)
+from litigant_portal.app.models.choices import VariableDataType
+from litigant_portal.app.selectors.topic_flow import (
+    topic_flow_find,
+    topic_flow_list,
+)
+
+
+def _eviction_flow() -> TopicFlow:
+    topic = Topic.objects.create(slug="eviction", title="Eviction")
+    return TopicFlow.objects.create(
+        topic=topic,
+        slug="tenant",
+        name="Responding to an Eviction",
+        enabled=True,
+    )
+
+
+def _thread() -> ChatThread:
+    identity = UserIdentity.objects.create(session_key="abc123")
+    return ChatThread.objects.create(
+        identity=identity, thread_type="user_chat"
+    )
+
+
+@pytest.mark.postgres
+class TopicFlowSelectorTests(TestCase):
+    def test_list_returns_only_enabled_flows(self):
+        flow = _eviction_flow()
+        TopicFlow.objects.create(
+            topic=flow.topic,
+            slug="landlord",
+            name="Filing an Eviction",
+            enabled=False,
+        )
+        self.assertEqual(topic_flow_list(), [flow])
+
+    def test_find_returns_flow_by_slugs(self):
+        flow = _eviction_flow()
+        self.assertEqual(
+            topic_flow_find(topic_slug="eviction", flow_slug="tenant"), flow
+        )
+
+    def test_find_returns_none_for_disabled_flow(self):
+        flow = _eviction_flow()
+        flow.enabled = False
+        flow.save()
+        self.assertIsNone(
+            topic_flow_find(topic_slug="eviction", flow_slug="tenant")
+        )
+
+    def test_find_returns_none_for_unknown_slugs(self):
+        self.assertIsNone(
+            topic_flow_find(topic_slug="eviction", flow_slug="tenant")
+        )
+
+
+@pytest.mark.postgres
+class TopicFlowPathTests(TestCase):
+    def test_round_trip(self):
+        flow = _eviction_flow()
+        self.assertEqual(topic_flow_path(flow), "eviction/tenant")
+        self.assertEqual(topic_flow_from_path("eviction/tenant"), flow)
+
+    def test_malformed_paths_return_none(self):
+        _eviction_flow()
+        for path in ("eviction", "eviction/", "/tenant", ""):
+            self.assertIsNone(topic_flow_from_path(path))
+
+
+@pytest.mark.postgres
+class TopicFlowMarkdownTests(TestCase):
+    def test_markdown_covers_the_flow_content_graph(self):
+        flow = _eviction_flow()
+        TopicFlowSection.objects.create(
+            flow=flow, heading="First steps", content="Read the notice."
+        )
+        served = Variable.objects.create(
+            name="date_served",
+            label="Date you were served",
+            data_type=VariableDataType.DATE,
+        )
+        TopicFlowDeadline.objects.create(
+            flow=flow, label="Answer due", offset_days=28, offset_from=served
+        )
+        county = Variable.objects.create(
+            name="county",
+            question="What county do you live in?",
+            data_type=VariableDataType.CHOICE,
+            choices=[{"value": "cass", "label": "Cass County"}],
+        )
+        page = TopicFlowInterviewPage.objects.create(
+            flow=flow, title="About your case"
+        )
+        TopicFlowInterviewVariable.objects.create(page=page, variable=served)
+        TopicFlowInterviewVariable.objects.create(page=page, variable=county)
+        form = Form.objects.create(slug="answer", name="Answer Form")
+        TopicFlowFormCondition.objects.create(flow=flow, form=form)
+        TopicFlowLink.objects.create(
+            flow=flow, name="Court site", url="https://example.com/court"
+        )
+
+        markdown = topic_flow_markdown(
+            topic_flow_find(topic_slug="eviction", flow_slug="tenant")
+        )
+
+        self.assertIn("# Responding to an Eviction", markdown)
+        self.assertIn("Topic: Eviction", markdown)
+        self.assertIn("## First steps", markdown)
+        self.assertIn("Read the notice.", markdown)
+        self.assertIn(
+            "- Answer due: 28 days after Date you were served", markdown
+        )
+        self.assertIn("- Answer Form", markdown)
+        self.assertIn("### About your case", markdown)
+        self.assertIn("- date_served (date): Date you were served", markdown)
+        self.assertIn(
+            "- county (choice): What county do you live in? [choices: cass]",
+            markdown,
+        )
+        self.assertIn("- Court site: https://example.com/court", markdown)
+
+    def test_markdown_omits_empty_sections(self):
+        _eviction_flow()
+        markdown = topic_flow_markdown(
+            topic_flow_find(topic_slug="eviction", flow_slug="tenant")
+        )
+        for heading in ("## Deadlines", "## Form packet", "## Links"):
+            self.assertNotIn(heading, markdown)
+
+
+@pytest.mark.postgres
+class LoadTopicFlowToolTests(TestCase):
+    def setUp(self):
+        self.thread = _thread()
+        self.flow = _eviction_flow()
+
+    def test_result_names_the_active_flow_then_gives_its_markdown(self):
+        output = LoadTopicFlow(topic_flow="eviction/tenant")(
+            thread_id=self.thread.id
+        )
+        self.assertTrue(
+            output.result.startswith(
+                "The active topic flow is now eviction/tenant "
+                "(Responding to an Eviction)."
+            )
+        )
+        self.assertIn("# Responding to an Eviction", output.result)
+        self.assertFalse(output.refresh_system_prompt)
+        self.assertEqual(output.render_data["topic_flow"], "eviction/tenant")
+        self.thread.refresh_from_db()
+        state = LitigantAssistantState.model_validate(self.thread.state)
+        self.assertEqual(state.active_topic_flow, "eviction/tenant")
+
+    def test_preserves_other_state_keys(self):
+        self.thread.state = {"other": "kept"}
+        self.thread.save(update_fields=["state"])
+        LoadTopicFlow(topic_flow="eviction/tenant")(thread_id=self.thread.id)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.state["other"], "kept")
+
+    def test_unknown_flow_errors_and_writes_nothing(self):
+        output = LoadTopicFlow(topic_flow="eviction/landlord")(
+            thread_id=self.thread.id
+        )
+        self.assertIn("Error", output.result)
+        self.assertIn("eviction/tenant", output.result)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.state, {})
+
+
+@pytest.mark.postgres
+class AssistantSystemPromptTests(TestCase):
+    def setUp(self):
+        self.thread = _thread()
+        self.agent = LitigantAssistant()
+
+    def test_lists_available_flows(self):
+        _eviction_flow()
+        prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertIn(
+            "- eviction/tenant: Responding to an Eviction (Eviction)", prompt
+        )
+
+    def test_no_flow_section_when_no_flows_exist(self):
+        prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertNotIn("Guided topic flows", prompt)
+
+    def test_prompt_ignores_the_active_flow(self):
+        # The prompt depends only on the enabled-flow list, never on
+        # per-thread state, so all threads share one cached prompt
+        # artifact.
+        _eviction_flow()
+        before = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.thread.state = {"active_topic_flow": "eviction/tenant"}
+        self.thread.save(update_fields=["state"])
+        after = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertEqual(before, after)
+
+
+@pytest.mark.postgres
+class AssistantPrepareThreadTests(TestCase):
+    def setUp(self):
+        self.thread = _thread()
+        self.agent = LitigantAssistant()
+
+    def test_clears_a_stale_active_flow(self):
+        _eviction_flow()
+        self.thread.state = {"active_topic_flow": "eviction/gone"}
+        self.thread.save(update_fields=["state"])
+        self.agent.prepare_thread(thread_id=self.thread.id)
+        self.thread.refresh_from_db()
+        self.assertIsNone(self.thread.state["active_topic_flow"])
+
+    def test_keeps_a_valid_active_flow(self):
+        _eviction_flow()
+        self.thread.state = {"active_topic_flow": "eviction/tenant"}
+        self.thread.save(update_fields=["state"])
+        self.agent.prepare_thread(thread_id=self.thread.id)
+        self.thread.refresh_from_db()
+        self.assertEqual(
+            self.thread.state["active_topic_flow"], "eviction/tenant"
+        )
+
+    def test_ignores_a_thread_with_no_active_flow(self):
+        self.agent.prepare_thread(thread_id=self.thread.id)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.state, {})

--- a/litigant_portal/app/tests/test_assistant_topic_flow.py
+++ b/litigant_portal/app/tests/test_assistant_topic_flow.py
@@ -119,13 +119,27 @@ class TopicFlowMarkdownTests(TestCase):
             data_type=VariableDataType.CHOICE,
             choices=[{"value": "cass", "label": "Cass County"}],
         )
+        lease_end = Variable.objects.create(
+            name="lease_end",
+            question="When does your lease end?",
+            data_type=VariableDataType.DATE,
+            asked_when=county,
+            asked_when_value="cass",
+        )
         page = TopicFlowInterviewPage.objects.create(
             flow=flow, title="About your case"
         )
         TopicFlowInterviewVariable.objects.create(page=page, variable=served)
         TopicFlowInterviewVariable.objects.create(page=page, variable=county)
+        TopicFlowInterviewVariable.objects.create(
+            page=page, variable=lease_end
+        )
         form = Form.objects.create(slug="answer", name="Answer Form")
         TopicFlowFormCondition.objects.create(flow=flow, form=form)
+        fee_waiver = Form.objects.create(slug="fee-waiver", name="Fee Waiver")
+        TopicFlowFormCondition.objects.create(
+            flow=flow, form=fee_waiver, variable=county, value="cass"
+        )
         TopicFlowLink.objects.create(
             flow=flow, name="Court site", url="https://example.com/court"
         )
@@ -142,10 +156,18 @@ class TopicFlowMarkdownTests(TestCase):
             "- Answer due: 28 days after Date you were served", markdown
         )
         self.assertIn("- Answer Form", markdown)
+        self.assertIn(
+            '- Fee Waiver (included when county equals "cass")', markdown
+        )
         self.assertIn("### About your case", markdown)
         self.assertIn("- date_served (date): Date you were served", markdown)
         self.assertIn(
             "- county (choice): What county do you live in? [choices: cass]",
+            markdown,
+        )
+        self.assertIn(
+            "- lease_end (date): When does your lease end? "
+            '(asked when county = "cass")',
             markdown,
         )
         self.assertIn("- Court site: https://example.com/court", markdown)

--- a/litigant_portal/app/tests/test_chat_thread_state.py
+++ b/litigant_portal/app/tests/test_chat_thread_state.py
@@ -1,0 +1,41 @@
+"""chat_thread_state_merge is the single locked write path for thread
+state."""
+
+import pytest
+from django.test import TestCase
+
+from litigant_portal.app.models import ChatThread, UserIdentity
+from litigant_portal.app.services.chat_engine import chat_thread_state_merge
+
+
+@pytest.mark.postgres
+class ChatThreadStateMergeTests(TestCase):
+    def setUp(self):
+        identity = UserIdentity.objects.create(session_key="merge")
+        self.thread = ChatThread.objects.create(
+            identity=identity, thread_type="user_chat", state={"kept": 1}
+        )
+
+    def test_merges_and_preserves_other_keys(self):
+        merged = chat_thread_state_merge(
+            thread_id=self.thread.id, updates={"added": 2}
+        )
+        self.assertEqual(merged, {"kept": 1, "added": 2})
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.state, {"kept": 1, "added": 2})
+
+    def test_callable_updates_see_the_current_state(self):
+        merged = chat_thread_state_merge(
+            thread_id=self.thread.id,
+            updates=lambda state: {"kept": state["kept"] + 1},
+        )
+        self.assertEqual(merged["kept"], 2)
+
+    def test_callable_returning_empty_skips_the_write(self):
+        before = self.thread.updated_at
+        merged = chat_thread_state_merge(
+            thread_id=self.thread.id, updates=lambda state: {}
+        )
+        self.assertEqual(merged, {"kept": 1})
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.updated_at, before)

--- a/litigant_portal/app/tests/test_prepare_thread.py
+++ b/litigant_portal/app/tests/test_prepare_thread.py
@@ -1,0 +1,76 @@
+"""The engine runs Agent.prepare_thread once per user message, before the
+first model call."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.test import SimpleTestCase, TestCase
+
+from litigant_portal.agents.base import Agent
+from litigant_portal.app.models import ChatThread, UserIdentity
+from litigant_portal.app.services.chat_engine import chat_stream
+
+
+class PreparingAgent(Agent):
+    events: list = []
+
+    def prepare_thread(self, *, thread_id) -> None:
+        type(self).events.append("prepare")
+
+    def generate_system_prompt(self, *, thread_id) -> str:
+        type(self).events.append("prompt")
+        return "Prepared prompt"
+
+
+def _chunk(content):
+    return SimpleNamespace(
+        usage=None,
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content, tool_calls=[])
+            )
+        ],
+    )
+
+
+class PrepareThreadDefaultTests(SimpleTestCase):
+    def test_base_hook_is_a_noop(self):
+        self.assertIsNone(Agent().prepare_thread(thread_id="ignored"))
+
+
+@pytest.mark.postgres
+class PrepareThreadEngineTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="prep")
+        self.thread = ChatThread.objects.create(
+            identity=self.identity,
+            thread_type="test_agent",
+            description="Existing description",
+        )
+        PreparingAgent.events = []
+
+    def test_runs_once_before_the_first_prompt_build(self):
+        with (
+            patch(
+                "litigant_portal.app.services.chat_engine.litellm.completion",
+                return_value=iter([_chunk("Answer.")]),
+            ),
+            patch(
+                "litigant_portal.app.services.chat_engine.litellm.token_counter",
+                return_value=0,
+            ),
+        ):
+            response = chat_stream(
+                identity=self.identity,
+                message="Hello.",
+                agent_class=PreparingAgent,
+                thread_type="test_agent",
+                model="gpt-5-mini",
+                thread_id=str(self.thread.id),
+            )
+            list(response.streaming_content)
+
+        self.assertEqual(PreparingAgent.events.count("prepare"), 1)
+        self.assertEqual(PreparingAgent.events[0], "prepare")
+        self.assertIn("prompt", PreparingAgent.events)

--- a/litigant_portal/app/tests/test_prepare_thread.py
+++ b/litigant_portal/app/tests/test_prepare_thread.py
@@ -1,6 +1,8 @@
 """The engine runs Agent.prepare_thread once per user message, before the
-first model call."""
+first model call, and syncs its state writes to the client at stream
+start."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -17,6 +19,9 @@ class PreparingAgent(Agent):
 
     def prepare_thread(self, *, thread_id) -> None:
         type(self).events.append("prepare")
+        thread = ChatThread.objects.get(id=thread_id)
+        thread.state = {"prepared": True}
+        thread.save(update_fields=["state", "updated_at"])
 
     def generate_system_prompt(self, *, thread_id) -> str:
         type(self).events.append("prompt")
@@ -69,8 +74,17 @@ class PrepareThreadEngineTests(TestCase):
                 model="gpt-5-mini",
                 thread_id=str(self.thread.id),
             )
-            list(response.streaming_content)
+            frames = [
+                json.loads(chunk.decode().removeprefix("data: "))
+                for chunk in response.streaming_content
+            ]
 
         self.assertEqual(PreparingAgent.events.count("prepare"), 1)
         self.assertEqual(PreparingAgent.events[0], "prepare")
         self.assertIn("prompt", PreparingAgent.events)
+
+        # The hook's state write reaches the client at stream start, even
+        # on a turn with no tool calls.
+        self.assertEqual(frames[0]["type"], "thread")
+        self.assertEqual(frames[1]["type"], "state")
+        self.assertEqual(frames[1]["state"], {"prepared": True})


### PR DESCRIPTION
## What changed

Gives the assistant an active topic flow, set by the agent itself. Closes #831.

- **LoadTopicFlow tool** — takes a topic-slug/flow-slug path, validates it against enabled flows, stores it as `active_topic_flow` in thread state, and returns the flow's full content graph as markdown (sections, deadlines, form packet, interview variables, links). Unknown or disabled paths return an error listing the valid paths.
- **System prompt lists the available flows** via a `PROMPT_TEMPLATE` with one injection slot and one builder function per section, so the prompt can grow without `generate_system_prompt` accreting logic.
- **`Agent.prepare_thread(thread_id)` engine hook** — called once per user message, after the thread is resolved and before the message is stored or the first model call. Default no-op; documented in AGENT_DEV_GUIDE. The assistant uses it to clear a stale active flow.
- **Selectors** — `topic_flow_list` and `topic_flow_find` (enabled flows, content graph prefetched).
- **CLAUDE.md** — adds the `corpus` domain to the data-layer table (tack-on).

## Decisions recorded

- **The system prompt omits the active flow.** It varies only with the shared enabled-flow list, never per-thread state, so all threads reuse one cached prompt artifact; a test pins the prompt as byte-identical with and without an active flow. The active flow reaches the model through the tool result in history, and the tool does not set `refresh_system_prompt`.
- **State stores a slug path, not a foreign key**, so a corpus sync can rename, disable, or delete the flow out from under it. `prepare_thread` clears a stale path on every user message; validation reuses the flow list, costing no extra query when no flow is active.
- **State writes are dict merges**, preserving unrelated keys.
- **Strict path parsing.** A pasted listing line errors with the valid paths listed, and the model self-corrects on retry; the argument description and prompt both spell out the path-only format.
-  **Model imports are nested**, a temporary bandaid to the circular imports that would result from `ChatThead` depending on `MessageSchema`. We can fix this once we find a better place for Pydantic schemas (see #830)

## Test plan

- [x] 19 new tests (tool, selectors, markdown, prompt, hook semantics, engine-loop hook ordering); fast-suite portion green, `postgres`-marked portion needs `make test`
- [x] ruff check/format clean; rebased onto #829 with the selector conflict resolved additively

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.