### PR TITLE
feat(ai): render prompt artifacts in Markdown audit transcripts

### DIFF
--- a/docs/wiki/audit-transcripts.md
+++ b/docs/wiki/audit-transcripts.md
@@ -15,7 +15,7 @@ You need a portal account with **staff status**. A developer grants this once (i
    - **Filter** by date or thread type using the sidebar.
 4. Click the thread to open it. The page shows who the conversation belongs to, when it started, and the full transcript: user messages, AI answers, tool calls the AI made, and tool results. Rows marked `[hidden]` or `[meta]` were not visible to the user; they are included because an audit needs the complete record.
 5. To save a copy, use the **Downloads** links on the same page:
-   - **Markdown**: a readable transcript, good for review and sharing.
+   - **Markdown**: a readable transcript, including captured instruction states on first use and whenever they change, good for review and sharing.
    - **JSON**: the raw record with timestamps, token counts, and cost, good for deeper analysis or archiving.
 
 Everything is read-only. You cannot change or delete a conversation from this screen.
@@ -33,10 +33,10 @@ What this means in practice:
 
 ## Reconstituting a conversation's prompts
 
-For model-backed assistant messages, the JSON download stores the instruction state used for that call. Each message's `prompt_artifact_id` points to an entry in the top-level `prompt_artifacts` collection containing the rendered system prompt, tool-schema snapshot, and content hash. Each message also carries the deployed commit SHA (`git_sha` in JSON, or the `Deployed SHA` line(s) in Markdown), preserving the code version that produced it.
+For model-backed assistant messages with a captured prompt artifact, both downloads surface the instruction state used for that call: the rendered system prompt and tool-schema snapshot. The Markdown transcript renders the full prompt artifact immediately before its first use and again whenever the active artifact changes. The JSON download provides exact per-message references: each message's `prompt_artifact_id` points to an entry in the top-level `prompt_artifacts` collection containing the system prompt, tool schemas, and content hash. Each message also carries the deployed commit SHA (`git_sha` in JSON, or the `Deployed SHA` line(s) in Markdown), preserving the code version that produced it.
 
-1. Open the thread's JSON download and find the assistant message for the turn you need.
-2. If it has a `prompt_artifact_id`, find that ID in `prompt_artifacts`. Its `system_prompt` and `tool_schemas` are the values captured for that model call.
+1. For a readable review, open the Markdown transcript. A `Prompt artifact` block appears immediately before its first referenced assistant message and again when a later non-null `prompt_artifact_id` changes. Null references do not reset the renderer's last-known artifact state. Each block includes the artifact ID, content hash, complete system prompt, and tool-schema snapshot.
+2. For exact per-message linkage, open the JSON download and find the assistant message for the turn you need. If it has a `prompt_artifact_id`, find that ID in `prompt_artifacts`. Its `system_prompt` and `tool_schemas` are the values captured for that model call.
 3. Use the message's `git_sha` when you also need the deployed code, or when a legacy message has no prompt artifact. Check it out with `git checkout <sha>`. Long conversations can span more than one SHA; Markdown flags each change and JSON records it per message.
 4. A tool may run its own prompt against another model. Those tool-internal prompts are not captured by prompt artifacts. Currently the only one is the document-query tool, `litigant_portal/agents/tools/query_document.py` (`READER_SYSTEM_PROMPT`), which can be inspected at the recorded SHA.
 5. Combine the captured system prompt, any separately reconstructed tool prompts, and the transcript to see what the AI was told and what it said.
@@ -54,6 +54,7 @@ A spot-check has to happen inside that 30-day window, or the transcript has to b
 ## Known limits
 
 - **Users can delete their own conversations.** The delete button in the portal removes a thread and all its messages immediately and permanently, at any time. The retention window above only protects against the automatic cleanup job, not against the user's own delete. If a transcript matters, download it early. Changing this behavior (for example, hiding a deleted conversation from the user but keeping it for audit) is an open team decision, deliberately deferred.
-- **Prompt artifacts are JSON-only and scoped to assistant model calls.** User, tool, hidden, meta, and legacy messages do not carry a prompt artifact. Markdown transcripts show deployed SHA changes but do not render prompt artifacts.
+- **Prompt artifacts are scoped to assistant model calls.** User, tool, hidden, meta, and legacy messages do not carry a prompt artifact. A null reference does not reset the Markdown renderer's last-known artifact state.
+- **Unreferenced prompt artifacts are not collected yet.** Prompt artifacts are shared across messages and threads. Deleting the last message that references one currently leaves the artifact row in place; orphan cleanup remains separate retention work.
 - **Session keys are lost at login.** If an anonymous user later logs in, their conversations move to their account and the old session key is discarded. The transcript survives; searching by the old session key will not find it, but searching by their email will.
 - **The whole transcript loads at once.** The page renders every message, with no paging or cap, so a very long conversation makes for a slow page. Use the Markdown download instead if a thread is unwieldy on screen.

--- a/litigant_portal/app/selectors/chat_engine.py
+++ b/litigant_portal/app/selectors/chat_engine.py
@@ -1,3 +1,6 @@
+import json
+import re
+
 from django.db.models import OuterRef, QuerySet, Subquery, Sum
 
 from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
@@ -119,6 +122,9 @@ def chat_thread_export_markdown(*, thread: ChatThread) -> str:
     """Human-readable audit transcript of every message row."""
     export = chat_thread_export_data(thread=thread)
     messages = export["messages"]
+    artifacts_by_id = {
+        artifact["id"]: artifact for artifact in export["prompt_artifacts"]
+    }
     lines = [
         f"# Chat transcript {export['thread_id']}",
         "",
@@ -130,6 +136,7 @@ def chat_thread_export_markdown(*, thread: ChatThread) -> str:
         lines.append(f"- Deployed SHA: {_sha_label(messages[0]['git_sha'])}")
 
     previous_sha = messages[0]["git_sha"] if messages else None
+    active_prompt_artifact_id = None
     for msg in messages:
         if msg["git_sha"] != previous_sha:
             lines += [
@@ -137,6 +144,16 @@ def chat_thread_export_markdown(*, thread: ChatThread) -> str:
                 f"**Deployed SHA changed to {_sha_label(msg['git_sha'])}**",
             ]
             previous_sha = msg["git_sha"]
+        prompt_artifact_id = msg["prompt_artifact_id"]
+        if (
+            prompt_artifact_id is not None
+            and prompt_artifact_id != active_prompt_artifact_id
+        ):
+            lines.append("")
+            lines.extend(
+                _prompt_artifact_lines(artifacts_by_id[prompt_artifact_id])
+            )
+            active_prompt_artifact_id = prompt_artifact_id
         lines.append("")
         lines.extend(_message_lines(msg))
     return "\n".join(lines) + "\n"
@@ -145,6 +162,34 @@ def chat_thread_export_markdown(*, thread: ChatThread) -> str:
 def _sha_label(git_sha: str) -> str:
     """A blank git_sha means the message predates this feature (#801)."""
     return git_sha or "unknown"
+
+
+def _prompt_artifact_lines(artifact: dict) -> list[str]:
+    tool_schemas = json.dumps(
+        artifact["tool_schemas"], indent=2, ensure_ascii=False
+    )
+    return [
+        "## Prompt artifact",
+        "",
+        f"- ID: `{artifact['id']}`",
+        f"- Content hash: `{artifact['content_hash']}`",
+        "",
+        "### System prompt",
+        "",
+        *_fenced_block(artifact["system_prompt"], language="text"),
+        "",
+        "### Tool schemas",
+        "",
+        *_fenced_block(tool_schemas, language="json"),
+    ]
+
+
+def _fenced_block(content: str, *, language: str) -> list[str]:
+    longest_run = max(
+        (len(run) for run in re.findall(r"`+", content)), default=0
+    )
+    fence = "`" * max(3, longest_run + 1)
+    return [f"{fence}{language}", content, fence]
 
 
 def _message_lines(msg: dict) -> list[str]:

--- a/litigant_portal/app/tests/test_audit_export.py
+++ b/litigant_portal/app/tests/test_audit_export.py
@@ -60,6 +60,19 @@ class ThreadExportTests(TestCase):
             thread=self.thread, data=data, **kwargs
         )
 
+    def _artifact(
+        self,
+        *,
+        system_prompt="Audit this prompt.",
+        tool_schemas=None,
+        hash_char="a",
+    ):
+        return PromptArtifact.objects.create(
+            system_prompt=system_prompt,
+            tool_schemas=[] if tool_schemas is None else tool_schemas,
+            content_hash=hash_char * 64,
+        )
+
     def test_markdown_renders_meta_rows_with_accounting(self):
         self._message(
             {"role": "meta", "kind": "thread_description"},
@@ -187,6 +200,208 @@ class ThreadExportTests(TestCase):
         self.assertIn("**Deployed SHA changed to def5678**", markdown)
         # Only the change is flagged, not the initial SHA already in the header.
         self.assertNotIn("changed to abc1234", markdown)
+
+    def test_markdown_renders_first_artifact_without_repeating_it(self):
+        artifact = self._artifact()
+        self._message({"role": "user", "content": "Help me."})
+        self._message(
+            {"role": "assistant", "content": "First answer."},
+            prompt_artifact=artifact,
+        )
+        self._message(
+            {"role": "assistant", "content": "Second answer."},
+            prompt_artifact=artifact,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 1)
+        self.assertEqual(markdown.count(f"- ID: `{artifact.id}`"), 1)
+        self.assertIn(f"- Content hash: `{artifact.content_hash}`", markdown)
+        self.assertLess(
+            markdown.index(f"- ID: `{artifact.id}`"),
+            markdown.index("First answer."),
+        )
+        self.assertIn("```json\n[]\n```", markdown)
+
+    def test_markdown_renders_changed_artifact(self):
+        first = self._artifact(system_prompt="First prompt.")
+        second = self._artifact(system_prompt="Second prompt.", hash_char="b")
+        self._message(
+            {"role": "assistant", "content": "First answer."},
+            prompt_artifact=first,
+        )
+        self._message(
+            {"role": "assistant", "content": "Second answer."},
+            prompt_artifact=second,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 2)
+        self.assertLess(
+            markdown.index(f"- ID: `{first.id}`"),
+            markdown.index(f"- ID: `{second.id}`"),
+        )
+        self.assertLess(
+            markdown.index(f"- ID: `{second.id}`"),
+            markdown.index("Second answer."),
+        )
+
+    def test_markdown_renders_artifact_again_when_returning_to_it(self):
+        first = self._artifact(system_prompt="First prompt.")
+        second = self._artifact(system_prompt="Second prompt.", hash_char="b")
+        for content, artifact in (
+            ("First answer.", first),
+            ("Second answer.", second),
+            ("Third answer.", first),
+        ):
+            self._message(
+                {"role": "assistant", "content": content},
+                prompt_artifact=artifact,
+            )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 3)
+        self.assertEqual(markdown.count(f"- ID: `{first.id}`"), 2)
+        second_first_id = markdown.index(f"- ID: `{second.id}`")
+        returned_first_id = markdown.index(
+            f"- ID: `{first.id}`", second_first_id
+        )
+        self.assertLess(returned_first_id, markdown.index("Third answer."))
+
+    def test_markdown_null_rows_do_not_reset_active_artifact(self):
+        artifact = self._artifact()
+        self._message(
+            {"role": "assistant", "content": "First answer."},
+            prompt_artifact=artifact,
+        )
+        self._message({"role": "user", "content": "Follow-up."})
+        self._message(
+            {
+                "role": "tool",
+                "name": "lookup",
+                "tool_call_id": "call-1",
+                "content": "Tool result.",
+            }
+        )
+        self._message({"role": "meta", "kind": "accounting"}, meta=True)
+        self._message(
+            {"role": "assistant", "content": "Second answer."},
+            prompt_artifact=artifact,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 1)
+        self.assertIn("Follow-up.", markdown)
+        self.assertIn("Tool result.", markdown)
+        self.assertIn("## meta: accounting [meta]", markdown)
+
+    def test_markdown_legacy_null_assistant_messages_are_safe(self):
+        artifact = self._artifact()
+        self._message({"role": "assistant", "content": "Legacy before."})
+        self._message(
+            {"role": "assistant", "content": "Captured answer."},
+            prompt_artifact=artifact,
+        )
+        self._message({"role": "assistant", "content": "Legacy between."})
+        self._message(
+            {"role": "assistant", "content": "Captured again."},
+            prompt_artifact=artifact,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 1)
+        self.assertLess(
+            markdown.index("Legacy before."),
+            markdown.index(f"- ID: `{artifact.id}`"),
+        )
+        self.assertIn("Legacy between.", markdown)
+
+    def test_markdown_tool_call_only_assistant_renders_artifact(self):
+        artifact = self._artifact()
+        self._message(
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "arguments": '{"query": "eviction"}',
+                        },
+                    }
+                ],
+            },
+            prompt_artifact=artifact,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertLess(
+            markdown.index(f"- ID: `{artifact.id}`"),
+            markdown.index('Tool call: lookup({"query": "eviction"})'),
+        )
+
+    def test_markdown_tool_schema_only_change_is_visible(self):
+        first = self._artifact(
+            system_prompt="Same prompt.",
+            tool_schemas=[{"function": {"name": "first_tool"}}],
+        )
+        second = self._artifact(
+            system_prompt="Same prompt.",
+            tool_schemas=[{"function": {"name": "second_tool"}}],
+            hash_char="b",
+        )
+        self._message(
+            {"role": "assistant", "content": "First answer."},
+            prompt_artifact=first,
+        )
+        self._message(
+            {"role": "assistant", "content": "Second answer."},
+            prompt_artifact=second,
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertEqual(markdown.count("## Prompt artifact"), 2)
+        self.assertEqual(markdown.count("Same prompt."), 2)
+        self.assertIn('"name": "first_tool"', markdown)
+        self.assertIn('"name": "second_tool"', markdown)
+
+    def test_markdown_contains_fences_and_orders_sha_before_prompt_change(
+        self,
+    ):
+        embedded_markdown = "# Nested heading\n\n```python\nprint('safe')\n```"
+        first = self._artifact(system_prompt="First prompt.")
+        second = self._artifact(system_prompt=embedded_markdown, hash_char="b")
+        self._message(
+            {"role": "assistant", "content": "Before deploy."},
+            prompt_artifact=first,
+            git_sha="abc1234",
+        )
+        self._message(
+            {"role": "assistant", "content": "After deploy."},
+            prompt_artifact=second,
+            git_sha="def5678",
+        )
+
+        markdown = chat_thread_export_markdown(thread=self.thread)
+
+        self.assertIn(
+            f"````text\n{embedded_markdown}\n````",
+            markdown,
+        )
+        sha_change = markdown.index("**Deployed SHA changed to def5678**")
+        prompt_change = markdown.index(f"- ID: `{second.id}`")
+        assistant_message = markdown.index("After deploy.")
+        self.assertLess(sha_change, prompt_change)
+        self.assertLess(prompt_change, assistant_message)
 
     def test_json_export_defines_each_referenced_prompt_artifact_once(self):
         artifact = PromptArtifact.objects.create(


### PR DESCRIPTION
## What changed

- Render captured prompt artifacts in Markdown audit transcripts.
- Show the full instruction state, including the rendered system prompt and tool-schema snapshot.
- Render a prompt artifact immediately before its first referenced assistant message and again whenever the active non-null artifact changes.
- Preserve the last-known artifact state across user, tool, hidden, meta, and legacy rows with null prompt references.
- Correctly render transitions back to an earlier artifact, such as A → B → A.
- Keep prompt-artifact transitions independent from deployed-SHA transitions.
- When both change on the same turn, render the deployed-SHA change first, then the prompt artifact, then the assistant message.
- Use collision-safe Markdown fences so prompts containing headings or code fences cannot break the transcript structure.
- Pretty-print tool schemas for readable audit review.
- Update the audit-transcript documentation to describe Markdown prompt artifacts, null-reference behavior, and the remaining retention/tool-internal-prompt limits.
- Add focused coverage for first use, unchanged artifacts, changed artifacts, returning artifacts, null rows, legacy messages, tool-call-only assistant responses, schema-only changes, and Markdown/SHA ordering.

This is the Markdown transcript slice of #790.

It does not change prompt capture, storage, hashing, deduplication, JSON export behavior, models, migrations, tool-internal prompt capture, orphan cleanup/retention, model-name tracking, or deployed-SHA capture.

Part of #790

## Test plan

Validated against the PostgreSQL-backed Docker environment:

- [x] Audit-export test module: 28 passed
- [x] Ruff check passed for changed Python files
- [x] Ruff format check passed for changed Python files
- [x] Prettier passed for `docs/wiki/audit-transcripts.md`
- [x] `git diff --check`

## AI Disclosure

- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

AI model used:

- ChatGPT GPT-5.6 Sol via Codex

I reviewed the implementation, tests, Markdown rendering behavior, null-reference state handling, documentation, Docker test results, and final diff, and take responsibility for the contribution.

Closes #840