### PR TITLE
Court context section in the assistant system prompt

### DIFF
--- a/litigant_portal/agents/assistant.py
+++ b/litigant_portal/agents/assistant.py
@@ -13,6 +13,16 @@ files appear directly in the conversation. A note reading [Attached file \
 tool with its upload_id to read or query it. Never guess at the contents \
 of a file you haven't seen."""
 
+COURT_PROMPT = """\
+## Court context
+
+{context}"""
+
+MULTI_COURT_CONTEXT = """\
+This portal is running in multi-court mode: the guided topic flows may \
+belong to different courts. Confirm which court and state the user's case \
+is in before relying on court-specific details."""
+
 TOPIC_FLOWS_PROMPT = """\
 ## Guided topic flows
 
@@ -26,10 +36,28 @@ flow is active. Available flows:
 
 {flows}"""
 
-PROMPT_TEMPLATE = """\
-{base}
 
-{topic_flows}"""
+def generate_court_prompt() -> str:
+    """The court-context section. A blank court name means the site
+    wasn't synced to one court, so the flows may span several."""
+    from litigant_portal.app.selectors.site import site_get
+
+    site = site_get()
+    if not site.court_name:
+        return COURT_PROMPT.format(context=MULTI_COURT_CONTEXT)
+    lines = [f"You are operating in {site.court_name}."]
+    if site.jurisdiction_level:
+        level = site.get_jurisdiction_level_display()
+        lines.append(f"- Jurisdiction level: {level}")
+    if site.state:
+        lines.append(f"- State: {site.get_state_display()}")
+    if site.official_url:
+        lines.append(f"- Court website: {site.official_url}")
+    if site.official_resources_url:
+        lines.append(
+            f"- Court self-help resources: {site.official_resources_url}"
+        )
+    return COURT_PROMPT.format(context="\n".join(lines))
 
 
 def generate_topic_flows_prompt() -> str:
@@ -84,7 +112,7 @@ class LitigantAssistant(Agent):
         chat_thread_state_merge(thread_id=thread_id, updates=clear_if_stale)
 
     def generate_system_prompt(self, *, thread_id) -> str:
-        """Each prompt piece injected into PROMPT_TEMPLATE.
+        """The non-empty prompt sections, blank-line separated.
 
         The active topic flow is deliberately absent: the model learns it
         from the LoadTopicFlow result in history, which only works while
@@ -92,7 +120,12 @@ class LitigantAssistant(Agent):
         we'll need to account for the active topic flow data being dropped from
         history.
         """
-        return PROMPT_TEMPLATE.format(
-            base=BASE_PROMPT,
-            topic_flows=generate_topic_flows_prompt(),
-        ).strip()
+        return "\n\n".join(
+            section
+            for section in (
+                BASE_PROMPT,
+                generate_court_prompt(),
+                generate_topic_flows_prompt(),
+            )
+            if section
+        )

--- a/litigant_portal/app/management/commands/sync_corpus.py
+++ b/litigant_portal/app/management/commands/sync_corpus.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
             help="Court slug to deploy: its topics, flows, and site config. "
             "Defaults to the CORPUS_COURT setting. With neither set, every "
             "court's topics, flows, contacts, and resources sync, and "
-            "the site's court fields are left alone.",
+            "the site's court fields are left alone. A blank court name "
+            "is treated as multi-court mode.",
         )
         parser.add_argument(
             "--strict",

--- a/litigant_portal/app/tests/test_assistant_topic_flow.py
+++ b/litigant_portal/app/tests/test_assistant_topic_flow.py
@@ -18,6 +18,7 @@ from litigant_portal.agents.tools.load_topic_flow import (
 from litigant_portal.app.models import (
     ChatThread,
     Form,
+    Site,
     Topic,
     TopicFlow,
     TopicFlowDeadline,
@@ -237,6 +238,41 @@ class AssistantSystemPromptTests(TestCase):
     def test_no_flow_section_when_no_flows_exist(self):
         prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
         self.assertNotIn("Guided topic flows", prompt)
+
+    def test_court_context_from_site_config(self):
+        site = Site.objects.get()
+        site.court_name = "Alpha District Court"
+        site.jurisdiction_level = "state"
+        site.state = "ND"
+        site.official_url = "https://alpha.test"
+        site.official_resources_url = "https://alpha.test/help"
+        site.save()
+        prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertIn("## Court context", prompt)
+        self.assertIn("You are operating in Alpha District Court.", prompt)
+        self.assertIn("- Jurisdiction level: State", prompt)
+        self.assertIn("- State: North Dakota", prompt)
+        self.assertIn("- Court website: https://alpha.test", prompt)
+        self.assertIn(
+            "- Court self-help resources: https://alpha.test/help", prompt
+        )
+
+    def test_court_context_omits_blank_fields(self):
+        site = Site.objects.get()
+        site.court_name = "Alpha District Court"
+        site.save()
+        prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertIn("You are operating in Alpha District Court.", prompt)
+        self.assertNotIn("Jurisdiction level", prompt)
+        self.assertNotIn("- State:", prompt)
+        self.assertNotIn("Court website", prompt)
+        self.assertNotIn("self-help resources", prompt)
+
+    def test_blank_court_name_means_multi_court_mode(self):
+        prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
+        self.assertIn("## Court context", prompt)
+        self.assertIn("multi-court mode", prompt)
+        self.assertNotIn("You are operating in", prompt)
 
     def test_prompt_ignores_the_active_flow(self):
         # The prompt depends only on the enabled-flow list, never on

--- a/litigant_portal/app/tests/test_assistant_topic_flow.py
+++ b/litigant_portal/app/tests/test_assistant_topic_flow.py
@@ -18,7 +18,6 @@ from litigant_portal.agents.tools.load_topic_flow import (
 from litigant_portal.app.models import (
     ChatThread,
     Form,
-    Site,
     Topic,
     TopicFlow,
     TopicFlowDeadline,
@@ -35,6 +34,7 @@ from litigant_portal.app.selectors.topic_flow import (
     topic_flow_find,
     topic_flow_list,
 )
+from litigant_portal.app.services.site import site_update
 
 
 def _eviction_flow() -> TopicFlow:
@@ -240,13 +240,14 @@ class AssistantSystemPromptTests(TestCase):
         self.assertNotIn("Guided topic flows", prompt)
 
     def test_court_context_from_site_config(self):
-        site = Site.objects.get()
-        site.court_name = "Alpha District Court"
-        site.jurisdiction_level = "state"
-        site.state = "ND"
-        site.official_url = "https://alpha.test"
-        site.official_resources_url = "https://alpha.test/help"
-        site.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            site_update(
+                court_name="Alpha District Court",
+                jurisdiction_level="state",
+                state="ND",
+                official_url="https://alpha.test",
+                official_resources_url="https://alpha.test/help",
+            )
         prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
         self.assertIn("## Court context", prompt)
         self.assertIn("You are operating in Alpha District Court.", prompt)
@@ -258,9 +259,8 @@ class AssistantSystemPromptTests(TestCase):
         )
 
     def test_court_context_omits_blank_fields(self):
-        site = Site.objects.get()
-        site.court_name = "Alpha District Court"
-        site.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            site_update(court_name="Alpha District Court")
         prompt = self.agent.generate_system_prompt(thread_id=self.thread.id)
         self.assertIn("You are operating in Alpha District Court.", prompt)
         self.assertNotIn("Jurisdiction level", prompt)


### PR DESCRIPTION
Fixes #838. Part of #179.

## What

Adds a `## Court context` section to the litigant assistant's system prompt, built from the Site singleton's court config:

- When `court_name` is populated, the section states the court the assistant is operating in, plus jurisdiction level, state, official court website, and official self-help resources URL. Each line is included only when its field is populated.
- When `court_name` is blank (a no-court `sync_corpus` run leaves the site's court fields alone), the section renders a multi-court variant instead: the guided topic flows may belong to different courts, so confirm the user's court and state before relying on court-specific details.

`generate_system_prompt` now joins the non-empty sections directly, which also removes the stray blank lines the old fixed template produced when a section was empty.

No sync or model changes. The `sync_corpus --court` help text gains one sentence noting that a blank court name is treated as multi-court mode.

## Tests

Four new cases in `AssistantSystemPromptTests`: fully populated court config, blank optional fields omitted, and the multi-court variant on a blank court name. All are `postgres`-marked, so they run under `make test`.