### PR TITLE
test: add coverage for chat engine tool execution, thread endpoints, and upload serialization

### DIFF
--- a/litigant_portal/app/tests/test_chat_thread_endpoints.py
+++ b/litigant_portal/app/tests/test_chat_thread_endpoints.py
@@ -1,0 +1,257 @@
+"""Tests for the thread endpoints in views/chat_engine.py, through the
+assistant surface.
+
+Every endpoint is a cross-identity ownership boundary: chat_thread_get scopes
+by identity and thread_type, and a regression there means one litigant reading
+another's conversation. All tests are postgres-marked (`make test`).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+from litigant_portal.app.models import ChatMessage, ChatThread, UserIdentity
+from litigant_portal.app.services.chat_engine import chat_message_create
+from litigant_portal.app.services.user import user_identity_ensure
+
+pytestmark = [pytest.mark.postgres, pytest.mark.django_db]
+
+ASSISTANT_BASE = "/api/agents/assistant/"
+MODEL = "gpt-5-mini"
+
+
+def _client_identity():
+    """A client with an established anonymous session and its identity."""
+    client = Client()
+    client.get(ASSISTANT_BASE + "threads/")
+    identity = UserIdentity.objects.get(session_key=client.session.session_key)
+    return client, identity
+
+
+def _superuser_client_identity():
+    # Identity for an authenticated user is keyed by user, not session key,
+    # so login-time session rotation doesn't detach it.
+    user = get_user_model().objects.create_superuser(
+        username="root", password="pw"
+    )
+    client = Client()
+    client.force_login(user)
+    return client, user_identity_ensure(user=user)
+
+
+def _thread(identity, thread_type="user_chat", **kwargs):
+    return ChatThread.objects.create(
+        identity=identity, thread_type=thread_type, **kwargs
+    )
+
+
+def _message(thread, content, role="user", **kwargs):
+    return chat_message_create(
+        thread_id=thread.id,
+        data={"role": role, "content": content},
+        model=MODEL,
+        num_tokens=kwargs.pop("num_tokens", 0),
+        **kwargs,
+    )
+
+
+# thread_list
+
+
+def test_thread_list_excludes_other_identities_threads():
+    client, identity = _client_identity()
+    mine = _thread(identity)
+    stranger = UserIdentity.objects.create(session_key="stranger")
+    _thread(stranger)
+
+    res = client.get(ASSISTANT_BASE + "threads/")
+
+    assert res.status_code == 200
+    assert [t["id"] for t in res.json()["threads"]] == [str(mine.id)]
+
+
+def test_thread_list_excludes_other_thread_types():
+    client, identity = _client_identity()
+    _thread(identity, thread_type="weather_chat")
+
+    assert client.get(ASSISTANT_BASE + "threads/").json()["threads"] == []
+
+
+def test_thread_list_orders_by_most_recently_updated():
+    client, identity = _client_identity()
+    first = _thread(identity)
+    _thread(identity)
+    first.save()  # bumps updated_at
+
+    ids = [
+        t["id"]
+        for t in client.get(ASSISTANT_BASE + "threads/").json()["threads"]
+    ]
+
+    assert ids[0] == str(first.id)
+
+
+def test_thread_list_snippet_skips_hidden_and_meta_messages():
+    client, identity = _client_identity()
+    thread = _thread(identity)
+    _message(thread, "visible answer", role="assistant")
+    _message(thread, "injected context", hidden=True)
+    _message(thread, "bookkeeping", meta=True)
+
+    threads = client.get(ASSISTANT_BASE + "threads/").json()["threads"]
+
+    assert threads[0]["snippet"] == "visible answer"
+
+
+def test_thread_list_snippet_is_truncated_to_500_chars():
+    client, identity = _client_identity()
+    thread = _thread(identity)
+    _message(thread, "x" * 600)
+
+    threads = client.get(ASSISTANT_BASE + "threads/").json()["threads"]
+
+    assert len(threads[0]["snippet"]) == 500
+
+
+def test_thread_list_last_at_falls_back_to_updated_at_when_empty():
+    client, identity = _client_identity()
+    thread = _thread(identity)
+
+    threads = client.get(ASSISTANT_BASE + "threads/").json()["threads"]
+
+    assert threads[0]["last_at"] == thread.updated_at.isoformat()
+
+
+# message_list
+
+
+def test_message_list_returns_thread_payload():
+    client, identity = _client_identity()
+    thread = _thread(identity, description="my case")
+    _message(thread, "hello")
+
+    res = client.get(ASSISTANT_BASE + f"threads/{thread.id}/")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["id"] == str(thread.id)
+    assert payload["description"] == "my case"
+    assert payload["state"] == {}
+    # Item contents are pinned by test_chat_hidden.py; here only the shape.
+    assert isinstance(payload["items"], list)
+
+
+def test_message_list_of_another_identitys_thread_is_404():
+    client, _ = _client_identity()
+    stranger = UserIdentity.objects.create(session_key="stranger")
+    thread = _thread(stranger)
+
+    res = client.get(ASSISTANT_BASE + f"threads/{thread.id}/")
+
+    assert res.status_code == 404
+    assert res.json()["error"] == "Thread not found"
+
+
+def test_message_list_of_other_thread_type_is_404():
+    client, identity = _client_identity()
+    thread = _thread(identity, thread_type="weather_chat")
+
+    assert (
+        client.get(ASSISTANT_BASE + f"threads/{thread.id}/").status_code == 404
+    )
+
+
+def test_message_list_of_unknown_thread_is_404():
+    client, _ = _client_identity()
+
+    res = client.get(
+        ASSISTANT_BASE + "threads/00000000-0000-0000-0000-000000000000/"
+    )
+
+    assert res.status_code == 404
+
+
+# thread_usage
+
+
+def test_thread_usage_is_forbidden_for_non_superuser():
+    client, identity = _client_identity()
+    thread = _thread(identity)
+
+    res = client.get(ASSISTANT_BASE + f"threads/{thread.id}/usage/")
+
+    assert res.status_code == 403
+    assert res.json()["error"] == "Forbidden"
+
+
+def test_thread_usage_sums_all_messages_including_hidden_and_meta():
+    client, identity = _superuser_client_identity()
+    thread = _thread(identity)
+    _message(thread, "visible", num_tokens=10, cost=0.1)
+    _message(thread, "hidden", num_tokens=20, cost=0.2, hidden=True)
+    _message(thread, "meta", num_tokens=30, cost=0.3, meta=True)
+
+    res = client.get(ASSISTANT_BASE + f"threads/{thread.id}/usage/")
+
+    assert res.status_code == 200
+    payload = res.json()
+    assert payload["total_tokens"] == 60
+    assert payload["total_cost"] == pytest.approx(0.6)
+
+
+def test_thread_usage_of_empty_thread_is_zero():
+    client, identity = _superuser_client_identity()
+    thread = _thread(identity)
+
+    payload = client.get(ASSISTANT_BASE + f"threads/{thread.id}/usage/").json()
+
+    assert payload == {"total_tokens": 0, "total_cost": 0.0}
+
+
+def test_thread_usage_of_another_identitys_thread_is_404():
+    client, _ = _superuser_client_identity()
+    stranger = UserIdentity.objects.create(session_key="stranger")
+    thread = _thread(stranger)
+
+    res = client.get(ASSISTANT_BASE + f"threads/{thread.id}/usage/")
+
+    assert res.status_code == 404
+
+
+# thread_delete
+
+
+def test_thread_delete_removes_thread_and_cascades_messages():
+    client, identity = _client_identity()
+    thread = _thread(identity)
+    _message(thread, "hello")
+
+    res = client.post(ASSISTANT_BASE + f"threads/{thread.id}/delete/")
+
+    assert res.status_code == 200
+    assert res.json() == {"deleted": True}
+    assert not ChatThread.objects.filter(id=thread.id).exists()
+    # Cascade is current behavior; the audit-log retention work (#745) will
+    # need to revisit this — the assertion is here to make that change loud.
+    assert not ChatMessage.objects.filter(thread_id=thread.id).exists()
+
+
+def test_thread_delete_of_another_identitys_thread_is_404_and_kept():
+    client, _ = _client_identity()
+    stranger = UserIdentity.objects.create(session_key="stranger")
+    thread = _thread(stranger)
+
+    res = client.post(ASSISTANT_BASE + f"threads/{thread.id}/delete/")
+
+    assert res.status_code == 404
+    assert ChatThread.objects.filter(id=thread.id).exists()
+
+
+def test_thread_delete_of_other_thread_type_is_404_and_kept():
+    client, identity = _client_identity()
+    thread = _thread(identity, thread_type="weather_chat")
+
+    res = client.post(ASSISTANT_BASE + f"threads/{thread.id}/delete/")
+
+    assert res.status_code == 404
+    assert ChatThread.objects.filter(id=thread.id).exists()

--- a/litigant_portal/app/tests/test_chat_thread_endpoints.py
+++ b/litigant_portal/app/tests/test_chat_thread_endpoints.py
@@ -137,8 +137,8 @@ def test_message_list_returns_thread_payload():
     assert payload["id"] == str(thread.id)
     assert payload["description"] == "my case"
     assert payload["state"] == {}
-    # Item contents are pinned by test_chat_hidden.py; here only the shape.
-    assert isinstance(payload["items"], list)
+    # Item contents are pinned by test_chat_hidden.py; here only the count.
+    assert len(payload["items"]) == 1
 
 
 def test_message_list_of_another_identitys_thread_is_404():

--- a/litigant_portal/app/tests/test_execute_tool.py
+++ b/litigant_portal/app/tests/test_execute_tool.py
@@ -1,0 +1,87 @@
+"""Tests for _execute_tool's error normalization in the chat engine.
+
+Every failure mode (unknown tool, invalid args, tool raising) must come back
+as a ToolOutput error result — an exception escaping the tool loop would kill
+the SSE stream mid-conversation. All tests are DB-free and run in the fast
+suite.
+"""
+
+from litigant_portal.agents.base import Tool, ToolOutput
+from litigant_portal.app.services.chat_engine import _execute_tool
+
+
+class EchoTool(Tool):
+    greeting: str
+
+    def __call__(self, *, thread_id) -> ToolOutput:
+        return ToolOutput(
+            result=f"{self.greeting} on {thread_id}",
+            render_data={"greeting": self.greeting},
+            refresh_system_prompt=True,
+            cost=0.25,
+        )
+
+
+class ExplodingTool(Tool):
+    def __call__(self, *, thread_id) -> ToolOutput:
+        raise RuntimeError("boom")
+
+
+def test_unknown_tool_returns_error_output():
+    output = _execute_tool(
+        tool_class=None, args={}, thread_id="t1", name="NoSuchTool"
+    )
+    assert output.result == "Error: Unknown tool: NoSuchTool"
+
+
+def test_invalid_args_return_error_output():
+    output = _execute_tool(
+        tool_class=EchoTool,
+        args={"greeting": {"not": "a string"}},
+        thread_id="t1",
+        name="EchoTool",
+    )
+    assert output.result.startswith("Error: ")
+    assert "greeting" in output.result
+
+
+def test_extra_args_are_accepted_not_errors():
+    # Pins Tool's extra="allow" (agents/base.py): a hallucinated argument
+    # name is silently ignored, not normalized to an error. If extras
+    # should be rejected instead, this test is the one to flip.
+    output = _execute_tool(
+        tool_class=EchoTool,
+        args={"greeting": "hello", "made_up_arg": True},
+        thread_id="t1",
+        name="EchoTool",
+    )
+    assert output.result == "hello on t1"
+
+
+def test_raising_tool_returns_error_output():
+    output = _execute_tool(
+        tool_class=ExplodingTool, args={}, thread_id="t1", name="ExplodingTool"
+    )
+    assert output.result == "Error: boom"
+
+
+def test_successful_tool_output_passes_through():
+    output = _execute_tool(
+        tool_class=EchoTool,
+        args={"greeting": "hello"},
+        thread_id="t1",
+        name="EchoTool",
+    )
+    assert output.result == "hello on t1"
+    assert output.render_data == {"greeting": "hello"}
+    assert output.refresh_system_prompt is True
+    assert output.cost == 0.25
+
+
+def test_error_output_keeps_toploop_defaults():
+    output = _execute_tool(
+        tool_class=ExplodingTool, args={}, thread_id="t1", name="ExplodingTool"
+    )
+    assert output.render_data is None
+    assert output.refresh_system_prompt is False
+    assert output.cost == 0.0

--- a/litigant_portal/app/tests/test_upload.py
+++ b/litigant_portal/app/tests/test_upload.py
@@ -14,8 +14,11 @@ from litigant_portal.app.services.upload import (
     INLINE_MAX_PAGES,
     READER_MAX_PAGES,
     READER_MAX_TEXT_TOKENS,
+    user_upload_create,
     user_upload_llm_parts,
     user_upload_reader_limit_error,
+    user_upload_render_list,
+    user_upload_serialize,
 )
 
 OPENAI = "gpt-5-mini"
@@ -391,3 +394,73 @@ class AttachmentOwnershipTests(TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json()["error"], "Invalid attachment")
         self.assertFalse(ChatThread.objects.exists())
+
+
+@pytest.mark.postgres
+@override_settings(MEDIA_ROOT=tempfile.mkdtemp())
+class UploadSerializeTests(TestCase):
+    """user_upload_serialize is the JSON contract the chat frontend renders."""
+
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="abc123")
+
+    def _upload(self, name, data=b"x"):
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        return user_upload_create(
+            identity=self.identity, file=SimpleUploadedFile(name, data)
+        )
+
+    def test_serializes_document_payload(self):
+        upload = self._upload("notes.txt", b"hello")
+        payload = user_upload_serialize(upload)
+        self.assertEqual(
+            payload,
+            {
+                "id": str(upload.id),
+                "name": "notes.txt",
+                "content_type": "text/plain",
+                "size": 5,
+                "is_image": False,
+                "url": upload.file.url,
+                "created_at": upload.created_at.isoformat(),
+            },
+        )
+
+    def test_image_content_type_sets_is_image(self):
+        upload = self._upload("photo.png")
+        self.assertTrue(user_upload_serialize(upload)["is_image"])
+
+    def test_render_list_preserves_requested_order(self):
+        first = self._upload("a.txt")
+        second = self._upload("b.txt")
+        items = user_upload_render_list([str(second.id), str(first.id)])
+        self.assertEqual(
+            [i["id"] for i in items], [str(second.id), str(first.id)]
+        )
+
+    def test_render_list_stubs_deleted_uploads(self):
+        gone = "00000000-0000-0000-0000-000000000000"
+        items = user_upload_render_list([gone])
+        self.assertEqual(
+            items,
+            [
+                {
+                    "id": gone,
+                    "name": "(deleted file)",
+                    "content_type": "",
+                    "size": 0,
+                    "is_image": False,
+                    "url": "",
+                    "missing": True,
+                }
+            ],
+        )
+
+    def test_render_list_mixes_present_and_missing(self):
+        upload = self._upload("a.txt")
+        gone = "00000000-0000-0000-0000-000000000000"
+        items = user_upload_render_list([str(upload.id), gone])
+        self.assertEqual(items[0]["name"], "a.txt")
+        self.assertNotIn("missing", items[0])
+        self.assertTrue(items[1]["missing"])

--- a/litigant_portal/app/tests/test_upload.py
+++ b/litigant_portal/app/tests/test_upload.py
@@ -6,6 +6,7 @@ import tempfile
 
 import pytest
 from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, TestCase, override_settings
 
 from litigant_portal.app.models import ChatThread, UserIdentity, UserUpload
@@ -405,8 +406,6 @@ class UploadSerializeTests(TestCase):
         self.identity = UserIdentity.objects.create(session_key="abc123")
 
     def _upload(self, name, data=b"x"):
-        from django.core.files.uploadedfile import SimpleUploadedFile
-
         return user_upload_create(
             identity=self.identity, file=SimpleUploadedFile(name, data)
         )


### PR DESCRIPTION
## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

**`_execute_tool` error normalization** (`test_execute_tool.py`, DB-free)
Unknown tool, invalid args, and a raising tool all come back as `ToolOutput` error results — an exception escaping the tool loop would kill the SSE stream mid-conversation. Also pins the current `extra="allow"` behavior: a hallucinated argument name is silently ignored, not rejected (see note below).

**Thread endpoint identity boundary** (`test_chat_thread_endpoints.py`, postgres)
`thread_list`, `message_list`, `thread_usage`, and `thread_delete` had zero direct tests. Each is a cross-identity ownership check (`chat_thread_get` scopes by identity and thread_type); a regression means one litigant reading another's conversation. Includes the superuser gate on `thread_usage`, and pins the delete cascade so the audit-log retention work (#745) changes it deliberately, not silently.

**Upload serialization contract** (`test_upload.py`, postgres)
`user_upload_serialize` and `user_upload_render_list` are the JSON shapes the chat frontend renders for attachments: payload contract, `is_image` flag, requested-order preservation, and the deleted-upload stub.

Closes #226 

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
