### PR TITLE
Migrate EMAIL_BACKEND to the MAILERS setting

### DIFF
--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -259,9 +259,15 @@ ACCOUNT_LOGOUT_ON_GET = False  # Require POST for CSRF protection
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 
-# Email backend (console for dev, configure SMTP for production)
-if DEBUG:
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+# Email (console mailer for dev, configure SMTP for production)
+MAILERS = {
+    "default": (
+        {"BACKEND": "django.core.mail.backends.console.EmailBackend"}
+        if DEBUG
+        # SMTP backend by default; host matches the old EMAIL_HOST default.
+        else {"OPTIONS": {"host": "localhost"}}
+    ),
+}
 
 # Content Security Policy (django-csp)
 # https://django-csp.readthedocs.io/


### PR DESCRIPTION
## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

Replaces the deprecated `EMAIL_BACKEND` setting with Django's new `MAILERS` dict. Every test run currently prints:

> RemovedInDjango70Warning: The EMAIL_BACKEND setting is deprecated. Migrate to MAILERS before Django 7.0.

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
