### PR TITLE
860: First PR defining agent arch and interfaces

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 
 # Application code
 !litigant_portal/
+!lp_agent/
 
 # Docker files
 !docker/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Run tox targets for ${{ matrix.python-version }}
         run: tox run -f py$(echo ${{ matrix.python-version }} | tr -d .)
+
+      - name: Test agent without Django
+        run: tox run -e agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}
     volumes:
       - ./litigant_portal:/app/litigant_portal
+      - ./lp_agent:/app/lp_agent
     stdin_open: true
     tty: true
     depends_on:

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -43,12 +43,13 @@ RUN TAILWIND_VERSION=${TAILWIND_VERSION} \
 # Stage 4: Application code
 # -----------------------------------------------------------------------------
 COPY litigant_portal litigant_portal
-COPY lp_agent lp_agent
 
 RUN /tmp/tailwindcss \
     -i /app/litigant_portal/app/src/main.css \
     -o /app/litigant_portal/app/static/css/main.built.css \
     --minify
+
+COPY lp_agent lp_agent
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --no-deps --python /opt/venv/bin/python -e .

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -43,6 +43,7 @@ RUN TAILWIND_VERSION=${TAILWIND_VERSION} \
 # Stage 4: Application code
 # -----------------------------------------------------------------------------
 COPY litigant_portal litigant_portal
+COPY lp_agent lp_agent
 
 RUN /tmp/tailwindcss \
     -i /app/litigant_portal/app/src/main.css \

--- a/litigant_portal/agent.py
+++ b/litigant_portal/agent.py
@@ -43,7 +43,9 @@ class PortalAgent(LPAgent):
             )
             ScopeSelection(court=court, topic=topic)
         except ValidationError as exc:
-            raise AgentValidationError.from_validation_error(exc) from exc
+            raise AgentValidationError.from_validation_error(
+                exc, models=(AgentConfiguration, ScopeSelection)
+            ) from exc
         if identity is None:
             raise AgentValidationError("a host-verified identity is required")
         raise NotImplementedError(

--- a/litigant_portal/agent.py
+++ b/litigant_portal/agent.py
@@ -1,0 +1,52 @@
+"""
+Host entry point for the new agent; Django adapter wiring follows in PR2.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+from lp_agent import AgentValidationError, LPAgent, RunLimits
+from lp_agent.types import (
+    AgentConfiguration,
+    InterruptBehavior,
+    Runtime,
+    ScopeSelection,
+)
+
+if TYPE_CHECKING:
+    from litigant_portal.app.models import UserIdentity
+
+
+class PortalAgent(LPAgent):
+    """
+    Wire host-verified identity, application adapters, and portal defaults.
+    """
+
+    def __init__(
+        self,
+        *,
+        identity: UserIdentity,
+        court: str | None = None,
+        topic: str | None = None,
+        runtime: Runtime = "Workers",
+        interrupt_behavior: InterruptBehavior = "reject",
+        limits: RunLimits | None = None,
+    ) -> None:
+        try:
+            AgentConfiguration(
+                runtime=runtime,
+                interrupt_behavior=interrupt_behavior,
+                limits=RunLimits() if limits is None else limits,
+            )
+            ScopeSelection(court=court, topic=topic)
+        except ValidationError as exc:
+            raise AgentValidationError.from_validation_error(exc) from exc
+        if identity is None:
+            raise AgentValidationError("a host-verified identity is required")
+        raise NotImplementedError(
+            "Django environment construction is not implemented; "
+            "PortalAgent adapter wiring follows in PR2."
+        )

--- a/lp_agent/README.md
+++ b/lp_agent/README.md
@@ -12,6 +12,7 @@ Direct execution and Django adapters follow in PR2; Workers follows in PR3.
 | `interfaces.py`         | Async run-handle and host-service contracts                          |
 | `environment.py`        | Live services and verified context, separate from serialized data    |
 | `errors.py`             | Validation, access, and busy errors before acceptance                |
+| `utils/audit.py`        | Versioned canonical instruction bytes and their SHA-256 fingerprint  |
 | `litigant_portal.agent` | Host constructor and portal defaults                                 |
 
 ## Calling the agent
@@ -67,6 +68,8 @@ The host owns HTTP framing, browser rendering, and live-stream buffering.
 unauthorized submissions and replies before acceptance. After acceptance,
 execution failures produce a `FailedOutcome` containing a caller-safe `PublicError`.
 Constructing data models directly uses Pydantic's `ValidationError`.
+Wrapped validation errors expose only known contract field paths and controlled
+messages. Unknown keys, dictionary keys, and submitted values are not echoed.
 
 ## Scope and services
 
@@ -91,7 +94,7 @@ Relevance filtering and returned-context limits belong in procedural tool code;
 actual ingestion and retrieval arrive in their planned later PRs.
 
 Prompts, tools, discovery, and execution policy belong to `lp_agent`. Django model
-access, provider clients, storage connections, and credentials stay behind host
+access, provider clients, storage connections, and credentials stay behind integration
 adapters. Only contract models are serialized with `model_dump_json()` and restored
 with `model_validate_json()`; use Pydantic `TypeAdapter` for unions such as
 `RunOutcome`. Service environments are never checkpoint or event payloads.
@@ -99,6 +102,69 @@ with `model_validate_json()`; use Pydantic `TypeAdapter` for unions such as
 The version-1 `RunCheckpoint` envelope contains run/conversation identifiers and
 JSON data. PR2 defines executor-state contents, accepted-input persistence, and
 atomic checkpoint commits. Persisted work survives replacement of the agent object.
+
+## Model data and instruction audits
+
+The model boundary uses our own Pydantic types matching a supported subset of the
+[OpenAI Responses format](https://developers.openai.com/api/docs/guides/function-calling).
+It does not import the OpenAI SDK or implement the complete Responses HTTP API.
+Provider SDKs belong in adapters; selecting or replacing LiteLLM follows in PR2.
+
+- `ModelRequest` contains resolved `instructions`, ordered `input` items, and
+  function `tools`. Model selection, credentials, and transport configuration
+  belong to the adapter. Put resolved system instructions in `instructions` so
+  there is one source for the instruction artifact.
+- `ModelMessage` uses `type="message"`, `role`, and `content`. The current subset
+  supports text inputs, assistant text/refusals, and assistant metadata including
+  IDs, status, annotations, log probabilities, and `phase`. Multimodal inputs and
+  provider-hosted tools are outside this contract. Unsupported fields/items fail
+  validation rather than being silently dropped.
+- `ToolCall` uses `type="function_call"`, `call_id`, `name`, and an unmodified JSON
+  argument **string**. `FunctionCallOutput` uses `type="function_call_output"`,
+  the same `call_id`, and an output string. PR2 parses and validates arguments
+  against the allowlisted tool before dispatch; preserving a string is not
+  permission to execute it.
+- `ReasoningItem` retains summary/content, encrypted continuation data, ID, and
+  status. `Conversation.items` retains all input and output items in order.
+  [Reasoning continuation items](https://developers.openai.com/api/docs/guides/reasoning)
+  and assistant metadata must survive persistence and subsequent model calls.
+- `ModelClient.stream()` yields `ModelTextDelta` and `ModelOutputItem` events.
+  Adapters assemble complete output items in provider order, including reasoning
+  and function calls. Deltas serve live display; assembled items become history
+  once, without duplicating the text. Item status remains authoritative: an
+  assembled item can be incomplete. Reasoning data is not public text.
+
+Function tools serialize as `type`, `name`, `description`, `parameters`, and
+`strict`. Strict mode defaults to `true` and is always serialized. Parameters
+must describe an object. Strict schemas close every object with
+`additionalProperties: false` and list every property in `required`; represent
+optional values using a nullable type. The validators beside `ToolDefinition` in `types.py` check these structural rules
+through nested objects, arrays, alternatives, and local references. Example and
+default data are preserved, including nulls. An explicit `strict=False` permits
+open objects and optional properties. Adapters must check any additional schema
+restrictions of their target model and reject unsupported strict mode rather
+than silently disabling it.
+
+Absent optional API metadata is omitted during serialization. Tool defaults are
+explicit; existing unreleased `messages`, `text`, and `input_schema` model shapes
+have no compatibility aliases. Application run controls, scope, identity,
+confirmations, and browser events retain their own contracts. MCP will translate
+shared tool definitions into its own protocol through the same runner.
+
+`lp_agent.utils.audit.InstructionArtifact.from_request(request)` snapshots instructions and tool
+definitions without retaining references to the request's mutable schemas.
+`canonical_bytes()` produces UTF-8 JSON containing `format`, `instructions`, and
+`tools`; `content_hash()` returns its SHA-256 digest. Version
+`lp_agent.instructions.v1` fixes sorted object keys, compact separators, explicit
+defaults, finite numbers, exact string content, and preserved array order.
+Dictionary insertion order does not affect the fingerprint; tool order does.
+Changes to this serialization contract require a new format version and fixture.
+
+PR2 will persist canonical bytes and their digest in restricted audit storage.
+The fingerprint identifies canonical instructions and tools, not conversation
+input, model configuration, or every byte of an adapted provider request.
+The current chat engine's artifacts are unchanged, and old hash compatibility
+is not required before release. PR1 adds no audit database or migration.
 
 ## Execution policy
 
@@ -126,8 +192,9 @@ construction until PR2 supplies Django environment wiring. It inherits agent met
 
 ## Checks
 
-From the repository root, run `tox -e agent`. Its isolated environment installs only
-Pydantic and pytest, disables plugin autoload, and requires neither Django nor a
+From the repository root, run `tox -e agent`. Default `tox` and `make test` also run
+this environment. It installs only Pydantic (at least 2.10.0) and pytest,
+disables plugin autoload, and requires neither Django nor a
 database or provider credentials. With existing development dependencies, use:
 
 ```sh
@@ -137,3 +204,7 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c lp_agent/pytest.ini lp_agen
 The regular project suite also discovers these tests. Contract tests verify imports,
 validation, serialization, and explicit placeholders; runtime behavior is tested
 when implemented in PR2 and PR3.
+
+PR2 must validate the wrapper's saved registered/anonymous identity before
+initialization callbacks, then delegate configuration and environment setup to
+the base constructor once. The wrapper remains explicitly unimplemented in PR1.

--- a/lp_agent/README.md
+++ b/lp_agent/README.md
@@ -1,0 +1,139 @@
+# Litigant portal agent contract
+
+PR1 establishes a framework-independent Python package and its public contract.
+It validates configuration and data. `run()`, `get_run()`, and `serve_mcp()`
+raise `NotImplementedError`; they do not accept work or invoke adapters yet.
+Direct execution and Django adapters follow in PR2; Workers follows in PR3.
+
+| Part                    | Responsibility                                                       |
+| ----------------------- | -------------------------------------------------------------------- |
+| `main.py`               | Public `LPAgent` facade and immutable execution configuration        |
+| `types.py`              | Serializable requests, events, outcomes, questions, and adapter data |
+| `interfaces.py`         | Async run-handle and host-service contracts                          |
+| `environment.py`        | Live services and verified context, separate from serialized data    |
+| `errors.py`             | Validation, access, and busy errors before acceptance                |
+| `litigant_portal.agent` | Host constructor and portal defaults                                 |
+
+## Calling the agent
+
+The following describes the interface that PR2 will implement:
+
+```python
+from lp_agent import LPAgent, RunLimits
+from lp_agent.types import ChoiceAnswer
+
+
+async def converse(environment, choose):
+    agent = LPAgent(
+        environment=environment,
+        runtime="Direct",
+        interrupt_behavior="reject",
+        limits=RunLimits(),
+    )
+    run = await agent.run(message="I need help", attachment_ids=())
+
+    async for event in run.events():
+        if event.payload.type == "question":
+            # The host presents the choices and obtains a user's selection.
+            selected_choice_id = await choose(event.payload.question)
+            answer = ChoiceAnswer(choice_id=selected_choice_id)
+            await run.respond(event.payload.question.question_id, answer)
+
+    return await run.result()
+```
+
+`run(message=..., conversation_id=None, attachment_ids=())` creates a conversation
+when its identifier is omitted. Otherwise it continues an authorized conversation.
+Identifiers are opaque nonempty strings; adapt host UUIDs with `str(id)`.
+Blank messages are invalid; valid messages retain their whitespace and content.
+
+`RunHandle` is a protocol, with read-only `run_id` and `conversation_id` properties:
+
+| Operation                                           | Contract                                                                    |
+| --------------------------------------------------- | --------------------------------------------------------------------------- |
+| `await run.status()`                                | Read saved state, including a pending question                              |
+| `run.events()`                                      | Iterate typed live events without awaiting the iterator itself              |
+| `await run.result()`                                | Wait for a completed, failed, or cancelled outcome                          |
+| `await run.respond(question_id, ChoiceAnswer(...))` | Validate the pending question and selected choice, then resume the same run |
+| `await run.cancel()`                                | Request cancellation; status/result report acknowledgement                  |
+| `await agent.get_run(run_id)`                       | Recover an authorized handle after reconstructing the agent                 |
+
+Waiting for input is nonterminal. Reconnecting callers recover saved status,
+questions, and final outcomes; there is initially no public event replay cursor.
+Events include an attempt number so consumers can distinguish restarted output.
+The host owns HTTP framing, browser rendering, and live-stream buffering.
+
+`AgentValidationError`, `AgentAccessError`, and `AgentBusyError` reject invalid or
+unauthorized submissions and replies before acceptance. After acceptance,
+execution failures produce a `FailedOutcome` containing a caller-safe `PublicError`.
+Constructing data models directly uses Pydantic's `ValidationError`.
+
+## Scope and services
+
+The host verifies both signed-in and anonymous identity and supplies an
+`AccessContext(identity_id=...)`. This value asserts host verification; it does
+not authenticate a caller. Host adapters enforce permissions on every operation.
+
+`AgentEnvironment` contains that context, conversation/run stores, a scope catalog,
+a scope factory, and `ScopeSelection(court=None, topic=None)`. The selection can
+also supply either or both identifiers. No services are called during construction.
+
+Normal execution requires both court and topic. Missing scope uses fixed procedural
+questions and the host catalog, without a model call. Discovery preserves the
+original message and run ID while releasing execution resources between replies.
+Once scope is complete, the factory binds a `ScopedEnvironment` with the same
+identity, a full `Scope`, model access, and separate corpus/document searches.
+The instance binds once and automatically continues the original message.
+
+Search adapters return ranked `SearchHit` values with relevance and provenance.
+They enforce bound identity/court/topic access and conversation attachment limits.
+Relevance filtering and returned-context limits belong in procedural tool code;
+actual ingestion and retrieval arrive in their planned later PRs.
+
+Prompts, tools, discovery, and execution policy belong to `lp_agent`. Django model
+access, provider clients, storage connections, and credentials stay behind host
+adapters. Only contract models are serialized with `model_dump_json()` and restored
+with `model_validate_json()`; use Pydantic `TypeAdapter` for unions such as
+`RunOutcome`. Service environments are never checkpoint or event payloads.
+
+The version-1 `RunCheckpoint` envelope contains run/conversation identifiers and
+JSON data. PR2 defines executor-state contents, accepted-input persistence, and
+atomic checkpoint commits. Persisted work survives replacement of the agent object.
+
+## Execution policy
+
+Runtime and interruption policy are fixed at construction. `Direct` is the package
+default; `Workers` is the portal default. `await agent.serve_mcp()` is a separate
+unimplemented Model Context Protocol entry point, not a runtime selection.
+
+| Interruption policy | New message during an active run                                    |
+| ------------------- | ------------------------------------------------------------------- |
+| `reject` (default)  | Raise a busy error                                                  |
+| `queue`             | Create a queued run; add its message to history only when it starts |
+| `steer`             | Preserve the input in order and return the active run's handle      |
+
+Steering takes effect after the current model response or tool operation. Finish
+tool A, mark remaining unstarted calls skipped, and let the model reconsider before
+tool B. Cancellation is separate; a browser disconnect does not cancel worker work.
+
+Defaults are 30 model steps, 300 active seconds, and two automatic worker restarts.
+Budgets span recovery attempts and exclude queue time and waiting for human input.
+Step/time limits must be positive; zero restarts disables automatic recovery.
+
+`PortalAgent(identity=..., court=None, topic=None, runtime="Workers", ...)` declares
+the host entry point now. It validates independent options and explicitly fails
+construction until PR2 supplies Django environment wiring. It inherits agent methods.
+
+## Checks
+
+From the repository root, run `tox -e agent`. Its isolated environment installs only
+Pydantic and pytest, disables plugin autoload, and requires neither Django nor a
+database or provider credentials. With existing development dependencies, use:
+
+```sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -c lp_agent/pytest.ini lp_agent/tests
+```
+
+The regular project suite also discovers these tests. Contract tests verify imports,
+validation, serialization, and explicit placeholders; runtime behavior is tested
+when implemented in PR2 and PR3.

--- a/lp_agent/__init__.py
+++ b/lp_agent/__init__.py
@@ -1,0 +1,26 @@
+"""
+Public entry points for the framework-independent litigant portal agent.
+"""
+
+from lp_agent.environment import AgentEnvironment, ScopedEnvironment
+from lp_agent.errors import (
+    AgentAccessError,
+    AgentBusyError,
+    AgentError,
+    AgentValidationError,
+)
+from lp_agent.interfaces import RunHandle
+from lp_agent.main import LPAgent
+from lp_agent.types import RunLimits
+
+__all__ = [
+    "AgentAccessError",
+    "AgentBusyError",
+    "AgentEnvironment",
+    "AgentError",
+    "AgentValidationError",
+    "LPAgent",
+    "RunHandle",
+    "RunLimits",
+    "ScopedEnvironment",
+]

--- a/lp_agent/environment.py
+++ b/lp_agent/environment.py
@@ -1,0 +1,61 @@
+"""
+Live service dependencies, separate from serializable contracts.
+"""
+
+from dataclasses import dataclass, field
+
+from lp_agent.errors import AgentValidationError
+from lp_agent.interfaces import (
+    ConversationStore,
+    ModelClient,
+    RunStore,
+    ScopeCatalog,
+    ScopedSearch,
+    ScopeFactory,
+)
+from lp_agent.types import AccessContext, Scope, ScopeSelection
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScopedEnvironment:
+    """
+    Services bound once to a verified identity, court, and topic.
+    """
+
+    access: AccessContext
+    scope: Scope
+    model: ModelClient
+    corpus: ScopedSearch
+    documents: ScopedSearch
+
+    def __post_init__(self) -> None:
+        """
+        Reject unresolved scope at the normal execution boundary.
+        """
+        if not isinstance(self.access, AccessContext):
+            raise AgentValidationError("access must be an AccessContext")
+        if not isinstance(self.scope, Scope):
+            raise AgentValidationError("scoped services require a full Scope")
+
+
+@dataclass(frozen=True, kw_only=True)
+class AgentEnvironment:
+    """
+    Host-verified context and services for scope discovery and execution.
+    """
+
+    access: AccessContext
+    conversations: ConversationStore
+    runs: RunStore
+    catalog: ScopeCatalog
+    scope_factory: ScopeFactory
+    scope: ScopeSelection = field(default_factory=ScopeSelection)
+
+    def __post_init__(self) -> None:
+        """
+        Require validated data without invoking any host service.
+        """
+        if not isinstance(self.access, AccessContext):
+            raise AgentValidationError("access must be an AccessContext")
+        if not isinstance(self.scope, ScopeSelection):
+            raise AgentValidationError("scope must be a ScopeSelection")

--- a/lp_agent/errors.py
+++ b/lp_agent/errors.py
@@ -4,7 +4,55 @@ Errors raised before a run or input is accepted.
 
 from typing import Self
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
+
+_ERROR_MESSAGES = {
+    "extra_forbidden": "Unexpected field",
+    "missing": "Required field",
+    "string_type": "Must be text",
+    "int_type": "Must be an integer",
+    "float_type": "Must be a number",
+    "bool_type": "Must be a boolean",
+    "tuple_type": "Must be a sequence",
+    "list_type": "Must be a sequence",
+    "dict_type": "Must be an object",
+    "greater_than": "Value is too small",
+    "greater_than_equal": "Value is too small",
+    "less_than": "Value is too large",
+    "less_than_equal": "Value is too large",
+    "finite_number": "Must be a finite number",
+    "literal_error": "Unsupported option",
+    "union_tag_invalid": "Unsupported option",
+    "union_tag_not_found": "Missing option type",
+}
+
+
+def _safe_location(location: tuple, schema: dict) -> str:
+    """
+    Follow declared properties and sequence indices, never dictionary keys.
+    """
+    definitions = schema.get("$defs", {})
+    path = []
+    for segment in location:
+        seen = set()
+        while "$ref" in schema:
+            reference = schema["$ref"]
+            if reference in seen or not reference.startswith("#/$defs/"):
+                return ".".join(path)
+            seen.add(reference)
+            schema = definitions.get(reference.removeprefix("#/$defs/"), {})
+        if isinstance(segment, str) and segment in schema.get(
+            "properties", {}
+        ):
+            schema = schema["properties"][segment]
+        elif isinstance(segment, int) and isinstance(
+            schema.get("items"), dict
+        ):
+            schema = schema["items"]
+        else:
+            break
+        path.append(str(segment))
+    return ".".join(path)
 
 
 class AgentError(Exception):
@@ -19,16 +67,36 @@ class AgentValidationError(AgentError, ValueError):
     """
 
     @classmethod
-    def from_validation_error(cls, error: ValidationError) -> Self:
+    def from_validation_error(
+        cls,
+        error: ValidationError,
+        *,
+        models: tuple[type[BaseModel], ...] = (),
+    ) -> Self:
         """
-        Describe invalid fields without including the submitted values.
+        Use trusted model fields and fixed messages, with a generic fallback.
+
+        Pydantic locations and messages can both contain submitted data.
+        Only schemas generated from the caller's contract classes are trusted.
         """
+        schemas = [model.model_json_schema() for model in models]
         problems = []
         for item in error.errors(
             include_url=False, include_context=False, include_input=False
         ):
-            location = ".".join(map(str, item["loc"])) or "input"
-            problems.append(f"{location}: {item['msg']}")
+            location = (
+                max(
+                    (
+                        _safe_location(item["loc"], schema)
+                        for schema in schemas
+                    ),
+                    key=len,
+                    default="",
+                )
+                or "input"
+            )
+            message = _ERROR_MESSAGES.get(item["type"], "Invalid value")
+            problems.append(f"{location}: {message}")
         return cls("; ".join(problems))
 
 

--- a/lp_agent/errors.py
+++ b/lp_agent/errors.py
@@ -1,0 +1,44 @@
+"""
+Errors raised before a run or input is accepted.
+"""
+
+from typing import Self
+
+from pydantic import ValidationError
+
+
+class AgentError(Exception):
+    """
+    Base exception for the public agent interface.
+    """
+
+
+class AgentValidationError(AgentError, ValueError):
+    """
+    Configuration, a submission, or a question reply is invalid.
+    """
+
+    @classmethod
+    def from_validation_error(cls, error: ValidationError) -> Self:
+        """
+        Describe invalid fields without including the submitted values.
+        """
+        problems = []
+        for item in error.errors(
+            include_url=False, include_context=False, include_input=False
+        ):
+            location = ".".join(map(str, item["loc"])) or "input"
+            problems.append(f"{location}: {item['msg']}")
+        return cls("; ".join(problems))
+
+
+class AgentAccessError(AgentError):
+    """
+    The host's access context does not authorize the requested resource.
+    """
+
+
+class AgentBusyError(AgentError):
+    """
+    The conversation has an active run and its policy rejects new input.
+    """

--- a/lp_agent/interfaces.py
+++ b/lp_agent/interfaces.py
@@ -1,0 +1,172 @@
+"""
+Async boundaries implemented by runtimes and host adapters in later PRs.
+"""
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Protocol
+
+from lp_agent.types import (
+    AccessContext,
+    AgentConfiguration,
+    Choice,
+    ChoiceAnswer,
+    Conversation,
+    ModelEvent,
+    ModelRequest,
+    RunCheckpoint,
+    RunEvent,
+    RunOutcome,
+    RunRequest,
+    RunStatus,
+    Scope,
+    ScopeSelection,
+    SearchHit,
+)
+
+if TYPE_CHECKING:
+    from lp_agent.environment import ScopedEnvironment
+
+
+class RunHandle(Protocol):
+    """
+    An authorized reference to work, independent of a request's lifetime.
+    """
+
+    @property
+    def run_id(self) -> str: ...
+
+    @property
+    def conversation_id(self) -> str: ...
+
+    async def status(self) -> RunStatus: ...
+
+    def events(self) -> AsyncIterator[RunEvent]:
+        """
+        Observe live events; no public cursor replay is provided initially.
+        """
+        ...
+
+    async def result(self) -> RunOutcome:
+        """
+        Wait for a terminal outcome, including across pauses for user input.
+        """
+        ...
+
+    async def respond(self, question_id: str, answer: ChoiceAnswer) -> None:
+        """
+        Validate a reply to the pending question and resume the same run.
+        """
+        ...
+
+    async def cancel(self) -> None:
+        """
+        Request cancellation; status and result report acknowledgement.
+        """
+        ...
+
+
+class ConversationStore(Protocol):
+    """
+    Authorize every operation; enforce ownership and fixed resolved scope.
+    """
+
+    async def create(
+        self, *, access: AccessContext, scope: ScopeSelection
+    ) -> Conversation: ...
+
+    async def get(
+        self, *, access: AccessContext, conversation_id: str
+    ) -> Conversation: ...
+
+    async def bind_scope(
+        self, *, access: AccessContext, conversation_id: str, scope: Scope
+    ) -> None: ...
+
+
+class RunStore(Protocol):
+    """
+    Authorized persistence boundary; PR2 supplies transactions and locking.
+    """
+
+    async def create(
+        self,
+        *,
+        access: AccessContext,
+        conversation_id: str,
+        request: RunRequest,
+        configuration: AgentConfiguration,
+    ) -> RunStatus: ...
+
+    async def status(
+        self, *, access: AccessContext, run_id: str
+    ) -> RunStatus: ...
+
+    async def outcome(
+        self, *, access: AccessContext, run_id: str
+    ) -> RunOutcome | None: ...
+
+    async def checkpoint(
+        self, *, access: AccessContext, run_id: str
+    ) -> RunCheckpoint | None: ...
+
+    async def commit_checkpoint(
+        self,
+        *,
+        access: AccessContext,
+        checkpoint: RunCheckpoint,
+        status: RunStatus,
+        outcome: RunOutcome | None = None,
+    ) -> None:
+        """
+        Atomically save completed work, consumed inputs, status, and outcome.
+
+        All references must identify the same authorized run. PR2 defines
+        checkpoint contents and the transaction/concurrency implementation.
+        """
+        ...
+
+
+class ModelClient(Protocol):
+    """
+    Normalize provider streaming and assemble tool arguments here.
+    """
+
+    def stream(self, request: ModelRequest) -> AsyncIterator[ModelEvent]: ...
+
+
+class ScopeCatalog(Protocol):
+    """
+    List valid host-authorized choices without invoking a model.
+    """
+
+    async def courts(
+        self, *, access: AccessContext, topic: str | None = None
+    ) -> tuple[Choice, ...]: ...
+
+    async def topics(
+        self, *, access: AccessContext, court: str
+    ) -> tuple[Choice, ...]: ...
+
+
+class ScopedSearch(Protocol):
+    """
+    Search within bound access/scope and enforce document attachments.
+    """
+
+    async def search(
+        self,
+        *,
+        query: str,
+        conversation_id: str,
+        attachment_ids: tuple[str, ...] = (),
+    ) -> tuple[SearchHit, ...]: ...
+
+
+class ScopeFactory(Protocol):
+    """
+    Build services bound to the same verified identity and complete scope.
+    """
+
+    async def bind(
+        self, *, access: AccessContext, scope: Scope
+    ) -> "ScopedEnvironment": ...

--- a/lp_agent/interfaces.py
+++ b/lp_agent/interfaces.py
@@ -128,7 +128,12 @@ class RunStore(Protocol):
 
 class ModelClient(Protocol):
     """
-    Normalize provider streaming and assemble tool arguments here.
+    Stream text deltas and assembled Responses output items in provider order.
+
+    Preserve reasoning, message metadata, and argument strings for history.
+    PR2 validates arguments before dispatch; adapters reject unsupported schema
+    features or strict mode instead of changing them silently. These events
+    are internal agent signals, not the Responses HTTP streaming protocol.
     """
 
     def stream(self, request: ModelRequest) -> AsyncIterator[ModelEvent]: ...

--- a/lp_agent/main.py
+++ b/lp_agent/main.py
@@ -1,0 +1,99 @@
+"""
+The public agent facade. Runtime implementation starts in PR2.
+"""
+
+from pydantic import TypeAdapter, ValidationError
+
+from lp_agent.environment import AgentEnvironment
+from lp_agent.errors import AgentValidationError
+from lp_agent.interfaces import RunHandle
+from lp_agent.types import (
+    AgentConfiguration,
+    Identifier,
+    InterruptBehavior,
+    RunLimits,
+    RunRequest,
+    Runtime,
+)
+
+
+class LPAgent:
+    """
+    A reusable, async agent runner configured with host-supplied services.
+    """
+
+    def __init__(
+        self,
+        *,
+        environment: AgentEnvironment,
+        runtime: Runtime = "Direct",
+        interrupt_behavior: InterruptBehavior = "reject",
+        limits: RunLimits | None = None,
+    ) -> None:
+        try:
+            self._configuration = AgentConfiguration(
+                runtime=runtime,
+                interrupt_behavior=interrupt_behavior,
+                limits=RunLimits() if limits is None else limits,
+            )
+        except ValidationError as exc:
+            raise AgentValidationError.from_validation_error(exc) from exc
+        if not isinstance(environment, AgentEnvironment):
+            raise AgentValidationError(
+                "environment must be an AgentEnvironment"
+            )
+        self._environment = environment
+
+    @property
+    def environment(self) -> AgentEnvironment:
+        return self._environment
+
+    @property
+    def runtime(self) -> Runtime:
+        return self._configuration.runtime
+
+    @property
+    def interrupt_behavior(self) -> InterruptBehavior:
+        return self._configuration.interrupt_behavior
+
+    @property
+    def limits(self) -> RunLimits:
+        return self._configuration.limits
+
+    async def run(
+        self,
+        *,
+        message: str,
+        conversation_id: str | None = None,
+        attachment_ids: tuple[str, ...] = (),
+    ) -> RunHandle:
+        """
+        Submit a turn, creating a conversation when no ID is supplied.
+        """
+        try:
+            RunRequest(
+                message=message,
+                conversation_id=conversation_id,
+                attachment_ids=attachment_ids,
+            )
+        except ValidationError as exc:
+            raise AgentValidationError.from_validation_error(exc) from exc
+        raise NotImplementedError(
+            f"{self.runtime} execution is not implemented yet."
+        )
+
+    async def get_run(self, run_id: str) -> RunHandle:
+        """
+        Recover an authorized handle after instance reconstruction.
+        """
+        try:
+            TypeAdapter(Identifier).validate_python(run_id)
+        except ValidationError as exc:
+            raise AgentValidationError.from_validation_error(exc) from exc
+        raise NotImplementedError("Run recovery is not implemented yet.")
+
+    async def serve_mcp(self) -> None:
+        """
+        TODO: expose this agent through a Model Context Protocol adapter.
+        """
+        raise NotImplementedError("MCP exposure is not implemented yet.")

--- a/lp_agent/main.py
+++ b/lp_agent/main.py
@@ -37,7 +37,9 @@ class LPAgent:
                 limits=RunLimits() if limits is None else limits,
             )
         except ValidationError as exc:
-            raise AgentValidationError.from_validation_error(exc) from exc
+            raise AgentValidationError.from_validation_error(
+                exc, models=(AgentConfiguration,)
+            ) from exc
         if not isinstance(environment, AgentEnvironment):
             raise AgentValidationError(
                 "environment must be an AgentEnvironment"
@@ -77,7 +79,9 @@ class LPAgent:
                 attachment_ids=attachment_ids,
             )
         except ValidationError as exc:
-            raise AgentValidationError.from_validation_error(exc) from exc
+            raise AgentValidationError.from_validation_error(
+                exc, models=(RunRequest,)
+            ) from exc
         raise NotImplementedError(
             f"{self.runtime} execution is not implemented yet."
         )

--- a/lp_agent/pytest.ini
+++ b/lp_agent/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+pythonpath = ..
+testpaths = tests
+python_files = test_*.py
+python_classes = *Tests
+addopts = -ra --strict-markers

--- a/lp_agent/tests/conftest.py
+++ b/lp_agent/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+from lp_agent import AgentEnvironment
+from lp_agent.types import AccessContext
+
+
+class UnusedService:
+    """
+    Fail if a contract placeholder attempts any adapter work.
+    """
+
+    def __getattr__(self, name):
+        raise AssertionError(f"PR1 must not invoke service method {name}")
+
+
+@pytest.fixture
+def environment():
+    service = UnusedService()
+    return AgentEnvironment(
+        access=AccessContext(identity_id="test-identity"),
+        conversations=service,
+        runs=service,
+        catalog=service,
+        scope_factory=service,
+    )

--- a/lp_agent/tests/test_agent.py
+++ b/lp_agent/tests/test_agent.py
@@ -1,0 +1,191 @@
+import asyncio
+import inspect
+import subprocess
+import sys
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from pydantic import ValidationError
+
+from lp_agent import (
+    AgentValidationError,
+    LPAgent,
+    RunHandle,
+    RunLimits,
+    ScopedEnvironment,
+)
+from lp_agent.types import ScopeSelection
+
+
+def test_configuration_is_fixed_with_documented_defaults(environment):
+    agent = LPAgent(environment=environment)
+    assert agent.runtime == "Direct"
+    assert agent.interrupt_behavior == "reject"
+    assert agent.limits == RunLimits(
+        max_steps=30, max_active_seconds=300, max_restarts=2
+    )
+    for name, value in [
+        ("runtime", "Workers"),
+        ("interrupt_behavior", "steer"),
+        ("limits", RunLimits(max_steps=1)),
+        ("environment", environment),
+    ]:
+        with pytest.raises(AttributeError):
+            setattr(agent, name, value)
+    with pytest.raises(ValidationError):
+        agent.limits.max_steps = 1
+    with pytest.raises(FrozenInstanceError):
+        environment.scope = ScopeSelection(court="another-court")
+    assert not hasattr(agent, "set_runtime")
+
+
+@pytest.mark.parametrize("runtime", ["Direct", "Workers"])
+@pytest.mark.parametrize("policy", ["reject", "queue", "steer"])
+def test_valid_execution_is_explicitly_unimplemented(
+    environment, runtime, policy
+):
+    agent = LPAgent(
+        environment=environment, runtime=runtime, interrupt_behavior=policy
+    )
+    with pytest.raises(NotImplementedError, match=f"{runtime} execution"):
+        asyncio.run(agent.run(message="Hello"))
+    with pytest.raises(NotImplementedError, match="Run recovery"):
+        asyncio.run(agent.get_run("stored-run"))
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"runtime": "MCP"},
+        {"runtime": "direct"},
+        {"interrupt_behavior": "cancel"},
+        {"limits": {"max_steps": 0}},
+        {"limits": {"max_restarts": -1}},
+    ],
+)
+def test_constructor_rejects_invalid_configuration(environment, options):
+    with pytest.raises(AgentValidationError):
+        LPAgent(environment=environment, **options)
+
+
+@pytest.mark.parametrize(
+    "run_request",
+    [
+        {"message": " \n\t"},
+        {"message": "Hello", "conversation_id": ""},
+        {"message": "Hello", "attachment_ids": ("",)},
+        {"message": "Hello", "attachment_ids": "attachment"},
+        {"message": {"private": "do not echo this"}},
+    ],
+)
+def test_submission_validation_precedes_runtime(environment, run_request):
+    with pytest.raises(AgentValidationError) as error:
+        asyncio.run(LPAgent(environment=environment).run(**run_request))
+    assert "do not echo this" not in str(error.value)
+
+
+@pytest.mark.parametrize("run_id", ["", " \n", None, 42])
+def test_recovery_validates_identifiers(environment, run_id):
+    with pytest.raises(AgentValidationError):
+        asyncio.run(LPAgent(environment=environment).get_run(run_id))
+
+
+def test_mcp_is_a_separate_unimplemented_entry_point(environment):
+    with pytest.raises(NotImplementedError, match="MCP exposure"):
+        asyncio.run(LPAgent(environment=environment).serve_mcp())
+
+
+def test_environment_requires_validated_access_and_scope(environment):
+    with pytest.raises(AgentValidationError, match="AccessContext"):
+        replace(environment, access="unverified")
+    with pytest.raises(AgentValidationError, match="ScopeSelection"):
+        replace(environment, scope={"court": "court"})
+    with pytest.raises(AgentValidationError, match="AgentEnvironment"):
+        LPAgent(environment=object())
+    with pytest.raises(AgentValidationError, match="full Scope"):
+        ScopedEnvironment(
+            access=environment.access,
+            scope=ScopeSelection(court="court"),
+            model=environment.runs,
+            corpus=environment.runs,
+            documents=environment.runs,
+        )
+
+
+def test_handle_contract_distinguishes_iteration_from_awaiting():
+    for name in ["status", "result", "respond", "cancel"]:
+        assert inspect.iscoroutinefunction(getattr(RunHandle, name))
+    assert not inspect.iscoroutinefunction(RunHandle.events)
+    assert RunHandle.run_id.fset is None
+    assert RunHandle.conversation_id.fset is None
+
+
+def test_core_import_and_validation_without_host_dependencies(tmp_path):
+    source = dedent(
+        """
+        import importlib.abc
+        import sys
+
+        sys.path.insert(0, sys.argv[1])
+        forbidden = {
+            "django",
+            "litigant_portal",
+            "litellm",
+            "celery",
+            "redis",
+            "boto3",
+            "botocore"
+        }
+
+        class BlockHostImports(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname.split(".")[0] in forbidden:
+                    raise AssertionError(f"Forbidden dependency: {fullname}")
+
+        sys.meta_path.insert(0, BlockHostImports())
+        from lp_agent import LPAgent, RunLimits
+        from lp_agent.types import RunRequest
+
+        assert RunLimits().max_steps == 30
+        request = RunRequest(message="hello")
+        assert RunRequest.model_validate_json(request.model_dump_json()) == request
+        assert not (forbidden & {name.split(".")[0] for name in sys.modules})
+        """
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            source,
+            str(Path(__file__).resolve().parents[2]),
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_portal_declares_host_inputs_and_workers_default():
+    from litigant_portal.agent import PortalAgent
+
+    parameters = inspect.signature(PortalAgent).parameters
+    assert parameters["runtime"].default == "Workers"
+    assert parameters["identity"].default is inspect.Parameter.empty
+    assert parameters["court"].default is None
+    assert parameters["topic"].default is None
+    assert parameters["identity"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert PortalAgent.run is LPAgent.run
+    assert PortalAgent.get_run is LPAgent.get_run
+    with pytest.raises(NotImplementedError, match="Django environment"):
+        PortalAgent(identity=object())
+    with pytest.raises(AgentValidationError):
+        PortalAgent(identity=object(), runtime="invalid")
+    with pytest.raises(AgentValidationError):
+        PortalAgent(identity=object(), court=" ")
+    with pytest.raises(AgentValidationError):
+        PortalAgent(identity=None)

--- a/lp_agent/tests/test_agent.py
+++ b/lp_agent/tests/test_agent.py
@@ -133,6 +133,8 @@ def test_core_import_and_validation_without_host_dependencies(tmp_path):
             "django",
             "litigant_portal",
             "litellm",
+            "openai",
+            "anthropic",
             "celery",
             "redis",
             "boto3",
@@ -146,11 +148,22 @@ def test_core_import_and_validation_without_host_dependencies(tmp_path):
 
         sys.meta_path.insert(0, BlockHostImports())
         from lp_agent import LPAgent, RunLimits
-        from lp_agent.types import RunRequest
+        from lp_agent.utils.audit import InstructionArtifact
+        from lp_agent.types import ModelMessage, ModelRequest, RunRequest, ToolDefinition
 
         assert RunLimits().max_steps == 30
         request = RunRequest(message="hello")
         assert RunRequest.model_validate_json(request.model_dump_json()) == request
+        model_request = ModelRequest(
+            input=(ModelMessage(role="user", content="hello"),),
+            tools=(ToolDefinition(
+                name="lookup", description="Find guidance",
+                parameters={"type": "object", "properties": {},
+                            "required": [], "additionalProperties": False},
+            ),),
+        )
+        assert ModelRequest.model_validate_json(model_request.model_dump_json()) == model_request
+        assert len(InstructionArtifact.from_request(model_request).content_hash()) == 64
         assert not (forbidden & {name.split(".")[0] for name in sys.modules})
         """
     )

--- a/lp_agent/tests/test_audit.py
+++ b/lp_agent/tests/test_audit.py
@@ -1,0 +1,122 @@
+import json
+from copy import deepcopy
+
+import pytest
+from pydantic import ValidationError
+
+from lp_agent.types import ModelMessage, ModelRequest, ToolDefinition
+from lp_agent.utils.audit import InstructionArtifact
+
+TOOL = {
+    "name": "lookup",
+    "description": "Find guidance",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": False,
+    },
+}
+GOLDEN_JSON = (
+    '{"format":"lp_agent.instructions.v1","instructions":" Help café\\n",'
+    '"tools":[{"description":"Find guidance","name":"lookup","parameters":'
+    '{"additionalProperties":false,"properties":{},"required":[],"type":"object"},'
+    '"strict":true,"type":"function"}]}'
+)
+GOLDEN_HASH = (
+    "9c8586107696585a34694550cf5bf5943dc692f874eee7504e847dd774e163fe"
+)
+
+
+def artifact(*, instructions=" Help café\n", tools=None):
+    return InstructionArtifact(
+        instructions=instructions,
+        tools=[TOOL] if tools is None else tools,
+    )
+
+
+def test_version_one_canonical_bytes_and_hash_are_fixed():
+    original = artifact()
+    assert original.canonical_bytes() == GOLDEN_JSON.encode("utf-8")
+    assert original.content_hash() == GOLDEN_HASH
+    restored = InstructionArtifact.model_validate_json(
+        original.canonical_bytes()
+    )
+    assert restored.content_hash() == GOLDEN_HASH
+
+
+def test_key_order_and_explicit_defaults_do_not_change_fingerprint():
+    reordered = dict(reversed(TOOL.items()))
+    reordered["parameters"] = dict(reversed(TOOL["parameters"].items()))
+    reordered.update(strict=True, type="function")
+    assert artifact(tools=[reordered]).content_hash() == GOLDEN_HASH
+
+
+@pytest.mark.parametrize(
+    "instructions", ["Help café\n", " Help café", " Help cafe\n"]
+)
+def test_instruction_whitespace_and_unicode_are_significant(instructions):
+    assert artifact(instructions=instructions).content_hash() != GOLDEN_HASH
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"name": "another_lookup"},
+        {"description": "Find different guidance"},
+        {"strict": False},
+        {"parameters": {**TOOL["parameters"], "description": "New arguments"}},
+    ],
+)
+def test_instruction_or_tool_changes_change_fingerprint(change):
+    assert artifact(tools=[{**TOOL, **change}]).content_hash() != GOLDEN_HASH
+
+
+def test_tool_and_schema_array_order_is_preserved():
+    other = {**TOOL, "name": "other"}
+    assert (
+        artifact(tools=[TOOL, other]).content_hash()
+        != artifact(tools=[other, TOOL]).content_hash()
+    )
+    parameters = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {"a": {"type": "string"}, "b": {"type": "string"}},
+        "required": ["a", "b"],
+    }
+    reordered = {**parameters, "required": ["b", "a"]}
+    assert (
+        artifact(tools=[{**TOOL, "parameters": parameters}]).content_hash()
+        != artifact(tools=[{**TOOL, "parameters": reordered}]).content_hash()
+    )
+
+
+def test_request_snapshot_excludes_history_and_copies_mutable_schemas():
+    tool = ToolDefinition(**deepcopy(TOOL))
+    request = ModelRequest(
+        instructions=" Help café\n",
+        tools=(tool,),
+        input=(ModelMessage(role="user", content="Private user message"),),
+    )
+    snapshot = InstructionArtifact.from_request(request)
+    assert snapshot.content_hash() == GOLDEN_HASH
+    assert "Private user message" not in snapshot.canonical_bytes().decode()
+    tool.parameters["description"] = "Changed after snapshot"
+    assert snapshot.content_hash() == GOLDEN_HASH
+    assert (
+        InstructionArtifact.from_request(request).content_hash() != GOLDEN_HASH
+    )
+
+
+def test_unknown_format_cannot_be_read_as_version_one():
+    payload = json.loads(GOLDEN_JSON)
+    payload["format"] = "lp_agent.instructions.v2"
+    with pytest.raises(ValidationError):
+        InstructionArtifact.model_validate(payload)
+
+
+def test_canonicalization_rejects_nonfinite_numbers_even_after_mutation():
+    original = artifact()
+    original.tools[0].parameters["default"] = float("nan")
+    with pytest.raises(ValueError):
+        original.canonical_bytes()

--- a/lp_agent/tests/test_contracts.py
+++ b/lp_agent/tests/test_contracts.py
@@ -10,6 +10,7 @@ from lp_agent.types import (
     ChoiceQuestion,
     CompletedOutcome,
     FailedOutcome,
+    FunctionCallOutput,
     ModelMessage,
     ModelRequest,
     OutcomeEvent,
@@ -194,15 +195,13 @@ def test_contract_rejects_undeclared_provider_fields():
 
 def test_model_context_and_search_provenance_are_portable():
     call = ToolCall(
-        call_id="call-1", name="search", arguments={"query": "help"}
+        call_id="call-1", name="search", arguments='{"query":"help"}'
     )
     request = ModelRequest(
-        messages=(
-            ModelMessage(role="user", text="Help"),
-            ModelMessage(role="assistant", tool_calls=(call,)),
-            ModelMessage(
-                role="tool", text="Relevant text", tool_call_id="call-1"
-            ),
+        input=(
+            ModelMessage(role="user", content="Help"),
+            call,
+            FunctionCallOutput(call_id="call-1", output="Relevant text"),
         )
     )
     assert (
@@ -217,4 +216,4 @@ def test_model_context_and_search_provenance_are_portable():
     )
     assert SearchHit.model_validate_json(hit.model_dump_json()) == hit
     with pytest.raises(ValidationError):
-        ModelMessage(role="tool", text="Unmatched output")
+        ModelMessage(role="tool", content="Unmatched output")

--- a/lp_agent/tests/test_contracts.py
+++ b/lp_agent/tests/test_contracts.py
@@ -1,0 +1,220 @@
+import json
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from lp_agent.types import (
+    CancelledOutcome,
+    Choice,
+    ChoiceAnswer,
+    ChoiceQuestion,
+    CompletedOutcome,
+    FailedOutcome,
+    ModelMessage,
+    ModelRequest,
+    OutcomeEvent,
+    PublicError,
+    QuestionEvent,
+    QuestionReply,
+    RunCheckpoint,
+    RunEvent,
+    RunLimits,
+    RunOutcome,
+    RunRequest,
+    RunStatus,
+    Scope,
+    ScopeSelection,
+    SearchHit,
+    SourceReference,
+    StatusEvent,
+    TextEvent,
+    ToolCall,
+    ToolEvent,
+)
+
+REFERENCE = {"run_id": "run-1", "conversation_id": "conversation-1"}
+QUESTION = ChoiceQuestion(
+    question_id="court-question",
+    prompt="Which court?",
+    choices=(Choice(choice_id="court-1", label="Example court"),),
+)
+
+
+def test_request_round_trip_preserves_message_and_attachment_order():
+    request = RunRequest(
+        message="  A question\n",
+        conversation_id="conversation-1",
+        attachment_ids=("document-2", "document-1"),
+    )
+    encoded = request.model_dump_json()
+    assert json.loads(encoded)["message"] == "  A question\n"
+    assert RunRequest.model_validate_json(encoded) == request
+
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"max_steps": 0},
+        {"max_steps": True},
+        {"max_steps": 1.5},
+        {"max_active_seconds": 0},
+        {"max_active_seconds": float("inf")},
+        {"max_active_seconds": float("nan")},
+        {"max_active_seconds": True},
+        {"max_restarts": -1},
+        {"max_restarts": False},
+    ],
+)
+def test_invalid_budgets_are_rejected(limits):
+    with pytest.raises(ValidationError):
+        RunLimits(**limits)
+
+
+def test_disabling_restarts_and_fractional_time_are_supported():
+    assert RunLimits(max_restarts=0, max_active_seconds=0.5).max_restarts == 0
+
+
+def test_partial_scope_is_distinct_from_execution_scope():
+    assert ScopeSelection(topic="topic-1").court is None
+    with pytest.raises(ValidationError):
+        Scope(topic="topic-1")
+    with pytest.raises(ValidationError):
+        Scope(court="court-1", topic=" ")
+
+
+def test_question_and_reply_survive_serialization():
+    reply = QuestionReply(
+        question_id=QUESTION.question_id,
+        answer=ChoiceAnswer(choice_id="court-1"),
+    )
+    assert (
+        ChoiceQuestion.model_validate_json(QUESTION.model_dump_json())
+        == QUESTION
+    )
+    assert QuestionReply.model_validate_json(reply.model_dump_json()) == reply
+
+
+@pytest.mark.parametrize("choices", [(), QUESTION.choices * 2])
+def test_choice_questions_require_unambiguous_options(choices):
+    with pytest.raises(ValidationError):
+        ChoiceQuestion(
+            question_id="question", prompt="Choose", choices=choices
+        )
+
+
+def test_only_waiting_status_carries_a_pending_question():
+    paused = RunStatus(
+        **REFERENCE, state="waiting_for_input", pending_question=QUESTION
+    )
+    assert RunStatus.model_validate_json(paused.model_dump_json()) == paused
+    with pytest.raises(ValidationError):
+        RunStatus(**REFERENCE, state="waiting_for_input")
+    with pytest.raises(ValidationError):
+        RunStatus(**REFERENCE, state="completed", pending_question=QUESTION)
+    with pytest.raises(ValidationError):
+        TypeAdapter(RunOutcome).validate_python(paused.model_dump())
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        CompletedOutcome(**REFERENCE, text="Answer"),
+        FailedOutcome(
+            **REFERENCE,
+            error=PublicError(
+                code="model_failed", message="Please try again."
+            ),
+        ),
+        CancelledOutcome(**REFERENCE),
+    ],
+)
+def test_outcome_union_preserves_terminal_type(outcome):
+    adapter = TypeAdapter(RunOutcome)
+    assert adapter.validate_json(adapter.dump_json(outcome)) == outcome
+    assert adapter.json_schema()["discriminator"]["propertyName"] == "state"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        TextEvent(delta="Incremental text"),
+        ToolEvent(call_id="call-1", name="search", state="skipped"),
+        QuestionEvent(question=QUESTION),
+        StatusEvent(status=RunStatus(**REFERENCE, state="running")),
+        OutcomeEvent(outcome=CompletedOutcome(**REFERENCE, text="Answer")),
+    ],
+)
+def test_event_round_trip_restores_typed_payload(payload):
+    event = RunEvent(**REFERENCE, attempt=2, payload=payload)
+    restored = RunEvent.model_validate_json(event.model_dump_json())
+    assert restored == event
+    assert type(restored.payload) is type(payload)
+
+
+def test_event_rejects_mismatched_run_and_unknown_payload():
+    with pytest.raises(ValidationError):
+        RunEvent(
+            **REFERENCE,
+            payload=StatusEvent(
+                status=RunStatus(
+                    run_id="different-run",
+                    conversation_id=REFERENCE["conversation_id"],
+                    state="running",
+                )
+            ),
+        )
+    with pytest.raises(ValidationError):
+        RunEvent(**REFERENCE, payload={"type": "raw_provider_response"})
+
+
+def test_checkpoint_envelope_round_trip():
+    checkpoint = RunCheckpoint(
+        **REFERENCE, data={"original_message": "Hello", "steps": 0}
+    )
+    assert (
+        RunCheckpoint.model_validate_json(checkpoint.model_dump_json())
+        == checkpoint
+    )
+    with pytest.raises(ValidationError):
+        RunCheckpoint(**REFERENCE, version=2, data={})
+
+
+@pytest.mark.parametrize("value", [object(), float("inf"), float("nan")])
+def test_json_payloads_reject_live_objects_and_nonfinite_numbers(value):
+    with pytest.raises(ValidationError):
+        RunCheckpoint(**REFERENCE, data={"nested": [value]})
+    with pytest.raises(ValidationError):
+        ToolEvent(call_id="call", name="search", state="completed", data=value)
+
+
+def test_contract_rejects_undeclared_provider_fields():
+    with pytest.raises(ValidationError):
+        RunRequest(message="Hello", provider_response={"id": "raw"})
+
+
+def test_model_context_and_search_provenance_are_portable():
+    call = ToolCall(
+        call_id="call-1", name="search", arguments={"query": "help"}
+    )
+    request = ModelRequest(
+        messages=(
+            ModelMessage(role="user", text="Help"),
+            ModelMessage(role="assistant", tool_calls=(call,)),
+            ModelMessage(
+                role="tool", text="Relevant text", tool_call_id="call-1"
+            ),
+        )
+    )
+    assert (
+        ModelRequest.model_validate_json(request.model_dump_json()) == request
+    )
+    hit = SearchHit(
+        content="Relevant text",
+        score=2.5,
+        source=SourceReference(
+            source_id="source-1", kind="corpus", title="Example court guide"
+        ),
+    )
+    assert SearchHit.model_validate_json(hit.model_dump_json()) == hit
+    with pytest.raises(ValidationError):
+        ModelMessage(role="tool", text="Unmatched output")

--- a/lp_agent/tests/test_errors.py
+++ b/lp_agent/tests/test_errors.py
@@ -1,0 +1,67 @@
+from typing import Annotated, Literal
+
+import pytest
+from pydantic import Field, ValidationError, field_validator
+
+from lp_agent import AgentValidationError, LPAgent
+from lp_agent.types import ContractModel
+
+SECRET = "private-person@example.invalid"
+
+
+def test_constructor_retains_known_paths_without_echoing_extra_keys(
+    environment,
+):
+    with pytest.raises(AgentValidationError) as error:
+        LPAgent(
+            environment=environment,
+            limits={"max_steps": 0, SECRET: "private value"},
+        )
+    assert str(error.value) == (
+        "limits.max_steps: Value is too small; limits: Unexpected field"
+    )
+
+
+class TypedOption(ContractModel):
+    type: Literal["known"]
+
+
+class SensitiveInput(ContractModel):
+    values: dict[str, int] = {}
+    option: Annotated[TypedOption, Field(discriminator="type")] | None = None
+    message: str = ""
+
+    @field_validator("message")
+    @classmethod
+    def reject_message(cls, value):
+        """
+        Simulate a validator that echoes submitted text in its exception.
+        """
+        raise ValueError(value)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({SECRET: 1}, "input: Unexpected field"),
+        ({"values": {SECRET: "invalid"}}, "values: Invalid value"),
+        ({"option": {"type": SECRET}}, "option: Unsupported option"),
+        ({"message": SECRET}, "message: Invalid value"),
+    ],
+)
+def test_error_locations_and_messages_do_not_echo_input(data, expected):
+    with pytest.raises(ValidationError) as error:
+        SensitiveInput.model_validate(data)
+    public_error = AgentValidationError.from_validation_error(
+        error.value, models=(SensitiveInput,)
+    )
+    assert str(public_error) == expected
+    assert SECRET not in str(public_error)
+
+
+def test_missing_schema_uses_safe_generic_location():
+    with pytest.raises(ValidationError) as error:
+        SensitiveInput.model_validate({"option": {"type": SECRET}})
+    assert str(AgentValidationError.from_validation_error(error.value)) == (
+        "input: Unsupported option"
+    )

--- a/lp_agent/tests/test_model_contracts.py
+++ b/lp_agent/tests/test_model_contracts.py
@@ -1,0 +1,289 @@
+import json
+from copy import deepcopy
+from typing import Self
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from lp_agent.types import (
+    ContractModel,
+    Conversation,
+    FunctionCallOutput,
+    ModelEvent,
+    ModelMessage,
+    ModelOutputItem,
+    ModelRequest,
+    RunLimits,
+    ScopeSelection,
+    ToolCall,
+    ToolDefinition,
+)
+
+PARAMETERS = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}},
+    "required": ["query"],
+    "additionalProperties": False,
+}
+
+HISTORY = [
+    {"type": "message", "role": "user", "content": "Help\n"},
+    {
+        "type": "reasoning",
+        "id": "reasoning-1",
+        "summary": [{"type": "summary_text", "text": "Look up guidance"}],
+        "content": [
+            {"type": "reasoning_text", "text": "Provider continuation"}
+        ],
+        "encrypted_content": "opaque-continuation",
+        "status": "completed",
+    },
+    {
+        "type": "function_call",
+        "id": "item-1",
+        "call_id": "call-1",
+        "name": "lookup",
+        "arguments": '{ "query": "help" }',
+        "status": "completed",
+    },
+    {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": "Guidance",
+    },
+    {
+        "type": "message",
+        "id": "message-1",
+        "role": "assistant",
+        "phase": "final_answer",
+        "status": "completed",
+        "content": [
+            {
+                "type": "output_text",
+                "text": "Here is guidance.",
+                "annotations": [
+                    {
+                        "type": "url_citation",
+                        "url": "https://example.invalid",
+                        "title": "Guide",
+                        "start_index": 0,
+                        "end_index": 8,
+                    }
+                ],
+                "logprobs": [],
+            }
+        ],
+    },
+]
+
+
+def test_responses_request_and_conversation_preserve_complete_items():
+    payload = {
+        "instructions": " Help the user.\n",
+        "input": HISTORY,
+        "tools": [],
+    }
+    request = ModelRequest.model_validate(payload)
+    assert json.loads(request.model_dump_json()) == payload
+    assert (
+        ModelRequest.model_validate_json(request.model_dump_json()) == request
+    )
+    conversation = Conversation(
+        conversation_id="conversation",
+        identity_id="identity",
+        scope=ScopeSelection(),
+        items=request.input,
+    )
+    restored = Conversation.model_validate_json(conversation.model_dump_json())
+    assert json.loads(restored.model_dump_json())["items"] == HISTORY
+
+
+@pytest.mark.parametrize("item", [HISTORY[1], HISTORY[2], HISTORY[4]])
+def test_output_events_preserve_items_for_the_next_request(item):
+    event = ModelOutputItem(item=item)
+    adapter = TypeAdapter(ModelEvent)
+    restored = adapter.validate_json(adapter.dump_json(event))
+    assert json.loads(restored.model_dump_json())["item"] == item
+
+
+def test_text_deltas_remain_separate_from_history_items():
+    event = TypeAdapter(ModelEvent).validate_python(
+        {"type": "text", "delta": "Hi"}
+    )
+    assert event.delta == "Hi"
+    for item in [HISTORY[0], HISTORY[3]]:
+        with pytest.raises(ValidationError):
+            ModelOutputItem(item=item)
+
+
+def test_refusals_and_incomplete_status_are_preserved():
+    message = ModelMessage.model_validate(
+        {
+            "role": "assistant",
+            "status": "incomplete",
+            "content": [
+                {"type": "refusal", "refusal": "Cannot help with that"}
+            ],
+        }
+    )
+    assert (
+        ModelMessage.model_validate_json(message.model_dump_json()) == message
+    )
+    assert message.content[0].refusal == "Cannot help with that"
+    with pytest.raises(ValidationError):
+        ModelMessage(role="user", content="Hi", phase="final_answer")
+
+
+def test_function_arguments_remain_unmodified_until_dispatch():
+    call = ToolCall(call_id="call", name="lookup", arguments="{unfinished")
+    assert json.loads(call.model_dump_json())["arguments"] == "{unfinished"
+    with pytest.raises(ValidationError):
+        FunctionCallOutput(output="Missing call ID")
+
+
+@pytest.mark.parametrize(
+    "create",
+    [
+        lambda: ModelRequest(messages=[]),
+        lambda: ModelMessage(role="user", text="old shape"),
+        lambda: ToolCall(call_id="call", name="lookup", arguments={}),
+        lambda: ToolDefinition(
+            name="lookup", description="Find", input_schema={}
+        ),
+        lambda: ModelRequest(input=[{"type": "unknown_provider_item"}]),
+    ],
+)
+def test_old_and_unsupported_model_shapes_are_rejected(create):
+    with pytest.raises(ValidationError):
+        create()
+
+
+def test_tool_definition_uses_explicit_responses_fields_and_strict_default():
+    tool = ToolDefinition(
+        name="lookup", description="Find", parameters=PARAMETERS
+    )
+    assert json.loads(tool.model_dump_json()) == {
+        "type": "function",
+        "name": "lookup",
+        "description": "Find",
+        "parameters": PARAMETERS,
+        "strict": True,
+    }
+    with pytest.raises(ValidationError):
+        ModelRequest(input=(), tools=(tool, tool))
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"type": "array", "items": {"type": "string"}},
+        {"type": "object", "properties": {}, "required": []},
+        {**PARAMETERS, "required": []},
+        {**PARAMETERS, "required": ["query", "query"]},
+        {**PARAMETERS, "additionalProperties": {"type": "string"}},
+        {**PARAMETERS, "properties": {"query": {"type": "object"}}},
+        {
+            **PARAMETERS,
+            "properties": {
+                "query": {"type": "array", "items": {"type": "object"}}
+            },
+        },
+        {
+            **PARAMETERS,
+            "properties": {
+                "query": {"anyOf": [{"type": "null"}, {"type": "object"}]}
+            },
+        },
+        {**PARAMETERS, "$defs": {"Bad": {"type": "object"}}},
+        {**PARAMETERS, "properties": {"query": {"$ref": "#/missing"}}},
+        {
+            **PARAMETERS,
+            "properties": {
+                "query": {"$ref": "https://example.invalid/schema"}
+            },
+        },
+    ],
+)
+def test_strict_schemas_reject_open_or_optional_nested_objects(parameters):
+    with pytest.raises(ValidationError):
+        ToolDefinition(
+            name="lookup", description="Find", parameters=parameters
+        )
+
+
+def test_strict_schemas_support_nullable_fields_references_and_literal_data():
+    parameters = deepcopy(PARAMETERS)
+    parameters["properties"]["query"] = {
+        "anyOf": [{"type": "null"}, {"$ref": "#/$defs/Filter"}]
+    }
+    parameters["$defs"] = {
+        "Filter": {
+            "type": "object",
+            "properties": {"next": {"$ref": "#/$defs/Filter"}},
+            "required": ["next"],
+            "additionalProperties": False,
+        }
+    }
+    parameters["examples"] = [{"type": "object", "properties": "literal data"}]
+    parameters["default"] = None
+    tool = ToolDefinition(
+        name="lookup", description="Find", parameters=parameters
+    )
+    assert json.loads(tool.model_dump_json())["parameters"] == parameters
+
+
+def test_non_strict_schemas_require_an_explicit_opt_out():
+    parameters = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+    }
+    tool = ToolDefinition(
+        name="lookup", description="Find", parameters=parameters, strict=False
+    )
+    assert json.loads(tool.model_dump_json())["strict"] is False
+    with pytest.raises(ValidationError):
+        ToolDefinition(
+            name="lookup", description="Find", parameters=parameters
+        )
+    with pytest.raises(ValidationError):
+        ToolDefinition(
+            name="lookup",
+            description="Find",
+            parameters=PARAMETERS,
+            strict="false",
+        )
+
+
+def test_strict_schemas_accept_pydantic_recursive_object_definitions():
+    class Filter(ContractModel):
+        term: str
+        next: Self | None
+
+    parameters = Filter.model_json_schema()
+    tool = ToolDefinition(
+        name="lookup", description="Find", parameters=parameters
+    )
+    assert json.loads(tool.model_dump_json())["parameters"] == parameters
+
+
+@pytest.mark.parametrize("strict", [True, False])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_parameter_schemas_reject_nonfinite_json(strict, value):
+    with pytest.raises(ValidationError):
+        ToolDefinition(
+            name="lookup",
+            description="Find",
+            parameters={**PARAMETERS, "default": value},
+            strict=strict,
+        )
+
+
+def test_timeout_default_matches_explicit_value_in_memory_and_json():
+    default = RunLimits()
+    explicit = RunLimits(max_active_seconds=300.0)
+    assert (
+        type(default.max_active_seconds)
+        is type(explicit.max_active_seconds)
+        is float
+    )
+    assert default.model_dump_json() == explicit.model_dump_json()

--- a/lp_agent/types.py
+++ b/lp_agent/types.py
@@ -1,0 +1,372 @@
+"""
+Provider- and transport-independent data exchanged with the agent.
+"""
+
+from typing import Annotated, Literal, Self
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    StrictInt,
+    model_validator,
+)
+
+
+def _not_blank(value: str) -> str:
+    """
+    Reject whitespace-only values without altering valid content.
+    """
+    if not value.strip():
+        raise ValueError("must not be blank")
+    return value
+
+
+type Identifier = Annotated[str, AfterValidator(_not_blank)]
+type NonBlankText = Annotated[str, AfterValidator(_not_blank)]
+type Runtime = Literal["Direct", "Workers"]
+type InterruptBehavior = Literal["reject", "queue", "steer"]
+type RunState = Literal[
+    "queued",
+    "running",
+    "waiting_for_input",
+    "completed",
+    "failed",
+    "cancelled",
+]
+
+
+class ContractModel(BaseModel):
+    """
+    Validate known fields and finite numbers; prevent field reassignment.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, allow_inf_nan=False)
+
+
+class RunLimits(ContractModel):
+    """
+    Cumulative budgets, excluding queue time and time waiting for input.
+    """
+
+    max_steps: Annotated[StrictInt, Field(gt=0)] = 30
+    max_active_seconds: Annotated[float, Field(gt=0, strict=True)] = 300
+    max_restarts: Annotated[StrictInt, Field(ge=0)] = 2
+
+
+class AgentConfiguration(ContractModel):
+    """
+    Execution choices fixed for an instance and persisted with a run.
+    """
+
+    runtime: Runtime = "Direct"
+    interrupt_behavior: InterruptBehavior = "reject"
+    limits: RunLimits = Field(default_factory=RunLimits)
+
+
+class AccessContext(ContractModel):
+    """
+    An opaque identity verified by the host, including anonymous users.
+    """
+
+    identity_id: Identifier
+
+
+class ScopeSelection(ContractModel):
+    """
+    Host-supplied scope, which may still require procedural discovery.
+    """
+
+    court: Identifier | None = None
+    topic: Identifier | None = None
+
+
+class Scope(ContractModel):
+    """
+    Complete court and topic scope required for normal execution.
+    """
+
+    court: Identifier
+    topic: Identifier
+
+
+class RunRequest(ContractModel):
+    """
+    A message and references to its conversation and authorized attachments.
+    """
+
+    message: NonBlankText
+    conversation_id: Identifier | None = None
+    attachment_ids: tuple[Identifier, ...] = ()
+
+
+class Choice(ContractModel):
+    """
+    One host-validated option presented to the user.
+    """
+
+    choice_id: Identifier
+    label: NonBlankText
+
+
+class ChoiceAnswer(ContractModel):
+    """
+    A selection checked against the pending question by the runtime.
+    """
+
+    choice_id: Identifier
+
+
+class ChoiceQuestion(ContractModel):
+    """
+    A choice question that survives run suspension and reconstruction.
+    """
+
+    question_id: Identifier
+    prompt: NonBlankText
+    choices: Annotated[tuple[Choice, ...], Field(min_length=1)]
+
+    @model_validator(mode="after")
+    def unique_choices(self) -> Self:
+        """
+        Keep replies unambiguous within a question.
+        """
+        ids = [choice.choice_id for choice in self.choices]
+        if len(ids) != len(set(ids)):
+            raise ValueError("choice IDs must be unique")
+        return self
+
+
+class QuestionReply(ContractModel):
+    """
+    An answer addressed to a particular pending question.
+    """
+
+    question_id: Identifier
+    answer: ChoiceAnswer
+
+
+class RunReference(ContractModel):
+    """
+    Stable identifiers shared by status, events, and terminal outcomes.
+    """
+
+    run_id: Identifier
+    conversation_id: Identifier
+
+
+class RunStatus(RunReference):
+    """
+    A recoverable status snapshot, including the question while paused.
+    """
+
+    state: RunState
+    pending_question: ChoiceQuestion | None = None
+
+    @model_validator(mode="after")
+    def question_matches_state(self) -> Self:
+        """
+        Require a question exactly when the run is waiting for input.
+        """
+        if (self.state == "waiting_for_input") != (
+            self.pending_question is not None
+        ):
+            raise ValueError(
+                "pending_question is required only for waiting_for_input"
+            )
+        return self
+
+
+class PublicError(ContractModel):
+    """
+    A stable code and caller-safe explanation, without exception data.
+    """
+
+    code: Identifier
+    message: NonBlankText
+
+
+class SourceReference(ContractModel):
+    """
+    Provenance for a court source or an authorized private document.
+    """
+
+    source_id: Identifier
+    kind: Literal["corpus", "document"]
+    title: NonBlankText
+    locator: str | None = None
+
+
+class SearchHit(ContractModel):
+    """
+    Ranked content; scores use the search adapter's documented scale.
+    """
+
+    content: str
+    score: float
+    source: SourceReference
+
+
+class CompletedOutcome(RunReference):
+    state: Literal["completed"] = "completed"
+    text: str
+    sources: tuple[SourceReference, ...] = ()
+
+
+class FailedOutcome(RunReference):
+    state: Literal["failed"] = "failed"
+    error: PublicError
+
+
+class CancelledOutcome(RunReference):
+    state: Literal["cancelled"] = "cancelled"
+
+
+type RunOutcome = Annotated[
+    CompletedOutcome | FailedOutcome | CancelledOutcome,
+    Field(discriminator="state"),
+]
+
+
+class TextEvent(ContractModel):
+    type: Literal["text"] = "text"
+    delta: str
+
+
+class ToolEvent(ContractModel):
+    type: Literal["tool"] = "tool"
+    call_id: Identifier
+    name: Identifier
+    state: Literal["started", "completed", "failed", "skipped"]
+    data: JsonValue = None
+
+
+class QuestionEvent(ContractModel):
+    type: Literal["question"] = "question"
+    question: ChoiceQuestion
+
+
+class StatusEvent(ContractModel):
+    type: Literal["status"] = "status"
+    status: RunStatus
+
+
+class OutcomeEvent(ContractModel):
+    type: Literal["outcome"] = "outcome"
+    outcome: RunOutcome
+
+
+type EventPayload = Annotated[
+    TextEvent | ToolEvent | QuestionEvent | StatusEvent | OutcomeEvent,
+    Field(discriminator="type"),
+]
+
+
+class RunEvent(RunReference):
+    """
+    A serializable event; attempt distinguishes output across restarts.
+    """
+
+    attempt: Annotated[StrictInt, Field(ge=1)] = 1
+    payload: EventPayload
+
+    @model_validator(mode="after")
+    def matching_reference(self) -> Self:
+        """
+        Keep envelope and nested status/outcome identifiers consistent.
+        """
+        reference: RunReference | None = None
+        if isinstance(self.payload, StatusEvent):
+            reference = self.payload.status
+        elif isinstance(self.payload, OutcomeEvent):
+            reference = self.payload.outcome
+        if reference is not None and (
+            reference.run_id != self.run_id
+            or reference.conversation_id != self.conversation_id
+        ):
+            raise ValueError("event and payload run references must match")
+        return self
+
+
+class RunCheckpoint(RunReference):
+    """
+    Versioned executor state; PR2 defines its payload and atomic commits.
+    """
+
+    version: Literal[1] = 1
+    data: dict[str, JsonValue]
+
+
+class ToolCall(ContractModel):
+    """
+    A normalized model-selected call with fully assembled arguments.
+    """
+
+    call_id: Identifier
+    name: Identifier
+    arguments: dict[str, JsonValue]
+
+
+class ModelMessage(ContractModel):
+    """
+    Model context independent of provider response classes.
+    """
+
+    role: Literal["system", "user", "assistant", "tool"]
+    text: str = ""
+    tool_calls: tuple[ToolCall, ...] = ()
+    tool_call_id: Identifier | None = None
+
+    @model_validator(mode="after")
+    def valid_tool_message(self) -> Self:
+        """
+        Associate tool results with calls made by assistant messages.
+        """
+        if (self.role == "tool") != (self.tool_call_id is not None):
+            raise ValueError("tool_call_id is required only for tool messages")
+        if self.tool_calls and self.role != "assistant":
+            raise ValueError("only assistant messages may contain tool calls")
+        return self
+
+
+class ToolDefinition(ContractModel):
+    name: Identifier
+    description: NonBlankText
+    input_schema: dict[str, JsonValue]
+
+
+class ModelRequest(ContractModel):
+    """
+    One model operation; provider configuration belongs to its adapter.
+    """
+
+    messages: tuple[ModelMessage, ...]
+    tools: tuple[ToolDefinition, ...] = ()
+
+
+class ModelTextDelta(ContractModel):
+    type: Literal["text"] = "text"
+    delta: str
+
+
+class ModelToolCall(ContractModel):
+    type: Literal["tool_call"] = "tool_call"
+    call: ToolCall
+
+
+type ModelEvent = Annotated[
+    ModelTextDelta | ModelToolCall, Field(discriminator="type")
+]
+
+
+class Conversation(ContractModel):
+    """
+    An authorized conversation snapshot, separate from an agent instance.
+    """
+
+    conversation_id: Identifier
+    identity_id: Identifier
+    scope: ScopeSelection
+    messages: tuple[ModelMessage, ...] = ()

--- a/lp_agent/types.py
+++ b/lp_agent/types.py
@@ -1,7 +1,8 @@
 """
-Provider- and transport-independent data exchanged with the agent.
+Agent contracts and Responses-compatible model data, without SDK dependencies.
 """
 
+import json
 from typing import Annotated, Literal, Self
 
 from pydantic import (
@@ -10,7 +11,9 @@ from pydantic import (
     ConfigDict,
     Field,
     JsonValue,
+    StrictBool,
     StrictInt,
+    model_serializer,
     model_validator,
 )
 
@@ -52,7 +55,7 @@ class RunLimits(ContractModel):
     """
 
     max_steps: Annotated[StrictInt, Field(gt=0)] = 30
-    max_active_seconds: Annotated[float, Field(gt=0, strict=True)] = 300
+    max_active_seconds: Annotated[float, Field(gt=0, strict=True)] = 300.0
     max_restarts: Annotated[StrictInt, Field(ge=0)] = 2
 
 
@@ -299,51 +302,253 @@ class RunCheckpoint(RunReference):
     data: dict[str, JsonValue]
 
 
-class ToolCall(ContractModel):
+class ResponsesModel(ContractModel):
     """
-    A normalized model-selected call with fully assembled arguments.
-    """
-
-    call_id: Identifier
-    name: Identifier
-    arguments: dict[str, JsonValue]
-
-
-class ModelMessage(ContractModel):
-    """
-    Model context independent of provider response classes.
+    Omit absent metadata while retaining nulls inside JSON content and schemas.
     """
 
-    role: Literal["system", "user", "assistant", "tool"]
-    text: str = ""
-    tool_calls: tuple[ToolCall, ...] = ()
-    tool_call_id: Identifier | None = None
+    @model_serializer(mode="wrap")
+    def serialize_present_fields(self, serialize):
+        """
+        Optional API fields are absent unless they have a value.
+        """
+        return {
+            key: value
+            for key, value in serialize(self).items()
+            if value is not None
+        }
+
+
+class InputText(ResponsesModel):
+    type: Literal["input_text"] = "input_text"
+    text: str
+
+
+class OutputText(ResponsesModel):
+    type: Literal["output_text"] = "output_text"
+    text: str
+    annotations: tuple[dict[str, JsonValue], ...] = ()
+    logprobs: tuple[dict[str, JsonValue], ...] | None = None
+
+
+class Refusal(ResponsesModel):
+    type: Literal["refusal"] = "refusal"
+    refusal: str
+
+
+type MessageContent = Annotated[
+    InputText | OutputText | Refusal, Field(discriminator="type")
+]
+type ModelItemStatus = Literal["in_progress", "completed", "incomplete"]
+
+
+class ModelMessage(ResponsesModel):
+    """
+    Text input or assistant output in the Responses message representation.
+    """
+
+    type: Literal["message"] = "message"
+    role: Literal["system", "developer", "user", "assistant"]
+    content: str | tuple[MessageContent, ...]
+    id: Identifier | None = None
+    status: ModelItemStatus | None = None
+    phase: Literal["commentary", "final_answer"] | None = None
 
     @model_validator(mode="after")
-    def valid_tool_message(self) -> Self:
+    def valid_message_role(self) -> Self:
         """
-        Associate tool results with calls made by assistant messages.
+        Keep assistant-only metadata and output content on assistant messages.
         """
-        if (self.role == "tool") != (self.tool_call_id is not None):
-            raise ValueError("tool_call_id is required only for tool messages")
-        if self.tool_calls and self.role != "assistant":
-            raise ValueError("only assistant messages may contain tool calls")
+        if self.role != "assistant":
+            if self.id is not None or self.phase is not None:
+                raise ValueError(
+                    "only assistant messages carry output metadata"
+                )
+            if not isinstance(self.content, str) and any(
+                not isinstance(part, InputText) for part in self.content
+            ):
+                raise ValueError("input messages require input text")
         return self
 
 
-class ToolDefinition(ContractModel):
+class ToolCall(ResponsesModel):
+    """
+    An assembled function call; PR2 parses and validates arguments for dispatch.
+    """
+
+    type: Literal["function_call"] = "function_call"
+    call_id: Identifier
+    name: Identifier
+    arguments: str
+    id: Identifier | None = None
+    status: ModelItemStatus | None = None
+
+
+class FunctionCallOutput(ResponsesModel):
+    type: Literal["function_call_output"] = "function_call_output"
+    call_id: Identifier
+    output: str
+    id: Identifier | None = None
+    status: ModelItemStatus | None = None
+
+
+class ReasoningSummary(ResponsesModel):
+    type: Literal["summary_text"] = "summary_text"
+    text: str
+
+
+class ReasoningText(ResponsesModel):
+    type: Literal["reasoning_text"] = "reasoning_text"
+    text: str
+
+
+class ReasoningItem(ResponsesModel):
+    """
+    Continuation data retained in model history, not emitted as public text.
+    """
+
+    type: Literal["reasoning"] = "reasoning"
+    id: Identifier
+    summary: tuple[ReasoningSummary, ...]
+    content: tuple[ReasoningText, ...] | None = None
+    encrypted_content: str | None = None
+    status: ModelItemStatus | None = None
+
+
+type ModelItem = Annotated[
+    ModelMessage | ToolCall | FunctionCallOutput | ReasoningItem,
+    Field(discriminator="type"),
+]
+
+
+def _resolve_schema_reference(parameters: dict, reference: str) -> dict:
+    """
+    Resolve a local JSON pointer without fetching external schema resources.
+    """
+    if not isinstance(reference, str) or not (
+        reference == "#" or reference.startswith("#/")
+    ):
+        raise ValueError("parameter schemas require local references")
+    target = parameters
+    tokens = reference[2:].split("/") if reference != "#" else ()
+    for token in tokens:
+        token = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(target, dict) or token not in target:
+            raise ValueError("schema reference does not resolve")
+        target = target[token]
+    if not isinstance(target, dict):
+        raise ValueError("schema references must resolve to objects")
+    return target
+
+
+def _validate_tool_parameters(parameters: dict, *, strict: bool) -> None:
+    """
+    Require finite JSON and closed, fully required objects in strict schemas.
+
+    Walk schema keywords, not example/default data. Provider adapters must
+    additionally check the schema features supported by their target model.
+    """
+    json.dumps(parameters, allow_nan=False)
+    root = parameters
+    root_references = set()
+    while "$ref" in root:
+        if id(root) in root_references:
+            raise ValueError("root reference must resolve to an object schema")
+        root_references.add(id(root))
+        root = _resolve_schema_reference(parameters, root["$ref"])
+    if root.get("type") != "object":
+        raise ValueError("function parameters must describe an object")
+    if not strict:
+        return
+
+    pending = [parameters]
+    visited = set()
+    while pending:
+        schema = pending.pop()
+        if not isinstance(schema, dict):
+            raise ValueError("schema nodes must be objects")
+        if id(schema) in visited:
+            continue
+        visited.add(id(schema))
+
+        if "$ref" in schema:
+            pending.append(
+                _resolve_schema_reference(parameters, schema["$ref"])
+            )
+
+        kind = schema.get("type")
+        is_object = kind == "object" or (
+            isinstance(kind, list) and "object" in kind
+        )
+        if is_object or "properties" in schema:
+            properties = schema.get("properties", {})
+            required = schema.get("required", [])
+            if (
+                not is_object
+                or not isinstance(properties, dict)
+                or not isinstance(required, list)
+                or not all(isinstance(name, str) for name in required)
+                or len(required) != len(properties)
+                or set(required) != set(properties)
+                or schema.get("additionalProperties") is not False
+                or "patternProperties" in schema
+            ):
+                raise ValueError(
+                    "strict objects must forbid extra properties and require every property"
+                )
+
+        for keyword in ("properties", "$defs"):
+            children = schema.get(keyword, {})
+            if not isinstance(children, dict):
+                raise ValueError("schema property definitions must be objects")
+            pending.extend(children.values())
+        if "items" in schema:
+            pending.append(schema["items"])
+        for keyword in ("anyOf", "oneOf", "allOf", "prefixItems"):
+            children = schema.get(keyword, [])
+            if not isinstance(children, list):
+                raise ValueError("schema alternatives must be arrays")
+            pending.extend(children)
+
+
+class ToolDefinition(ResponsesModel):
+    """
+    Responses function schema; adapters must not silently disable strict mode.
+    """
+
+    type: Literal["function"] = "function"
     name: Identifier
     description: NonBlankText
-    input_schema: dict[str, JsonValue]
+    parameters: dict[str, JsonValue]
+    strict: StrictBool = True
+
+    @model_validator(mode="after")
+    def valid_parameters(self) -> Self:
+        """
+        Check the common strict-schema requirements before adapter invocation.
+        """
+        _validate_tool_parameters(self.parameters, strict=self.strict)
+        return self
 
 
-class ModelRequest(ContractModel):
+class ModelRequest(ResponsesModel):
     """
-    One model operation; provider configuration belongs to its adapter.
+    Responses input; model selection, credentials, and transport stay in adapters.
     """
 
-    messages: tuple[ModelMessage, ...]
+    instructions: str = ""
+    input: tuple[ModelItem, ...]
     tools: tuple[ToolDefinition, ...] = ()
+
+    @model_validator(mode="after")
+    def unique_tools(self) -> Self:
+        """
+        Require unambiguous names for dispatch.
+        """
+        names = [tool.name for tool in self.tools]
+        if len(names) != len(set(names)):
+            raise ValueError("tool names must be unique")
+        return self
 
 
 class ModelTextDelta(ContractModel):
@@ -351,13 +556,33 @@ class ModelTextDelta(ContractModel):
     delta: str
 
 
-class ModelToolCall(ContractModel):
-    type: Literal["tool_call"] = "tool_call"
-    call: ToolCall
+class ModelOutputItem(ContractModel):
+    """
+    An assembled output item in provider order, alongside incremental text.
+    """
+
+    type: Literal["output_item"] = "output_item"
+    item: Annotated[
+        ModelMessage | ToolCall | ReasoningItem, Field(discriminator="type")
+    ]
+
+    @model_validator(mode="after")
+    def assistant_output_only(self) -> Self:
+        """
+        The model cannot emit user messages or tool execution results.
+        """
+        if (
+            isinstance(self.item, ModelMessage)
+            and self.item.role != "assistant"
+        ):
+            raise ValueError(
+                "model output messages must have the assistant role"
+            )
+        return self
 
 
 type ModelEvent = Annotated[
-    ModelTextDelta | ModelToolCall, Field(discriminator="type")
+    ModelTextDelta | ModelOutputItem, Field(discriminator="type")
 ]
 
 
@@ -369,4 +594,4 @@ class Conversation(ContractModel):
     conversation_id: Identifier
     identity_id: Identifier
     scope: ScopeSelection
-    messages: tuple[ModelMessage, ...] = ()
+    items: tuple[ModelItem, ...] = ()

--- a/lp_agent/utils/__init__.py
+++ b/lp_agent/utils/__init__.py
@@ -1,0 +1,3 @@
+"""
+Shared utilities for the agent package.
+"""

--- a/lp_agent/utils/audit.py
+++ b/lp_agent/utils/audit.py
@@ -1,0 +1,51 @@
+"""
+Utilities for versioned fingerprints of instructions and Responses function tools.
+"""
+
+import hashlib
+import json
+from typing import Literal, Self
+
+from lp_agent.types import ContractModel, ModelRequest, ToolDefinition
+
+
+class InstructionArtifact(ContractModel):
+    """
+    Canonical instruction state, independent of provider request encoding.
+
+    Persist the canonical bytes with their digest in restricted audit storage.
+    This does not fingerprint conversation input or the complete wire request.
+    Changes to this serialization contract require a new format version.
+    """
+
+    format: Literal["lp_agent.instructions.v1"] = "lp_agent.instructions.v1"
+    instructions: str
+    tools: tuple[ToolDefinition, ...] = ()
+
+    @classmethod
+    def from_request(cls, request: ModelRequest) -> Self:
+        """
+        Snapshot resolved instructions and tools without shared mutable schemas.
+        """
+        return cls(
+            instructions=request.instructions,
+            tools=tuple(tool.model_copy(deep=True) for tool in request.tools),
+        )
+
+    def canonical_bytes(self) -> bytes:
+        """
+        Sort object keys; preserve array order, string content, and defaults.
+        """
+        return json.dumps(
+            self.model_dump(mode="python"),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+
+    def content_hash(self) -> str:
+        """
+        Return the SHA-256 digest of this artifact's canonical bytes.
+        """
+        return hashlib.sha256(self.canonical_bytes()).hexdigest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "heroicons>=2.0",
     # AI Chat — 1.98 adds the bedrock_mantle/* model ids
     "litellm>=1.98",
-    "pydantic>=2.0",
+    "pydantic>=2.10.0",
     # Topic Flow corpus loading (litigant_portal/app/topic_flow)
     "pyyaml>=6.0",
     # Topic Flow file artifacts — .ics calendar + .vcf vCard export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ test = [
 manage = "litigant_portal.manage:main"
 
 [tool.setuptools.packages.find]
-include = [ "litigant_portal*" ]
+include = [ "litigant_portal*", "lp_agent*" ]
 
 
 [tool.setuptools.package-data]
@@ -104,6 +104,11 @@ litigant_portal = [
   "corpus/**/*.pdf",
   "prompts/**/*.json",
   "prompts/**/*.md",
+]
+lp_agent = [
+  "py.typed",
+  "README.md",
+  "pytest.ini"
 ]
 
 [tool.ruff]
@@ -150,7 +155,7 @@ DJANGO_SETTINGS_MODULE = "litigant_portal.settings"
 python_files = ["tests.py", "test_*.py"]
 python_classes = ["*Tests"]
 pythonpath = ["."]
-testpaths = ["litigant_portal"]
+testpaths = ["litigant_portal", "lp_agent/tests"]
 addopts = "-ra --strict-markers"
 markers = [
     "postgres: test requires a PostgreSQL database",

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,15 @@ setenv =
     POSTGRES_PASSWORD = postgres
     CHAT_ENABLED = false
 commands = pytest -m "not postgres" {posargs:--verbosity=1}
+
+[testenv:agent]
+# Exercise the core without installing Django or initializing its settings.
+runner = uv-venv-runner
+package = skip
+extras =
+deps =
+    pydantic>=2.0
+    pytest>=8.0
+setenv =
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1
+commands = python -m pytest -c lp_agent/pytest.ini lp_agent/tests {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{313}
+envlist = py{313}, agent
 
 [testenv]
 runner = uv-venv-lock-runner
@@ -35,7 +35,7 @@ runner = uv-venv-runner
 package = skip
 extras =
 deps =
-    pydantic>=2.0
+    pydantic>=2.10.0
     pytest>=8.0
 setenv =
     PYTEST_DISABLE_PLUGIN_AUTOLOAD = 1

--- a/uv.lock
+++ b/uv.lock
@@ -1096,7 +1096,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
-    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pypdf", specifier = ">=6.15.0" },
     { name = "pytailwindcss", marker = "extra == 'dev'", specifier = ">=0.2" },


### PR DESCRIPTION
## What changed

Introduces a standalone `lp_agent` package and establishes the `LPAgent` interface for future agent execution. The contract covers submitting work, receiving updates and outcomes, handling user replies, and providing verified identity and court/topic context.

Defines a boundary between reusable agent behavior and application-specific services, with a thin `PortalAgent` entry point for Django. Packaging, Docker, and continuous integration support allow the core contract to be tested independently of Django, a database, or a model provider.

This PR provides contract scaffolding and validation. Runtime execution and concrete service adapters follow in subsequent PRs.

Part of #860.

## Test plan

- [x] `make pre-commit` green (lint + full suite)
- [x] Pre-commit checks on changed files and static typing checks passed.
- [x] `tox -e agent`: 57 contract tests passed without Django, a database, or provider credentials.
- [x] `make test`: application tests passed inside Docker.
- [x] Wheel and Docker image builds passed; the installed package imports outside the checkout without Django.

The checks above were run separately; the combined `make pre-commit` target remains unchecked.

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.