### PR TITLE
Document how work is tracked and where priority and size live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,13 +155,18 @@ EOF
 
 Field ids are validated against the chosen template — a section that doesn't match (wrong field or wrong template) warns and would render blank. The label is applied by the template; set assignee/priority/size in the browser. See `scripts/file_issue.py` for the full format and accepted type aliases.
 
-## Sprint mapping
+## Work tracking
 
-When someone references a sprint by its web-team letter/artist name ("the Ed Sheeran sprint", "Sprint F"), translate to the matching LP Iteration on board #75 via the sprint-map crosswalk (JI-team record kept outside the repo; the board/vault tooling holds the current copy), then pull the work from #75 + git. This crosswalk is LP-specific — other JI repos don't necessarily align with the web-team retro, so it lives here, not in org-level instructions.
+Contributor-facing docs are canonical — don't restate them here:
+
+- **Board, iterations, statuses, assignment:** [CONTRIBUTING.md](CONTRIBUTING.md#how-work-is-tracked)
+- **Where priority and size live, and why the board mirrors them:** [docs/wiki/issue-conventions.md](docs/wiki/issue-conventions.md#where-priority-and-size-live)
+
+**Sprint mapping.** LP iterations are numbered and dated; the web team names its sprints by letter/artist. When someone references "Sprint F" or an artist name, translate to the matching LP Iteration through the sprint-map crosswalk (JI-team record kept outside the repo; the board/vault tooling holds the current copy), then pull the work from #75 + git. The crosswalk is LP-specific, so it lives here rather than at the org level.
 
 ## Sizing & estimation
 
-The compact rules (board mechanics live at the org level; sizing history, anchors, and calibration records are JI-team material, kept outside the repo):
+The compact rules (sizing history, anchors, and calibration records are JI-team material, kept outside the repo):
 
 - **Scale:** XS 0.5 (~1–2h) · S 1 (half day) · M 3 (1–2 days) · L 5 (3–4 days), calibrated to AI-assisted effort. Size is the one human input; the board derives Estimate.
 - **Size the work, not the diff** — a one-line fix after three days of debugging isn't an XS; a 600-line mechanical rename can be. Incident work: size the diagnosis. Count off-repo work (content authoring, infra, verification).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,28 @@ Litigant Portal is an open-source access-to-justice project by [Free Law Project
 - **Ticket-specific acceptance criteria live on the issue**, on top of the repo-wide bar in [docs/wiki/definition-of-done.md](docs/wiki/definition-of-done.md). If you spot adjacent problems along the way, file them as new issues rather than growing the PR.
 - **Priority and size** are assigned by the team during grooming — leave them off when filing.
 
+## How work is tracked
+
+Work is tracked on the [Sprint (Litigant Portal)](https://github.com/orgs/freelawproject/projects/75) board, which is public — anyone can read it without being a member.
+
+**Assignment.** Issues are assigned when someone starts work, not when they're filed. Unassigned is normal and legitimate, including for work in the current iteration. `good first issue` and `help wanted` are never pre-assigned.
+
+**Iterations.** Sprints are two-week iterations on the board, identified by number and date range (e.g. "Iteration 9 · Sep 1–14"). An iteration is a record of what was committed and what shipped, so unplanned work that lands inside the window is folded in, and the committed total is recorded at close before any carry-over moves. Unfinished work returns to Backlog and is re-placed at the next planning session, never auto-rolled into a future iteration.
+
+**Status.** The Iteration field records commitment. Status records where the work is.
+
+| Status      | Meaning                                                                             |
+| ----------- | ----------------------------------------------------------------------------------- |
+| Backlog     | Not committed to an iteration. No Iteration set; size and priority not required.    |
+| Ready       | Committed to the current iteration, not started. Iteration, size, and priority set. |
+| In progress | Being worked on now.                                                                |
+| In review   | PR open, awaiting review.                                                           |
+| Done        | PR merged or issue closed.                                                          |
+
+Size and priority are the gate to _leave_ Backlog, not to enter it — an issue can be filed and sit there untriaged. Work placed in a future iteration stays in Backlog until that iteration opens. Issues that aren't units of work at all (decision records, research threads, open questions) live in Backlog permanently and are never sized.
+
+**Priority and size live on the issue as labels** (`P0`–`P3`, `size: XS` through `size: XL`), set during grooming. The board mirrors them into its own Priority and Size fields, because a project board can't group or sort by label. The labels are the source of truth — edit those, not the board fields.
+
 ## Commits
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope?): description`, with types `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Imperative mood, atomic commits.

--- a/docs/wiki/issue-conventions.md
+++ b/docs/wiki/issue-conventions.md
@@ -85,6 +85,16 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 | `tech debt`        | `#D4C5F9` | Deferred cleanup, consolidation, refactoring                 |
 | `user story`       | `#0FB3A1` | Persona user story — living reference, exempt from stale bot |
 
+## Where priority and size live
+
+**The labels on the issue are the source of truth.** The [Sprint (Litigant Portal)](https://github.com/orgs/freelawproject/projects/75) board mirrors `P0`–`P3` and `size: *` into its own Priority and Size fields, and derives Estimate from Size. That mirror exists only because [a project board can't group or sort by label](https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/customizing-the-board-layout) — it isn't a second place to record the value.
+
+The sync is one way, label → field. Change priority or size by editing the label on the issue, which anyone with write access can do from the issue page or `gh`. An edit made in the board UI is invisible from the issue and gets overwritten on the next sync.
+
+GitHub now offers organization-level issue fields as a first-class replacement for encoding this on labels — one typed value on the issue that boards read directly. Adopting them is an org-wide decision, tracked in #777. Until that lands, labels stay canonical.
+
+How the board is used day to day — statuses, iterations, assignment — lives in [CONTRIBUTING.md](../../CONTRIBUTING.md#how-work-is-tracked).
+
 ## Conventions
 
 - **Lowercase, spaces (no hyphens)** for multi-word labels. Matches GitHub defaults (`good first issue`, `help wanted`).
@@ -106,3 +116,4 @@ Each surface area gets its own distinct hue so multi-label issues are scannable.
 - 2026-05-21 — label audit: 32 → 28 labels. Resolved color collisions (`security`, `research`, `a11y`); sizes unified to soft grey; deleted unused `blocked`, `invalid`, `wontfix`, `Chat Flow`. Created `task` label; renamed `QA` → `qa` (lowercase).
 - 2026-06-15 — added `user story` label (`#0FB3A1`) and added it to the stale bot's exempt list, so persona stories under #22 don't auto-close. Applied to #26, #190, #191, #192, #311, #312.
 - 2026-06-16 — dropped the dead `blocked` reference from `stale.yml` (label was deleted in the 2026-05-21 audit); renamed the new label `user-story` → `user story` to match the no-hyphens convention.
+- 2026-09-08 — documented where priority and size live: the labels are the source of truth and the board mirrors them one way, because a board can't group or sort by label. Board usage (statuses, iterations, assignment) documented in `CONTRIBUTING.md`. Org-wide issue fields as the eventual replacement tracked in #777. PR for #776.


### PR DESCRIPTION
Board usage had no contributor-facing home — it lived only in instruction files outside the repo. `CONTRIBUTING.md` gains a "How work is tracked" section covering the board, assignment, iterations and the Backlog through Done statuses; `docs/wiki/issue-conventions.md` states that the `P*` and `size:` labels are the source of truth; `CLAUDE.md` points at both instead of restating them.

The board mirror exists because a project board can't group or sort by label, not as a second place to record the value. Org-wide issue fields as the eventual single surface are tracked in #777.

Two things were corrected against the original August write-up, since the board moved while it sat: the letter/artist sprint crosswalk does still exist (kept outside the repo, read by `/board-audit`), and carry-over is additive — a closing iteration's committed total is recorded before anything moves.

Closes #776

## Test plan

Documentation only, no code paths touched. Verified against live state rather than the August assumptions:

- Board #75 is public, so the CONTRIBUTING link is readable by non-members
- Board #61 has zero litigant-portal items
- `board-sync.py`'s write path is one-way, label → field
- `/board-audit` exempts unsized Backlog and never-sized non-work items
- Anchor links between the three files resolve to real headings
