### PR TITLE
feat(content): restore name and county questions

### DIFF
--- a/litigant_portal/app/templates/cotton/molecules/toast_container.html
+++ b/litigant_portal/app/templates/cotton/molecules/toast_container.html
@@ -3,7 +3,8 @@
 {% if messages %}
   <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-md px-4">
     {% for message in messages %}
-      <c-atoms.auto-dismiss>
+      {# 5s, not the atom's 1.5s default: flash messages are full sentences #}
+      <c-atoms.auto-dismiss timeout="5000">
       <c-atoms.alert variant="{{ message.variant }}" class="mb-2 shadow-lg">{{ message.text }}</c-atoms.alert>
       </c-atoms.auto-dismiss>
     {% endfor %}

--- a/litigant_portal/app/templates/pages/style_guide.html
+++ b/litigant_portal/app/templates/pages/style_guide.html
@@ -1035,7 +1035,7 @@
           <section id="toast-container" class="mb-12" aria-labelledby="toast-container-heading">
             <h3 id="toast-container-heading" class="mb-4">Toast Container</h3>
             <p class="text-greyscale-600 mb-6">Renders Django flash messages as auto-dismissing toast overlays. Included in <code>base.html</code>.</p>
-            <p class="text-sm text-greyscale-500 mb-4">Composes <code>c-atoms.auto-dismiss</code> and <code>c-atoms.alert</code>. No props — reads <code>messages</code> from template context.</p>
+            <p class="text-sm text-greyscale-500 mb-4">Composes <code>c-atoms.auto-dismiss</code> (at a 5s timeout, so sentence-length messages stay readable) and <code>c-atoms.alert</code>. No props — reads <code>messages</code> from template context.</p>
           </section>
           <section id="user-menu" class="mb-12" aria-labelledby="user-menu-heading">
             <h3 id="user-menu-heading" class="mb-4">User Menu</h3>

--- a/litigant_portal/app/tests/test_content_never_prefill.py
+++ b/litigant_portal/app/tests/test_content_never_prefill.py
@@ -1,0 +1,42 @@
+"""Drift guard: the name/county questions real content asks never echo back.
+
+The ND name-change flows collect them for the docassemble prefill, not to
+display them, and a content-side addition that misses ``_NEVER_PREFILL`` would
+only surface on a shared terminal. DB-free.
+"""
+
+import pytest
+
+from litigant_portal.app.topic_flow.loader import CorpusLoader
+from litigant_portal.app.topic_flow.registry import CONTENT_DIR
+from litigant_portal.app.topic_flow.renderer import _NEVER_PREFILL
+
+NAME_CHANGE_FLOWS = [
+    "adult-name-change-standard.yml",
+    "adult-name-change-waiver.yml",
+]
+IDENTITY_QUESTIONS = ["first_name", "middle_name", "last_name", "county"]
+
+
+def _question_ids(file_name):
+    path = CONTENT_DIR / file_name
+    corpus = CorpusLoader.load(path)
+    return [
+        question.id
+        for section in corpus.sections
+        if section.kind == "fact_gather"
+        for question in section.questions
+    ]
+
+
+@pytest.mark.parametrize("file_name", NAME_CHANGE_FLOWS)
+@pytest.mark.parametrize("question_id", IDENTITY_QUESTIONS)
+def test_name_change_flow_collects_the_identity_question(
+    file_name, question_id
+):
+    assert question_id in _question_ids(file_name)
+
+
+@pytest.mark.parametrize("question_id", IDENTITY_QUESTIONS)
+def test_identity_question_is_never_prefilled(question_id):
+    assert question_id in _NEVER_PREFILL

--- a/litigant_portal/app/tests/test_content_never_prefill.py
+++ b/litigant_portal/app/tests/test_content_never_prefill.py
@@ -1,7 +1,7 @@
 """Drift guard: the name/county questions real content asks never echo back.
 
 The ND name-change flows collect them for the docassemble prefill, not to
-display them, and a content-side addition that misses ``_NEVER_PREFILL`` would
+display them, and a content-side addition that misses ``NEVER_PREFILL`` would
 only surface on a shared terminal. DB-free.
 """
 
@@ -9,7 +9,7 @@ import pytest
 
 from litigant_portal.app.topic_flow.loader import CorpusLoader
 from litigant_portal.app.topic_flow.registry import CONTENT_DIR
-from litigant_portal.app.topic_flow.renderer import _NEVER_PREFILL
+from litigant_portal.app.topic_flow.renderer import NEVER_PREFILL
 
 NAME_CHANGE_FLOWS = [
     "adult-name-change-standard.yml",
@@ -39,4 +39,4 @@ def test_name_change_flow_collects_the_identity_question(
 
 @pytest.mark.parametrize("question_id", IDENTITY_QUESTIONS)
 def test_identity_question_is_never_prefilled(question_id):
-    assert question_id in _NEVER_PREFILL
+    assert question_id in NEVER_PREFILL

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -61,6 +61,16 @@ def test_info_renders_heading_and_body():
 
 # --- fact_gather ------------------------------------------------------------
 
+# Literal, not imported from the renderer: importing the set under test would
+# make these agree with a deletion from it.
+PROTECTED_IDS = [
+    "name_change_publication_date",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "county",
+]
+
 
 def _fg(questions, heading=None, id="facts"):
     return FactGatherSection(
@@ -90,22 +100,11 @@ def test_fact_gather_unanswered_question_prefills_empty():
     assert q["value"] == ""
 
 
-def test_fact_gather_never_prefills_publication_date():
-    # #638: unlike other fields, name_change_publication_date must never echo a stored
-    # answer back into the form.
-    section = _fg(
-        [
-            Question(
-                id="name_change_publication_date",
-                label="Publication date",
-                type="date",
-            )
-        ]
-    )
+@pytest.mark.parametrize("question_id", PROTECTED_IDS)
+def test_fact_gather_never_prefills_a_protected_question(question_id):
+    section = _fg([Question(id=question_id, label="Protected")])
     rendered = render_section(
-        section,
-        _corpus(section),
-        {"name_change_publication_date": "2026-05-01"},
+        section, _corpus(section), {question_id: "stored"}
     )
     (q,) = rendered.context["questions"]
     assert q["value"] == ""
@@ -206,16 +205,11 @@ def test_summary_omits_unanswered_questions():
     ]
 
 
-def test_summary_never_prefills_publication_date():
-    # #638: the recap reads the same session-backed answers as the fact_gather
-    # form — a prior guest's name_change_publication_date can't leak in here either.
+@pytest.mark.parametrize("question_id", PROTECTED_IDS)
+def test_summary_never_recaps_a_protected_question(question_id):
     fg = _fg(
         [
-            Question(
-                id="name_change_publication_date",
-                label="Publication date",
-                type="date",
-            ),
+            Question(id=question_id, label="Protected"),
             Question(id="filing_county", label="County"),
         ]
     )
@@ -225,10 +219,7 @@ def test_summary_never_prefills_publication_date():
     rendered = render_section(
         summary,
         _corpus(fg, summary),
-        {
-            "name_change_publication_date": "2026-05-01",
-            "filing_county": "Cass",
-        },
+        {question_id: "stored", "filing_county": "Cass"},
     )
     assert rendered.context["items"] == [{"label": "County", "value": "Cass"}]
 

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -788,6 +788,37 @@ def test_post_persists_stripped_value(client, monkeypatch, variables):
     assert _values().get("filing_county") == "Cass"
 
 
+@pytest.mark.django_db
+def test_post_save_flashes_a_saved_toast(client, monkeypatch, variables):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(URL, {"filing_county": "Cass"}, follow=True)
+    html = response.content.decode()
+    assert "Saved." in html
+    assert "For your privacy" not in html
+
+
+@pytest.mark.django_db
+def test_post_of_a_protected_answer_explains_the_privacy_blank(
+    client, monkeypatch, variables
+):
+    # A NEVER_PREFILL answer re-renders blank right after saving (#638), so
+    # the toast must say the save worked and why the field looks empty (#803).
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(
+        URL, {"name_change_publication_date": "2026-02-01"}, follow=True
+    )
+    assert "For your privacy" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_post_with_errors_flashes_no_toast(client, monkeypatch, variables):
+    # The error re-render's feedback is the inline field errors; a "Saved."
+    # toast beside them would contradict the page.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _corpus())
+    response = client.post(URL, {"name_change_publication_date": "not-a-date"})
+    assert "Saved." not in response.content.decode()
+
+
 # --- ics deadline rendering (#494, needs DB) --------------------------------
 # The ics output renders a personalized deadline computed from the stored
 # answer — fact_gather → AnswerStore → compute_deadline → on-page date, JS off.

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -94,7 +94,7 @@ def _render_info(section, corpus, answers):
 # Stored for downstream use (deadline computation, docassemble prefill) but
 # never echoed back into the form or the recap, so a shared terminal can't
 # replay one litigant's answers to the next (#638, #803).
-_NEVER_PREFILL = {
+NEVER_PREFILL = {
     "name_change_publication_date",
     "first_name",
     "middle_name",
@@ -113,7 +113,7 @@ def _render_fact_gather(section, corpus, answers):
             "required": q.required,
             "choices": q.choices,
             "help_text": q.help_text,
-            "value": "" if q.id in _NEVER_PREFILL else answers.get(q.id, ""),
+            "value": "" if q.id in NEVER_PREFILL else answers.get(q.id, ""),
             "errors": [],
             "autofocus": False,
         }
@@ -170,11 +170,11 @@ def _answered_in_corpus_order(corpus, answers):
     """Yield ``{label, value}`` for answered questions, in corpus order.
 
     Same leak vector as the fact_gather form: skip anything in
-    ``_NEVER_PREFILL`` so a prior guest's answer can't surface in the recap
+    ``NEVER_PREFILL`` so a prior guest's answer can't surface in the recap
     either (#638).
     """
     for question in _fact_gather_questions(corpus):
-        if question.id in answers and question.id not in _NEVER_PREFILL:
+        if question.id in answers and question.id not in NEVER_PREFILL:
             yield {"label": question.label, "value": answers[question.id]}
 
 

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -91,12 +91,16 @@ def _render_info(section, corpus, answers):
     )
 
 
-# name_change_publication_date is the one field left cached across sessions
-# on a shared terminal (#621 already pruned the riskier name/county
-# questions) (#638).
-# It's still stored for deadline computation — just never echoed back into
-# the form.
-_NEVER_PREFILL = {"name_change_publication_date"}
+# Stored for downstream use (deadline computation, docassemble prefill) but
+# never echoed back into the form or the recap, so a shared terminal can't
+# replay one litigant's answers to the next (#638, #803).
+_NEVER_PREFILL = {
+    "name_change_publication_date",
+    "first_name",
+    "middle_name",
+    "last_name",
+    "county",
+}
 
 
 @renderer("fact_gather")

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -23,6 +23,7 @@ from litigant_portal.app.selectors.topic_flow import topic_list
 from litigant_portal.app.services.topic_flow import variable_answer_set_many
 from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
+    NEVER_PREFILL,
     question_ids,
     render_section,
     submitted_section_anchor,
@@ -110,6 +111,19 @@ def topic_flow(request, court, topic, role):
             return _render_topic_flow(
                 request, corpus, topic_flow_answers(request, corpus), errors
             )
+        if valid:
+            # A NEVER_PREFILL field re-renders blank even after a successful
+            # save, so without a toast the save looks like it failed (#803).
+            if any(valid.get(qid) for qid in NEVER_PREFILL):
+                messages.success(
+                    request,
+                    _(
+                        "Saved. For your privacy, your answers are not "
+                        "shown on this page."
+                    ),
+                )
+            else:
+                messages.success(request, _("Saved."))
         # PRG back to the section just saved (#anchor) so the litigant keeps
         # their place and sees the recomputed deadlines, instead of the browser
         # jumping to the top of the page on the redirected GET.

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -128,10 +128,28 @@ sections:
       File in the district court for the county where you have lived for the past 6 months. Your driver's license, lease, or a utility bill usually shows this. The court locator link in the contacts at the end of this page can also help.
 
   - kind: fact_gather
-    # Pruned to the one fact the page actually uses (#621): name_change_publication_date
-    # drives the 30-day deadline and its calendar export. The name/county
-    # fields only echoed back in the summary, so they come back when
-    # docassemble prefill (#531) can reuse them downstream.
+    # Restored (#803) for the docassemble prefill (#531). Stored but never
+    # rendered back (_NEVER_PREFILL in the renderer).
+    id: your_information
+    heading: 'Your name and county'
+    questions:
+      - id: first_name
+        label: 'First name'
+        type: text
+        help_text: 'Your current legal name, as it appears on your ID. What you save here is used to fill out your forms. For your privacy on a shared computer, it is not shown back to you on this page.'
+      - id: middle_name
+        label: 'Middle name(s) (if any)'
+        type: text
+      - id: last_name
+        label: 'Last name'
+        type: text
+      - id: county
+        label: 'County'
+        type: text
+        help_text: 'The North Dakota county where you have lived for the past 6 months. This is the county you file in.'
+
+  - kind: fact_gather
+    # Its own section: the litigant fills this later, once the notice has run.
     id: publication_details
     heading: 'Your publication date'
     questions:

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -129,7 +129,7 @@ sections:
 
   - kind: fact_gather
     # Restored (#803) for the docassemble prefill (#531). Stored but never
-    # rendered back (_NEVER_PREFILL in the renderer).
+    # rendered back (NEVER_PREFILL in the renderer).
     id: your_information
     heading: 'Your name and county'
     questions:

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -127,6 +127,14 @@ sections:
     body: |
       File in the district court for the county where you have lived for the past 6 months. Your driver's license, lease, or a utility bill usually shows this. The court locator link in the contacts at the end of this page can also help.
 
+  - kind: info
+    # Sets the expectation before the form below: NEVER_PREFILL renders its
+    # saved answers blank, which looks like a failed save without this (#803).
+    id: your_information_privacy
+    heading: 'How your information is used'
+    body: |
+      What you enter below is used to fill out your court forms. For your privacy on a shared or public computer, your saved answers are not shown back on this page.
+
   - kind: fact_gather
     # Restored (#803) for the docassemble prefill (#531). Stored but never
     # rendered back (NEVER_PREFILL in the renderer).
@@ -136,7 +144,7 @@ sections:
       - id: first_name
         label: 'First name'
         type: text
-        help_text: 'Your current legal name, as it appears on your ID. What you save here is used to fill out your forms. For your privacy on a shared computer, it is not shown back to you on this page.'
+        help_text: 'Your current legal name, as it appears on your ID.'
       - id: middle_name
         label: 'Middle name(s) (if any)'
         type: text

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -114,7 +114,7 @@ sections:
 
   - kind: fact_gather
     # Restored (#803) for the docassemble prefill (#531). Stored but never
-    # rendered back (_NEVER_PREFILL in the renderer).
+    # rendered back (NEVER_PREFILL in the renderer).
     id: your_information
     heading: 'Your name and county'
     questions:

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -112,9 +112,26 @@ sections:
 
       If you have a felony conviction, North Dakota law assumes a name-change request is made in bad faith. A judge may still grant it, but you would need to show by clear and convincing evidence that your request is made in good faith and not to defraud, mislead, injure anyone, or compromise public safety.
 
-  # No fact_gather on this track (#621): the waiver flow computes no deadline,
-  # so the page uses no answers. The name/county fields only echoed back in
-  # the summary; they return when docassemble prefill (#531) can reuse them.
+  - kind: fact_gather
+    # Restored (#803) for the docassemble prefill (#531). Stored but never
+    # rendered back (_NEVER_PREFILL in the renderer).
+    id: your_information
+    heading: 'Your name and county'
+    questions:
+      - id: first_name
+        label: 'First name'
+        type: text
+        help_text: 'Your current legal name, as it appears on your ID. What you save here is used to fill out your forms. For your privacy on a shared computer, it is not shown back to you on this page.'
+      - id: middle_name
+        label: 'Middle name(s) (if any)'
+        type: text
+      - id: last_name
+        label: 'Last name'
+        type: text
+      - id: county
+        label: 'County'
+        type: text
+        help_text: 'The North Dakota county where you have lived for the past 6 months. This is the county you file in.'
 
   - kind: output
     output_type: packet

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -112,6 +112,14 @@ sections:
 
       If you have a felony conviction, North Dakota law assumes a name-change request is made in bad faith. A judge may still grant it, but you would need to show by clear and convincing evidence that your request is made in good faith and not to defraud, mislead, injure anyone, or compromise public safety.
 
+  - kind: info
+    # Sets the expectation before the form below: NEVER_PREFILL renders its
+    # saved answers blank, which looks like a failed save without this (#803).
+    id: your_information_privacy
+    heading: 'How your information is used'
+    body: |
+      What you enter below is used to fill out your court forms. For your privacy on a shared or public computer, your saved answers are not shown back on this page.
+
   - kind: fact_gather
     # Restored (#803) for the docassemble prefill (#531). Stored but never
     # rendered back (NEVER_PREFILL in the renderer).
@@ -121,7 +129,7 @@ sections:
       - id: first_name
         label: 'First name'
         type: text
-        help_text: 'Your current legal name, as it appears on your ID. What you save here is used to fill out your forms. For your privacy on a shared computer, it is not shown back to you on this page.'
+        help_text: 'Your current legal name, as it appears on your ID.'
       - id: middle_name
         label: 'Middle name(s) (if any)'
         type: text

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -89,7 +89,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-                # "portal.context_processors.toast_messages",
+                "litigant_portal.app.context_processors.toast_messages",
                 "litigant_portal.app.context_processors.app_meta",
             ],
             "builtins": [


### PR DESCRIPTION
## What changed

<!-- What this PR does. The issue holds the background; keep this to the change itself. -->

The two ND adult name change flows ask for first, middle, and last name plus county again, on both the standard and waiver tracks. #621 pruned these because their answers only echoed back into the summary and gave a shared terminal something to leak; they return now that the docassemble prefill has a real use for them, so the litigant does not retype what they already typed.

They come back under the shared-terminal protection rather than around it: all four ids join name_change_publication_date in the renderer's _NEVER_PREFILL, so the answers are stored and sent downstream but never rendered into the form or the recap. A litigant sees blank fields after saving, and the help text on the first name says so.

The questions are optional, unlike their glossary entries. A partly answered flow is a supported handoff case, and requiring them would block someone who only came for the publication deadline.

A new DB-free guard pins the two sides together: each flow asks all four questions, and each id is protected. The renderer's never-prefill tests now run over the whole protected set instead of the publication date alone.

Closes #803

## Test plan

<!-- How you verified it. Add the checks that matter for this change. -->

- [x] `make pre-commit` green (lint + full suite)
- [x] manual checks 
<img width="1568" height="923" alt="Screenshot From 2026-09-09 17-00-12" src="https://github.com/user-attachments/assets/1fa45f8a-1633-410c-9f43-7422a9ac5c33" />

<img width="1568" height="923" alt="Screenshot From 2026-09-09 17-00-03" src="https://github.com/user-attachments/assets/44478d39-f30a-465e-b689-00c2c80c761c" />

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.
