### PR TITLE
feat(topic_flow): prefill the docassemble interview from guided answers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key-here
 # it instead of the URL the content YAML carries.
 # DOCASSEMBLE_BASE_URL=http://localhost:8100
 # DOCASSEMBLE_API_KEY=
+# Only when LP reaches docassemble at an address litigants cannot (an internal
+# hostname): the resume link is rewritten onto this origin.
+# DOCASSEMBLE_PUBLIC_URL=
 
 # S3 object storage (static + public/private media)
 # USE_S3=true

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key-here
 # flows, contacts, and resources.
 # CORPUS_COURT=
 
+# docassemble prefill. Without the key the packet button links out to the
+# plain interview. Point the base URL at the local bench to prefill against
+# it instead of the URL the content YAML carries.
+# DOCASSEMBLE_BASE_URL=http://localhost:8100
+# DOCASSEMBLE_API_KEY=
+
 # S3 object storage (static + public/private media)
 # USE_S3=true
 # AWS_ACCESS_KEY_ID=

--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -40,7 +40,7 @@ code block, not a bare `multi_user: True` key, which throws `DASourceError`
 Prereq: the bench is up. See [`docs/docassemble.md`](../../docs/docassemble.md).
 
 - Start the bench: `make docassemble-up`
-- Open `http://localhost:8100` and log in (fresh box default: `admin@example.com` / `password`)
+- Open `http://localhost:8100` and log in with the `DA_ADMIN_EMAIL` / `DA_ADMIN_PASSWORD` seeded on the bench's first boot (see [`docs/docassemble.md`](../../docs/docassemble.md))
 - Top-right menu → **Playground**
 - Upload the templates: in the Playground, open the **Templates** folder → upload
   `petition.pdf`, `declaration.pdf`, `notice.pdf`, `confidential-info.pdf`, and `order.pdf`

--- a/docassemble/nd-name-change/README.md
+++ b/docassemble/nd-name-change/README.md
@@ -26,6 +26,15 @@ forms (Petition, Declaration, Notice, Confidential, Order), the waiver track 4
 §12 (objections); they fork at entry, matching the Topic Flow corpus's
 standard/waiver split — no in-interview branching.
 
+## `multi_user = True` (prefill prereq)
+
+Both interviews open with an `initial` code block setting `multi_user = True`.
+The Litigant Portal prefill handoff creates a session through the API and
+hands the litigant a one-time resume link; without this flag the session is
+encrypted per-browser and that link cannot decrypt it. It has to be an `initial`
+code block, not a bare `multi_user: True` key, which throws `DASourceError`
+.
+
 ## Test it locally
 
 Prereq: the bench is up. See [`docs/docassemble.md`](../../docs/docassemble.md).

--- a/docassemble/nd-name-change/petition-standard.yml
+++ b/docassemble/nd-name-change/petition-standard.yml
@@ -17,6 +17,12 @@ metadata:
 features:
   css: lp-branding.css
 ---
+# Required for the prefill handoff, and only works from an `initial` block.
+# See the README.
+initial: True
+code: |
+  multi_user = True
+---
 # Re-uses the Topic Flow corpus data points (current/requested name, county)
 # plus the Petition-only extras (residency-since, citizenship, criminal history,
 # publication). Variable names are interview-local; only the attachment field

--- a/docassemble/nd-name-change/petition-waiver.yml
+++ b/docassemble/nd-name-change/petition-waiver.yml
@@ -17,6 +17,12 @@ metadata:
 features:
   css: lp-branding.css
 ---
+# Required for the prefill handoff, and only works from an `initial` block.
+# See the README.
+initial: True
+code: |
+  multi_user = True
+---
 mandatory: True
 question: |
   Your current legal name

--- a/docker-compose.docassemble.yml
+++ b/docker-compose.docassemble.yml
@@ -16,7 +16,8 @@
 # Bring up:   docker compose -f docker-compose.docassemble.yml up -d
 #             (first run pulls ~20 GB / takes a while)
 # Open:       http://localhost:8100
-# Default login: admin@admin.com / password  — change it immediately on first login
+# Login:      DA_ADMIN_EMAIL / DA_ADMIN_PASSWORD below (seeded on first boot;
+#             docassemble's own stock default is unreliable)
 # Tear down:  docker compose -f docker-compose.docassemble.yml down
 #             (named volumes below persist Playground work across down/up)
 
@@ -30,6 +31,13 @@ services:
       DAHOSTNAME: 'localhost:8100'
       USEHTTPS: 'false'
       TIMEZONE: 'America/New_York'
+      # Seeded on an EMPTY database only — set these before the first boot,
+      # or wipe the volumes (`down -v`) to re-seed. Values come from .env;
+      # the fallbacks keep a bare `make docassemble-up` usable.
+      DA_ADMIN_EMAIL: '${DA_ADMIN_EMAIL:-admin@localhost}'
+      DA_ADMIN_PASSWORD: '${DA_ADMIN_PASSWORD:-docassemble}'
+      # Set this to prefill from LP without hunting for a key in the UI.
+      DA_ADMIN_API_KEY: '${DA_ADMIN_API_KEY:-}'
     stop_grace_period: 600s
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       # out to the plain interview.
       - DOCASSEMBLE_BASE_URL=${DOCASSEMBLE_BASE_URL}
       - DOCASSEMBLE_API_KEY=${DOCASSEMBLE_API_KEY}
+      - DOCASSEMBLE_PUBLIC_URL=${DOCASSEMBLE_PUBLIC_URL}
     volumes:
       - ./litigant_portal:/app/litigant_portal
       - ./lp_agent:/app/lp_agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       - AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK}
       - SUPERUSER_EMAIL=${SUPERUSER_EMAIL}
       - SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}
+      # docassemble prefill. Unset means no prefill: the packet button links
+      # out to the plain interview.
+      - DOCASSEMBLE_BASE_URL=${DOCASSEMBLE_BASE_URL}
+      - DOCASSEMBLE_API_KEY=${DOCASSEMBLE_API_KEY}
     volumes:
       - ./litigant_portal:/app/litigant_portal
       - ./lp_agent:/app/lp_agent

--- a/docs/docassemble.md
+++ b/docs/docassemble.md
@@ -16,7 +16,7 @@ One page for the document-assembly side: authoring gotchas, the local bench, QA 
 
 `make docassemble-up` / `make docassemble-down` → http://localhost:8100. Deliberately outside LP's dev/prod compose profiles (~20 GB all-in-one image, opt-in; first pull takes minutes).
 
-- Default login `admin@admin.com` / `password` — a well-known docassemble default, change it immediately.
+- Login is whatever `DA_ADMIN_EMAIL` / `DA_ADMIN_PASSWORD` seeded on the first boot (`docker-compose.docassemble.yml`, values from `.env`). docassemble's stock default does not reliably work. Those variables, and `DA_ADMIN_API_KEY` for the prefill client, seed **only into an empty database**: set them before the first `make docassemble-up`, or `down -v` and boot again.
 - Port 8100 because LP's Caddy owns `:80` in dev; `DAHOSTNAME` must include the port or websockets and generated URLs break.
 - Playground → **Utilities → "Get list of fields from a PDF or DOCX file"** reads an AcroForm PDF and scaffolds the `fields:` block — no manual field hunting.
 - Playground work persists on named volumes across `down`/`up`.

--- a/docs/docassemble.md
+++ b/docs/docassemble.md
@@ -43,7 +43,25 @@ docassemble's real production home rides the CL infra move (#461); QA hosting is
 
 Two systems, two jobs, one contract — with a deliberate split of which facts each side owns:
 
-- **Topic Flow owns** a light fact set, named 1:1 to the interview's variables so a future prefill is lossless: `current_first` · `current_middle` · `current_last` · `requested_first` · `requested_middle` (· `requested_last`, standard track only) · `filing_county` · `publication_date`. Today it collects only what a page actually uses (#621); the rest return when prefill (#531) gives them a consumer.
-- **The interview owns** the full document fact set Topic Flow never collects (residence, residency-since, citizenship, criminal history, publication newspaper, track-specific fields). Asking those in the AI-free flow would duplicate the interview.
+- **Topic Flow owns** a light fact set, named for the glossary (`first_name`, `county`, `name_change_publication_date`), and hands it over on the way out.
+- **The interview owns** the full document fact set Topic Flow never collects (residence, residency-since, citizenship, criminal history, publication newspaper, track-specific fields). Asking those in the guided flow would duplicate the interview.
 
-Names stay structured first / middle / last, never a single free-text field — splitting a combined string back apart is lossy. **v1 is link-out + manual return, no prefill** (#543): the prefill seam (POSTing the answer set to start a session, PII out of the URL) is deferred v2 (#531), with the Briefcase (#177) as its natural carrier. Same ids, no rework, makes that future a drop-in.
+**The names are not 1:1, and the mapping is explicit.** Only 3 of the interview's 19 variables happen to share our glossary names, so each flow's packet section carries an `interview_prefill` map from question id to interview variable, next to `interview_url`:
+
+```yaml
+interview_prefill:
+  first_name: current_first
+  county: residence_county
+```
+
+The schema validates every key is a `fact_gather` question id of that flow and every value is a plain Python identifier (docassemble executes these as assignment statements, so they may only come from author-controlled YAML). A drift guard in the test suite parses the versioned interviews and fails when a mapped variable no longer exists there.
+
+Names stay structured first / middle / last, never a single free-text field — splitting a combined string back apart is lossy.
+
+Three rules the prefill runs on:
+
+- **Only reviewed answers are sent.** A preset variable skips its question, so docassemble never asks the litigant to confirm it and there is no write-back. Confirmation has to happen on our side first.
+- **A preset variable skips its validation too.** A value outside a field's declared choices is never caught and prints straight onto the court form, which is why the drift guard also compares choice value sets.
+- **`waiver_reasons` is never mapped.** It's a `checkboxes` field, so prefilling it needs a DADict object encoding; the interview re-asks that one question. It is also the sensitive one (domestic violence), which is no loss to leave uncollected.
+
+Sending the payload creates a session, so the handoff is a POST from a form, not a link, and it falls back to the plain unprefilled `interview_url` whenever no API key is configured or the API call fails. Deleting the session once its packet is downloaded is tracked on #805.

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -63,19 +63,27 @@ def variable_answer_list(*, identity) -> list[VariableAnswer]:
     )
 
 
-def variable_answer_map(*, identity, names: list[str]) -> dict:
+def variable_answer_map(
+    *, identity, names: list[str], reviewed_only: bool = False
+) -> dict:
     """{variable_name: value} for the given names; names with no answer are omitted.
 
     A cleared answer (value None) counts as no answer: this map feeds
     prefill and templates, where an absent key must stay absent rather
     than fill a blank. Excludes out-of-schema variables, as
     ``variable_answer_list`` does.
+
+    ``reviewed_only`` drops answers no human has confirmed. The guided page
+    reads without it, since it is the surface where that confirmation
+    happens; the docassemble prefill reads with it, because a prefilled
+    variable skips its interview question and so never gets reviewed there.
     """
-    return dict(
-        VariableAnswer.objects.filter(
-            identity=identity,
-            variable__name__in=names,
-            variable__in_schema=True,
-            value__isnull=False,
-        ).values_list("variable__name", "value")
+    answers = VariableAnswer.objects.filter(
+        identity=identity,
+        variable__name__in=names,
+        variable__in_schema=True,
+        value__isnull=False,
     )
+    if reviewed_only:
+        answers = answers.filter(reviewed=True)
+    return dict(answers.values_list("variable__name", "value"))

--- a/litigant_portal/app/services/docassemble.py
+++ b/litigant_portal/app/services/docassemble.py
@@ -10,7 +10,7 @@ decrypt it.
 """
 
 import logging
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 
 import requests
 from django.conf import settings
@@ -46,7 +46,25 @@ def docassemble_session_create(*, interview_url: str, variables: dict) -> str:
 
     session = _session_new(api_root, api_key, interview)
     _variables_set(api_root, api_key, interview, session, variables)
-    return _resume_url(api_root, api_key, interview, session)
+    return _public(_resume_url(api_root, api_key, interview, session))
+
+
+def _public(resume_url: str) -> str:
+    """Swap in the litigant-facing origin, keeping the path and query.
+
+    docassemble builds the launch URL from the host we called it on, which on
+    a deployment is an internal address no browser can reach. Unset means the
+    URL comes back as docassemble built it.
+    """
+    public = settings.DOCASSEMBLE_PUBLIC_URL
+    if not public:
+        return resume_url
+    origin = urlparse(public)
+    return urlunparse(
+        urlparse(resume_url)._replace(
+            scheme=origin.scheme, netloc=origin.netloc
+        )
+    )
 
 
 def _target(interview_url: str) -> tuple[str, str]:

--- a/litigant_portal/app/services/docassemble.py
+++ b/litigant_portal/app/services/docassemble.py
@@ -1,0 +1,142 @@
+"""docassemble API client: start a prefilled interview session.
+
+Three calls, in order: create a session, set its variables, mint a one-time
+resume URL for the litigant's browser. Answers travel in a POST body, never
+in a URL, and the API key travels in a header.
+
+The target interview must set ``multi_user = True`` from an ``initial`` code
+block, or its session is encrypted per-browser and the resume URL cannot
+decrypt it.
+"""
+
+import logging
+from urllib.parse import parse_qs, urlparse
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 10
+# Short enough that a leaked link in shared-terminal history is dead, long
+# enough for a slow redirect.
+_RESUME_EXPIRY_SECONDS = 600
+
+
+class DocassembleError(Exception):
+    """A session could not be created.
+
+    Callers fall back to the plain interview link: unprefilled beats a dead
+    button.
+    """
+
+
+def docassemble_session_create(*, interview_url: str, variables: dict) -> str:
+    """Return a one-time URL onto a new session prefilled with ``variables``.
+
+    ``interview_url`` is the plain launch link from the corpus packet section,
+    carrying the interview reference in its ``?i=`` parameter. Keys in
+    ``variables`` are interview-side names, which docassemble executes as
+    assignment statements, so they may only come from author-controlled YAML.
+    """
+    api_root, interview = _target(interview_url)
+    api_key = settings.DOCASSEMBLE_API_KEY
+    if not api_key:
+        raise DocassembleError("DOCASSEMBLE_API_KEY is unset")
+
+    session = _session_new(api_root, api_key, interview)
+    _variables_set(api_root, api_key, interview, session, variables)
+    return _resume_url(api_root, api_key, interview, session)
+
+
+def _target(interview_url: str) -> tuple[str, str]:
+    """``(api root, interview reference)`` for a launch link."""
+    parts = urlparse(interview_url)
+    references = parse_qs(parts.query).get("i", [])
+    if not references:
+        raise DocassembleError(f"No ?i= interview in {interview_url!r}")
+    # The API sits beside the launch route, so drop that last segment: QA's
+    # /interview/interview leaves the /interview/ path prefix in place.
+    root = settings.DOCASSEMBLE_BASE_URL or (
+        f"{parts.scheme}://{parts.netloc}{parts.path.rsplit('/', 1)[0]}"
+    )
+    return root.rstrip("/"), references[0]
+
+
+def _call(*, method: str, api_root: str, path: str, api_key: str, **kwargs):
+    url = f"{api_root}/api/{path}"
+    try:
+        response = requests.request(
+            method,
+            url,
+            headers={"X-API-Key": api_key},
+            timeout=_TIMEOUT,
+            **kwargs,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        # No variables in the message: it reaches logs and error reporting.
+        raise DocassembleError(f"docassemble {path} failed: {exc}") from exc
+    return response
+
+
+def _session_new(api_root: str, api_key: str, interview: str) -> str:
+    response = _call(
+        method="GET",
+        api_root=api_root,
+        path="session/new",
+        api_key=api_key,
+        params={"i": interview},
+    )
+    try:
+        return response.json()["session"]
+    except (ValueError, KeyError, TypeError) as exc:
+        raise DocassembleError("No session in session/new response") from exc
+
+
+def _variables_set(
+    api_root: str,
+    api_key: str,
+    interview: str,
+    session: str,
+    variables: dict,
+) -> None:
+    # question=0 skips interview evaluation, so nothing assembles on our
+    # request and a 204 comes back.
+    _call(
+        method="POST",
+        api_root=api_root,
+        path="session",
+        api_key=api_key,
+        json={
+            "i": interview,
+            "session": session,
+            "variables": variables,
+            "question": 0,
+        },
+    )
+
+
+def _resume_url(
+    api_root: str, api_key: str, interview: str, session: str
+) -> str:
+    response = _call(
+        method="POST",
+        api_root=api_root,
+        path="resume_url",
+        api_key=api_key,
+        json={
+            "i": interview,
+            "session": session,
+            "one_time": 1,
+            "expire": _RESUME_EXPIRY_SECONDS,
+        },
+    )
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise DocassembleError("Unreadable resume_url response") from exc
+    url = payload.get("url") if isinstance(payload, dict) else payload
+    if not isinstance(url, str) or not url:
+        raise DocassembleError("No URL in resume_url response")
+    return url

--- a/litigant_portal/app/services/docassemble.py
+++ b/litigant_portal/app/services/docassemble.py
@@ -45,8 +45,33 @@ def docassemble_session_create(*, interview_url: str, variables: dict) -> str:
         raise DocassembleError("DOCASSEMBLE_API_KEY is unset")
 
     session = _session_new(api_root, api_key, interview)
-    _variables_set(api_root, api_key, interview, session, variables)
-    return _public(_resume_url(api_root, api_key, interview, session))
+    try:
+        _variables_set(api_root, api_key, interview, session, variables)
+        return _public(_resume_url(api_root, api_key, interview, session))
+    except DocassembleError:
+        # The session may already hold the litigant's answers, and nothing
+        # will ever resume it (#805 covers only downloaded packets), so
+        # delete it rather than leave the data orphaned. Best effort: the
+        # caller acts on the original error either way.
+        _session_delete(api_root, api_key, interview, session)
+        raise
+
+
+def _session_delete(
+    api_root: str, api_key: str, interview: str, session: str
+) -> None:
+    try:
+        _call(
+            method="DELETE",
+            api_root=api_root,
+            path="session",
+            api_key=api_key,
+            params={"i": interview, "session": session},
+        )
+    except DocassembleError:
+        logger.warning(
+            "orphaned docassemble session could not be deleted", exc_info=True
+        )
 
 
 def _public(resume_url: str) -> str:

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_fact_gather.html
@@ -4,6 +4,7 @@
 {# Values are prefilled server-side (ctx.questions[].value) — no x-model. The #}
 {# POST handler + deadline recompute land in Item 5; this renders the form. #}
 {% trans "Select…" as choice_placeholder %}
+{% trans "Clear my saved answer (it is not shown, for your privacy)" as clear_label %}
 <form method="post" class="space-y-4">
   {% csrf_token %}
   {% for q in ctx.questions %}
@@ -34,6 +35,16 @@
     :required="q.required"
     :autofocus="q.autofocus"
     :errors="q.errors"
+  />
+  {% endif %}
+  {% if q.saved %}
+  {# A protected field renders blank whatever is stored, so the checkbox is #}
+  {# the only way to erase the saved answer. Typing a new value replaces it #}
+  {# whether or not the box is checked. #}
+  <c-atoms.checkbox
+    name="{{ q.id }}__clear"
+    id="{{ q.id }}__clear"
+    label="{{ clear_label }}"
   />
   {% endif %}
   {% endfor %}

--- a/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
+++ b/litigant_portal/app/templates/cotton/molecules/flow_section_packet.html
@@ -1,9 +1,8 @@
 {% load i18n %}
 
 {# Packet section body: the forms the corpus says this flow needs. When the #}
-{# corpus sets interview_url, a warm link-out to a docassemble interview that #}
-{# fills these forms (v1: link-out + manual return, no prefill — #543). Unset #}
-{# => plain form list, so existing corpora are unaffected. #}
+{# corpus sets interview_url, a warm handoff to a docassemble interview that #}
+{# fills these forms. Unset => plain form list. #}
 <ul class="list-disc space-y-1 pl-5 text-greyscale-700">
   {% for form in ctx.forms %}
   <li>
@@ -18,16 +17,21 @@
 
 {% if ctx.interview_url %}
 <div class="mt-4 space-y-3">
-  <c-atoms.button
-    href="{{ ctx.interview_url }}"
-    variant="primary"
+  {# A POST: it creates a docassemble session and redirects onto a one-time #}
+  {# link, so it can't be a GET a crawler or a reload would fire. #}
+  <form
+    method="post"
+    action="{% url 'pages:topic_flow_interview' court=ctx.court topic=ctx.topic role=ctx.role %}"
     target="_blank"
     rel="noopener"
   >
-    <c-atoms.icon name="pencil-square" class="w-4 h-4" />
-    {% trans "Fill out your forms" %}
-    <span class="sr-only">{% trans "(opens in a new tab)" %}</span>
-  </c-atoms.button>
+    {% csrf_token %}
+    <c-atoms.button type="submit" variant="primary">
+      <c-atoms.icon name="pencil-square" class="w-4 h-4" />
+      {% trans "Fill out your forms" %}
+      <span class="sr-only">{% trans "(opens in a new tab)" %}</span>
+    </c-atoms.button>
+  </form>
   <p class="text-sm text-greyscale-700">
     {% trans "Save your completed packet somewhere easy to find. You'll need to print and sign these forms and bring them with you to court (or mail them in, depending on your court's process)." %}
   </p>

--- a/litigant_portal/app/tests/test_content_interview_mapping.py
+++ b/litigant_portal/app/tests/test_content_interview_mapping.py
@@ -1,0 +1,151 @@
+"""Drift guard: every mapped interview variable exists in the interview.
+
+A preset variable skips its question and its validation, so a stale name is
+dropped silently and a bad choice value prints onto a court form. Covers the
+flows whose interview is versioned under ``docassemble/``. DB-free.
+"""
+
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+import yaml
+
+from litigant_portal.app.topic_flow.loader import CorpusLoader
+from litigant_portal.app.topic_flow.prefill import interview_target
+from litigant_portal.app.topic_flow.registry import (
+    CONTENT_DIR,
+    iter_corpus_paths,
+)
+
+INTERVIEW_DIR = Path(__file__).resolve().parents[3] / "docassemble"
+
+# Keys sitting beside a field's ``Label: variable`` entry, whose values can
+# themselves look like identifiers ("datatype: date").
+_MODIFIERS = {
+    "required",
+    "datatype",
+    "choices",
+    "hint",
+    "help",
+    "default",
+    "min",
+    "max",
+    "maxlength",
+    "rows",
+    "show if",
+    "validate",
+    "note",
+    "css class",
+}
+
+
+def _interview_path(interview_url):
+    """The versioned interview file a launch URL points at, if we have it."""
+    reference = parse_qs(urlparse(interview_url).query).get("i", [])
+    if not reference:
+        return None
+    file_name = reference[0].rsplit(":", 1)[-1]
+    matches = list(INTERVIEW_DIR.glob(f"*/{file_name}"))
+    return matches[0] if len(matches) == 1 else None
+
+
+def _fields(interview_path):
+    """``{variable: field block}`` for every field the interview asks."""
+    fields = {}
+    for block in yaml.safe_load_all(
+        interview_path.read_text(encoding="utf-8")
+    ):
+        if not isinstance(block, dict):
+            continue
+        for entry in block.get("fields") or []:
+            if not isinstance(entry, dict):
+                continue
+            for key, value in entry.items():
+                if key in _MODIFIERS or not isinstance(value, str):
+                    continue
+                fields[value] = entry
+    return fields
+
+
+def _mapped():
+    """(content file, question id, interview variable, interview path)."""
+    for path in iter_corpus_paths(CONTENT_DIR):
+        target = interview_target(CorpusLoader.load(path))
+        if target is None:
+            continue
+        interview_url, mapping = target
+        interview_path = _interview_path(interview_url)
+        if interview_path is None:
+            continue
+        for question_id, variable in mapping.items():
+            yield path.name, question_id, variable, interview_path
+
+
+MAPPED = list(_mapped())
+
+
+def test_the_nd_name_change_flows_are_actually_being_checked():
+    # A broken URL-to-file match would empty every parametrized guard below.
+    assert len(MAPPED) >= 9
+
+
+@pytest.mark.parametrize(
+    ("file_name", "question_id", "variable", "interview_path"),
+    MAPPED,
+    ids=[f"{f}:{q}" for f, q, _v, _p in MAPPED],
+)
+def test_mapped_variable_exists_in_the_interview(
+    file_name, question_id, variable, interview_path
+):
+    fields = _fields(interview_path)
+    assert variable in fields, (
+        f"{file_name} maps '{question_id}' to '{variable}', which "
+        f"{interview_path.name} does not ask"
+    )
+
+
+@pytest.mark.parametrize(
+    ("file_name", "question_id", "variable", "interview_path"),
+    MAPPED,
+    ids=[f"{f}:{q}" for f, q, _v, _p in MAPPED],
+)
+def test_a_mapped_checkbox_variable_is_never_prefilled(
+    file_name, question_id, variable, interview_path
+):
+    # checkboxes is a DADict: a plain value corrupts the answer.
+    entry = _fields(interview_path).get(variable, {})
+    assert entry.get("datatype") != "checkboxes", (
+        f"{file_name} maps '{question_id}' to the checkboxes variable "
+        f"'{variable}'"
+    )
+
+
+def test_mapped_choice_values_agree_with_the_interview():
+    for file_name, question_id, variable, interview_path in MAPPED:
+        corpus = CorpusLoader.load(CONTENT_DIR / file_name)
+        question = next(
+            (
+                q
+                for section in corpus.sections
+                if section.kind == "fact_gather"
+                for q in section.questions
+                if q.id == question_id
+            ),
+            None,
+        )
+        if question is None or question.type != "choice":
+            continue
+        declared = _fields(interview_path)[variable].get("choices") or []
+        allowed = {
+            value
+            for choice in declared
+            for value in (
+                choice.values() if isinstance(choice, dict) else [choice]
+            )
+        }
+        assert set(question.choices) <= allowed, (
+            f"{file_name} '{question_id}' offers values "
+            f"{set(question.choices) - allowed} that {interview_path.name} "
+            f"does not accept for '{variable}'"
+        )

--- a/litigant_portal/app/tests/test_content_interview_mapping.py
+++ b/litigant_portal/app/tests/test_content_interview_mapping.py
@@ -9,6 +9,7 @@ Skipped under ``make test``: the container image carries no interviews, only
 merges there.
 """
 
+import re
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -59,14 +60,21 @@ def _interview_path(interview_url):
     return matches[0] if len(matches) == 1 else None
 
 
+def _blocks(interview_path):
+    """Every mapping block in an interview, in file order."""
+    return [
+        block
+        for block in yaml.safe_load_all(
+            interview_path.read_text(encoding="utf-8")
+        )
+        if isinstance(block, dict)
+    ]
+
+
 def _fields(interview_path):
     """``{variable: field block}`` for every field the interview asks."""
     fields = {}
-    for block in yaml.safe_load_all(
-        interview_path.read_text(encoding="utf-8")
-    ):
-        if not isinstance(block, dict):
-            continue
+    for block in _blocks(interview_path):
         for entry in block.get("fields") or []:
             if not isinstance(entry, dict):
                 continue
@@ -91,7 +99,25 @@ def _mapped():
             yield path.name, question_id, variable, interview_path
 
 
+def _handoff_interviews():
+    """(content file, interview path) per interview a flow hands off to.
+
+    Every flow with an interview_url, mapped or not: the handoff creates a
+    session either way.
+    """
+    seen = {}
+    for path in iter_corpus_paths(CONTENT_DIR):
+        target = interview_target(CorpusLoader.load(path))
+        if target is None:
+            continue
+        interview_path = _interview_path(target[0])
+        if interview_path is not None:
+            seen.setdefault(interview_path, path.name)
+    return [(name, path) for path, name in seen.items()]
+
+
 MAPPED = list(_mapped())
+INTERVIEWS = _handoff_interviews()
 
 
 def test_the_nd_name_change_flows_are_actually_being_checked():
@@ -158,3 +184,39 @@ def test_mapped_choice_values_agree_with_the_interview():
             f"{set(question.choices) - allowed} that {interview_path.name} "
             f"does not accept for '{variable}'"
         )
+
+
+@pytest.mark.parametrize(
+    ("file_name", "interview_path"),
+    INTERVIEWS,
+    ids=[p.name for _f, p in INTERVIEWS],
+)
+def test_interview_enables_multi_user_from_an_initial_block(
+    file_name, interview_path
+):
+    # The one prerequisite with no fallback: without it the resume link cannot
+    # decrypt the session, so the litigant gets an error rather than a plain
+    # interview.
+    initial_code = "\n".join(
+        block.get("code") or ""
+        for block in _blocks(interview_path)
+        if block.get("initial")
+    )
+    assert re.search(r"multi_user\s*=\s*True", initial_code), (
+        f"{interview_path.name} (handed off from {file_name}) does not set "
+        "multi_user = True in an initial code block"
+    )
+
+
+@pytest.mark.parametrize(
+    ("file_name", "interview_path"),
+    INTERVIEWS,
+    ids=[p.name for _f, p in INTERVIEWS],
+)
+def test_interview_never_sets_multi_user_as_a_bare_key(
+    file_name, interview_path
+):
+    # A bare `multi_user: True` key throws DASourceError on load.
+    assert not any(
+        "multi_user" in block for block in _blocks(interview_path)
+    ), f"{interview_path.name} sets multi_user as a key, not as initial code"

--- a/litigant_portal/app/tests/test_content_interview_mapping.py
+++ b/litigant_portal/app/tests/test_content_interview_mapping.py
@@ -3,6 +3,10 @@
 A preset variable skips its question and its validation, so a stale name is
 dropped silently and a bad choice value prints onto a court form. Covers the
 flows whose interview is versioned under ``docassemble/``. DB-free.
+
+Skipped under ``make test``: the container image carries no interviews, only
+``litigant_portal/``. CI runs tox against a full checkout, so the guard gates
+merges there.
 """
 
 from pathlib import Path
@@ -19,6 +23,11 @@ from litigant_portal.app.topic_flow.registry import (
 )
 
 INTERVIEW_DIR = Path(__file__).resolve().parents[3] / "docassemble"
+
+pytestmark = pytest.mark.skipif(
+    not INTERVIEW_DIR.is_dir(),
+    reason=f"no interviews at {INTERVIEW_DIR} (container image)",
+)
 
 # Keys sitting beside a field's ``Label: variable`` entry, whose values can
 # themselves look like identifiers ("datatype: date").

--- a/litigant_portal/app/tests/test_docassemble_client.py
+++ b/litigant_portal/app/tests/test_docassemble_client.py
@@ -229,3 +229,32 @@ def test_a_bare_string_resume_response_is_accepted(monkeypatch):
 def test_an_empty_variables_dict_still_creates_a_session(recorder):
     assert _create(variables={}) == RESUME
     assert recorder.calls[1]["json"]["variables"] == {}
+
+
+@override_settings(
+    DOCASSEMBLE_API_KEY="k",
+    DOCASSEMBLE_BASE_URL="http://docassemble",
+    DOCASSEMBLE_PUBLIC_URL="https://qa.example.gov/interview",
+)
+def test_resume_url_is_rewritten_onto_the_public_origin(monkeypatch):
+    # docassemble builds the launch URL from the host we called it on, which
+    # on a deployment is internal and unreachable from a browser.
+    monkeypatch.setattr(
+        requests,
+        "request",
+        _Recorder(
+            _Response({"session": "sess-1"}),
+            _Response(status=204),
+            _Response({"url": "http://docassemble/launch?c=tok"}),
+        ),
+    )
+    assert _create() == "https://qa.example.gov/launch?c=tok"
+
+
+@override_settings(
+    DOCASSEMBLE_API_KEY="k",
+    DOCASSEMBLE_BASE_URL=None,
+    DOCASSEMBLE_PUBLIC_URL=None,
+)
+def test_resume_url_is_left_alone_without_a_public_origin(recorder):
+    assert _create() == RESUME

--- a/litigant_portal/app/tests/test_docassemble_client.py
+++ b/litigant_portal/app/tests/test_docassemble_client.py
@@ -183,10 +183,72 @@ def test_a_failed_variables_post_raises_docassemble_error(monkeypatch):
     monkeypatch.setattr(
         requests,
         "request",
-        _Recorder(_Response({"session": "sess-1"}), _Response(status=400)),
+        _Recorder(
+            _Response({"session": "sess-1"}),
+            _Response(status=400),
+            _Response(status=204),
+        ),
     )
     with pytest.raises(DocassembleError):
         _create()
+
+
+# --- orphan cleanup ----------------------------------------------------------
+# A session that fails past creation already holds the litigant's answers, and
+# nothing will ever resume it (#805 covers only downloaded packets), so the
+# client deletes it on the way out.
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_failed_variables_post_deletes_the_orphaned_session(monkeypatch):
+    recorder = _Recorder(
+        _Response({"session": "sess-1"}),
+        _Response(status=400),
+        _Response(status=204),
+    )
+    monkeypatch.setattr(requests, "request", recorder)
+    with pytest.raises(DocassembleError):
+        _create()
+    cleanup = recorder.calls[-1]
+    assert cleanup["method"] == "DELETE"
+    assert cleanup["url"] == "https://qa.example.gov/interview/api/session"
+    assert cleanup["params"] == {"i": INTERVIEW, "session": "sess-1"}
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_failed_resume_url_deletes_the_orphaned_session(monkeypatch):
+    recorder = _Recorder(
+        _Response({"session": "sess-1"}),
+        _Response(status=204),
+        requests.Timeout("timed out"),
+        _Response(status=204),
+    )
+    monkeypatch.setattr(requests, "request", recorder)
+    with pytest.raises(DocassembleError):
+        _create()
+    assert recorder.calls[-1]["method"] == "DELETE"
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_failed_cleanup_does_not_mask_the_original_error(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        _Recorder(
+            _Response({"session": "sess-1"}),
+            _Response(status=204),
+            _Response(status=500),
+            requests.ConnectionError("refused"),
+        ),
+    )
+    with pytest.raises(DocassembleError, match="resume_url"):
+        _create()
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_the_happy_path_never_deletes(recorder):
+    _create()
+    assert not any(c["method"] == "DELETE" for c in recorder.calls)
 
 
 @override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
@@ -205,6 +267,7 @@ def test_a_resume_response_without_a_url_raises(monkeypatch):
             _Response({"session": "sess-1"}),
             _Response(status=204),
             _Response({}),
+            _Response(status=204),
         ),
     )
     with pytest.raises(DocassembleError):

--- a/litigant_portal/app/tests/test_docassemble_client.py
+++ b/litigant_portal/app/tests/test_docassemble_client.py
@@ -1,0 +1,231 @@
+"""docassemble client tests: the three-call session handoff, with HTTP mocked.
+
+DB-free. ``requests.request`` is replaced per test, so these assert the exact
+calls the client makes: payload shapes, the one-time resume flag, the API key
+in a header, and no answer ever reaching a URL.
+"""
+
+import pytest
+import requests
+from django.test import override_settings
+
+from litigant_portal.app.services.docassemble import (
+    DocassembleError,
+    docassemble_session_create,
+)
+
+INTERVIEW = "docassemble.playground1:petition-standard.yml"
+INTERVIEW_URL = f"https://qa.example.gov/interview/interview?i={INTERVIEW}"
+RESUME = "https://qa.example.gov/interview/session?resume=abc"
+VARIABLES = {"current_first": "Sandra", "residence_county": "Burleigh"}
+
+
+class _Response:
+    def __init__(self, payload=None, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code}")
+
+
+class _Recorder:
+    """Stands in for ``requests.request``, replying down a scripted list."""
+
+    def __init__(self, *responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, method, url, **kwargs):
+        self.calls.append({"method": method, "url": url, **kwargs})
+        reply = self.responses.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+
+def _happy_path():
+    return _Recorder(
+        _Response({"session": "sess-1"}),
+        _Response(status=204),
+        _Response({"url": RESUME}),
+    )
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    recording = _happy_path()
+    monkeypatch.setattr(requests, "request", recording)
+    return recording
+
+
+def _create(**kwargs):
+    return docassemble_session_create(
+        interview_url=kwargs.pop("interview_url", INTERVIEW_URL),
+        variables=kwargs.pop("variables", VARIABLES),
+    )
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_returns_the_resume_url(recorder):
+    assert _create() == RESUME
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_calls_the_three_endpoints_in_order(recorder):
+    _create()
+    assert [(c["method"], c["url"]) for c in recorder.calls] == [
+        ("GET", "https://qa.example.gov/interview/api/session/new"),
+        ("POST", "https://qa.example.gov/interview/api/session"),
+        ("POST", "https://qa.example.gov/interview/api/resume_url"),
+    ]
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_new_session_asks_for_the_interview_from_the_launch_url(recorder):
+    _create()
+    assert recorder.calls[0]["params"] == {"i": INTERVIEW}
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_variables_post_carries_the_session_and_skips_evaluation(recorder):
+    _create()
+    assert recorder.calls[1]["json"] == {
+        "i": INTERVIEW,
+        "session": "sess-1",
+        "variables": VARIABLES,
+        "question": 0,
+    }
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_resume_url_is_requested_one_time_and_expiring(recorder):
+    _create()
+    payload = recorder.calls[2]["json"]
+    assert payload["one_time"] == 1
+    assert 0 < payload["expire"] <= 3600
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_api_key_travels_in_a_header_on_every_call(recorder):
+    _create()
+    assert all(c["headers"]["X-API-Key"] == "k" for c in recorder.calls)
+    assert not any("k" in c["url"] for c in recorder.calls)
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_no_answer_value_reaches_a_url(recorder):
+    # The whole point of POSTing the payload: PII stays out of URLs, which
+    # land in access logs, browser history and Referer headers.
+    _create()
+    for call in recorder.calls:
+        for value in VARIABLES.values():
+            assert value not in call["url"]
+            assert value not in str(call.get("params") or "")
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_every_call_sets_a_timeout(recorder):
+    _create()
+    assert all(c["timeout"] for c in recorder.calls)
+
+
+@override_settings(
+    DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL="http://localhost:8100"
+)
+def test_base_url_override_replaces_the_api_root(recorder):
+    _create()
+    assert all(
+        c["url"].startswith("http://localhost:8100/api/")
+        for c in recorder.calls
+    )
+
+
+@override_settings(DOCASSEMBLE_API_KEY=None, DOCASSEMBLE_BASE_URL=None)
+def test_missing_api_key_raises_without_calling_out(recorder):
+    with pytest.raises(DocassembleError):
+        _create()
+    assert recorder.calls == []
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_launch_url_without_an_interview_reference_raises(recorder):
+    with pytest.raises(DocassembleError):
+        _create(interview_url="https://qa.example.gov/interview/interview")
+    assert recorder.calls == []
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        _Response(status=403),
+        _Response(status=500),
+        requests.Timeout("timed out"),
+        requests.ConnectionError("refused"),
+    ],
+    ids=["forbidden", "server-error", "timeout", "connection-refused"],
+)
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_failed_first_call_raises_docassemble_error(monkeypatch, failure):
+    monkeypatch.setattr(requests, "request", _Recorder(failure))
+    with pytest.raises(DocassembleError):
+        _create()
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_failed_variables_post_raises_docassemble_error(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        _Recorder(_Response({"session": "sess-1"}), _Response(status=400)),
+    )
+    with pytest.raises(DocassembleError):
+        _create()
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_session_response_without_a_session_raises(monkeypatch):
+    monkeypatch.setattr(requests, "request", _Recorder(_Response({})))
+    with pytest.raises(DocassembleError):
+        _create()
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_resume_response_without_a_url_raises(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        _Recorder(
+            _Response({"session": "sess-1"}),
+            _Response(status=204),
+            _Response({}),
+        ),
+    )
+    with pytest.raises(DocassembleError):
+        _create()
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_a_bare_string_resume_response_is_accepted(monkeypatch):
+    monkeypatch.setattr(
+        requests,
+        "request",
+        _Recorder(
+            _Response({"session": "sess-1"}),
+            _Response(status=204),
+            _Response(RESUME),
+        ),
+    )
+    assert _create() == RESUME
+
+
+@override_settings(DOCASSEMBLE_API_KEY="k", DOCASSEMBLE_BASE_URL=None)
+def test_an_empty_variables_dict_still_creates_a_session(recorder):
+    assert _create(variables={}) == RESUME
+    assert recorder.calls[1]["json"]["variables"] == {}

--- a/litigant_portal/app/tests/test_topic_flow_interview_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_interview_view.py
@@ -2,12 +2,14 @@
 
 Covers the guided-flow and assistant-flow scenarios on #804 with the
 docassemble client mocked. The client's own contract is tested in
-test_docassemble_client.py. The routing tests are DB-free; the rest read
-stored answers, so they need a database (``make test``).
+test_docassemble_client.py. The routing tests are DB-free; the rest need a
+database (``make test``), either for stored answers or because the session
+middleware touches it.
 """
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import Client
 from django.urls import resolve, reverse
 
 from litigant_portal.app.models import UserIdentity, Variable
@@ -246,13 +248,49 @@ def test_an_unexpected_client_error_is_not_swallowed(
         client.post(URL)
 
 
+# --- csrf fallback (needs DB) -----------------------------------------------
+
+
+@pytest.mark.django_db
+def test_csrf_failure_on_the_interview_falls_back_to_the_plain_link(
+    monkeypatch,
+):
+    _flow(monkeypatch)
+    response = Client(enforce_csrf_checks=True).post(URL)
+    assert response.status_code == 302
+    assert response["Location"] == INTERVIEW
+
+
+@pytest.mark.django_db
+def test_csrf_failure_on_an_unknown_flow_keeps_the_default_page(monkeypatch):
+    monkeypatch.setattr(topic_flow_views.registry, "get", lambda *a: None)
+    response = Client(enforce_csrf_checks=True).post(URL)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_csrf_failure_on_a_flow_without_an_interview_keeps_the_default_page(
+    monkeypatch,
+):
+    _flow(monkeypatch, interview_url=None)
+    response = Client(enforce_csrf_checks=True).post(URL)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_csrf_failure_elsewhere_keeps_the_default_page(monkeypatch):
+    _flow(monkeypatch)
+    response = Client(enforce_csrf_checks=True).post(
+        FLOW_URL, {"first_name": "Sandra", "filing_county": ""}
+    )
+    assert response.status_code == 403
+
+
 # --- guards (needs DB) ------------------------------------------------------
 
 
 @pytest.mark.django_db
 def test_get_is_rejected(client, monkeypatch, docassemble, variables):
-    # Creating a session is a side effect, so a crawler or a reload must not
-    # be able to fire one.
     _flow(monkeypatch)
     assert client.get(URL).status_code == 405
     assert docassemble.calls == []
@@ -275,8 +313,6 @@ def test_a_flow_without_an_interview_returns_404(
 
 
 # --- assistant flow (needs DB) ----------------------------------------------
-# The trust boundary. An answer no human has confirmed must not reach a court
-# form, since prefilling a variable skips the question that would show it.
 
 
 @pytest.mark.django_db

--- a/litigant_portal/app/tests/test_topic_flow_interview_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_interview_view.py
@@ -1,0 +1,325 @@
+"""The prefill handoff endpoint: POST -> session -> redirect.
+
+Covers the guided-flow and assistant-flow scenarios on #804 with the
+docassemble client mocked. The client's own contract is tested in
+test_docassemble_client.py. The routing tests are DB-free; the rest read
+stored answers, so they need a database (``make test``).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import resolve, reverse
+
+from litigant_portal.app.models import UserIdentity, Variable
+from litigant_portal.app.models.choices import VariableDataType
+from litigant_portal.app.services.docassemble import DocassembleError
+from litigant_portal.app.services.topic_flow import variable_answer_set
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    FactGatherSection,
+    Metadata,
+    PacketOutput,
+    Question,
+)
+from litigant_portal.app.views import topic_flow as topic_flow_views
+
+COURT, TOPIC, ROLE = "test-court", "test_topic", "petitioner"
+URL = f"/t/{COURT}/{TOPIC}/{ROLE}/interview/"
+FLOW_URL = f"/t/{COURT}/{TOPIC}/{ROLE}/"
+INTERVIEW = "https://da.example.gov/interview/interview?i=petition.yml"
+RESUME = "https://da.example.gov/interview/launch?c=token"
+MAPPING = {
+    "first_name": "current_first",
+    "filing_county": "residence_county",
+}
+
+
+def _corpus(*, mapping=None, interview_url=INTERVIEW):
+    return Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        sections=[
+            FactGatherSection(
+                kind="fact_gather",
+                id="your_information",
+                heading="Your name",
+                questions=[
+                    Question(id="first_name", label="First name"),
+                    Question(id="filing_county", label="County"),
+                ],
+            ),
+            PacketOutput(
+                kind="output",
+                output_type="packet",
+                id="filing_packet",
+                heading="Your filing packet",
+                forms=["Petition"],
+                interview_url=interview_url,
+                interview_prefill=MAPPING if mapping is None else mapping,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def variables(db):
+    Variable.objects.create(name="first_name", data_type=VariableDataType.TEXT)
+    Variable.objects.create(
+        name="filing_county", data_type=VariableDataType.TEXT
+    )
+
+
+class _Client:
+    """Stands in for docassemble_session_create, recording its payload."""
+
+    def __init__(self, resume_url=RESUME, error=None):
+        self.resume_url = resume_url
+        self.error = error
+        self.calls = []
+
+    def __call__(self, *, interview_url, variables):
+        self.calls.append(
+            {"interview_url": interview_url, "variables": variables}
+        )
+        if self.error:
+            raise self.error
+        return self.resume_url
+
+
+@pytest.fixture
+def docassemble(monkeypatch):
+    client = _Client()
+    monkeypatch.setattr(topic_flow_views, "docassemble_session_create", client)
+    return client
+
+
+def _flow(monkeypatch, **kwargs):
+    monkeypatch.setattr(
+        topic_flow_views.registry, "get", lambda *a: _corpus(**kwargs)
+    )
+
+
+def _identity(client):
+    identity, _ = UserIdentity.objects.get_or_create(
+        user=None, session_key=client.session.session_key
+    )
+    return identity
+
+
+def _store(client, name, value, reviewed):
+    variable_answer_set(
+        identity=_identity(client),
+        variable=Variable.objects.get(name=name),
+        value=value,
+        reviewed=reviewed,
+    )
+
+
+# --- routing (DB-free) ------------------------------------------------------
+
+
+def test_interview_url_resolves_to_the_handoff_view():
+    assert resolve(URL).view_name == "pages:topic_flow_interview"
+
+
+def test_interview_url_reverses():
+    assert (
+        reverse(
+            "pages:topic_flow_interview",
+            kwargs={"court": COURT, "topic": TOPIC, "role": ROLE},
+        )
+        == URL
+    )
+
+
+# --- guided flow (needs DB) -------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_post_redirects_to_the_one_time_resume_url(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    response = client.post(URL)
+    assert response.status_code == 302
+    assert response["Location"] == RESUME
+
+
+@pytest.mark.django_db
+def test_reviewed_answers_are_sent_under_their_interview_names(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=True)
+    _store(client, "filing_county", "Burleigh", reviewed=True)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {
+        "current_first": "Sandra",
+        "residence_county": "Burleigh",
+    }
+
+
+@pytest.mark.django_db
+def test_an_unanswered_question_is_left_for_the_interview_to_ask(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=True)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {"current_first": "Sandra"}
+
+
+@pytest.mark.django_db
+def test_a_fresh_guest_hands_over_an_empty_payload(
+    client, monkeypatch, docassemble
+):
+    # Equal to today's plain link-out, and no identity row minted for a
+    # visitor who answered nothing.
+    _flow(monkeypatch)
+    assert client.post(URL)["Location"] == RESUME
+    assert docassemble.calls[0]["variables"] == {}
+    assert UserIdentity.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_a_changed_answer_is_sent_at_its_new_value(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=True)
+    _store(client, "first_name", "Alex", reviewed=True)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {"current_first": "Alex"}
+
+
+@pytest.mark.django_db
+def test_the_launch_url_from_the_corpus_is_what_gets_prefilled(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    client.post(URL)
+    assert docassemble.calls[0]["interview_url"] == INTERVIEW
+
+
+@pytest.mark.django_db
+def test_an_unmapped_flow_still_hands_off_with_no_variables(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch, mapping={})
+    _store(client, "first_name", "Sandra", reviewed=True)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {}
+
+
+# --- fallback (needs DB) ----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_a_failed_session_falls_back_to_the_plain_interview_link(
+    client, monkeypatch, variables
+):
+    # No API key, docassemble down, a timeout: all arrive as DocassembleError,
+    # and all must leave the litigant with a working link.
+    monkeypatch.setattr(
+        topic_flow_views,
+        "docassemble_session_create",
+        _Client(error=DocassembleError("no key")),
+    )
+    _flow(monkeypatch)
+    response = client.post(URL)
+    assert response.status_code == 302
+    assert response["Location"] == INTERVIEW
+
+
+@pytest.mark.django_db
+def test_an_unexpected_client_error_is_not_swallowed(
+    client, monkeypatch, variables
+):
+    # Only DocassembleError means "fall back"; a bug in our own code must
+    # surface rather than hide behind an unprefilled interview.
+    monkeypatch.setattr(
+        topic_flow_views,
+        "docassemble_session_create",
+        _Client(error=TypeError("bug")),
+    )
+    _flow(monkeypatch)
+    with pytest.raises(TypeError):
+        client.post(URL)
+
+
+# --- guards (needs DB) ------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_get_is_rejected(client, monkeypatch, docassemble, variables):
+    # Creating a session is a side effect, so a crawler or a reload must not
+    # be able to fire one.
+    _flow(monkeypatch)
+    assert client.get(URL).status_code == 405
+    assert docassemble.calls == []
+
+
+@pytest.mark.django_db
+def test_unknown_flow_returns_404(client, monkeypatch, docassemble):
+    monkeypatch.setattr(topic_flow_views.registry, "get", lambda *a: None)
+    assert client.post(URL).status_code == 404
+    assert docassemble.calls == []
+
+
+@pytest.mark.django_db
+def test_a_flow_without_an_interview_returns_404(
+    client, monkeypatch, docassemble
+):
+    _flow(monkeypatch, interview_url=None)
+    assert client.post(URL).status_code == 404
+    assert docassemble.calls == []
+
+
+# --- assistant flow (needs DB) ----------------------------------------------
+# The trust boundary. An answer no human has confirmed must not reach a court
+# form, since prefilling a variable skips the question that would show it.
+
+
+@pytest.mark.django_db
+def test_an_unreviewed_answer_is_never_sent(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=False)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {}
+
+
+@pytest.mark.django_db
+def test_the_same_answer_is_sent_once_the_litigant_confirms_it(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=False)
+    client.post(FLOW_URL, {"first_name": "Sandra", "filing_county": ""})
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {"current_first": "Sandra"}
+
+
+@pytest.mark.django_db
+def test_an_assistant_overwrite_drops_a_confirmed_answer_again(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    _store(client, "first_name", "Sandra", reviewed=True)
+    _store(client, "first_name", "Alex", reviewed=False)
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {}
+
+
+@pytest.mark.django_db
+def test_answers_still_reach_the_payload_after_login(
+    client, monkeypatch, docassemble, variables
+):
+    _flow(monkeypatch)
+    client.post(FLOW_URL, {"first_name": "Sandra", "filing_county": ""})
+    client.get(FLOW_URL)
+    user = get_user_model().objects.create_user(username="u", password="p")
+    assert client.login(username="u", password="p")
+    client.post(URL)
+    assert docassemble.calls[0]["variables"] == {"current_first": "Sandra"}
+    assert UserIdentity.objects.filter(user=user).exists()

--- a/litigant_portal/app/tests/test_topic_flow_loader.py
+++ b/litigant_portal/app/tests/test_topic_flow_loader.py
@@ -158,6 +158,52 @@ def test_duplicate_resource_id_detected(tmp_path):
     assert any("duplicate resource id: 'dup'" in p for p in exc.value.problems)
 
 
+def _packet(**extra):
+    return {
+        "kind": "output",
+        "output_type": "packet",
+        "id": "packet",
+        "heading": "H",
+        "forms": ["Petition"],
+        **extra,
+    }
+
+
+def test_prefill_key_must_reference_a_question(tmp_path):
+    data = copy.deepcopy(VALID)
+    data["sections"].append(
+        _packet(
+            interview_url="https://da.example/i",
+            interview_prefill={"ghost": "current_first"},
+        )
+    )
+    path = _write(tmp_path, data)
+    with pytest.raises(CorpusValidationError) as exc:
+        CorpusLoader.load(path)
+    assert any(
+        "prefills 'ghost'" in p and "fact_gather question id" in p
+        for p in exc.value.problems
+    )
+
+
+def test_prefill_without_an_interview_url_is_rejected(tmp_path):
+    data = copy.deepcopy(VALID)
+    data["sections"].append(
+        _packet(interview_prefill={"pubdate": "publication_date"})
+    )
+    path = _write(tmp_path, data)
+    with pytest.raises(CorpusValidationError) as exc:
+        CorpusLoader.load(path)
+    assert any("no interview_url" in p for p in exc.value.problems)
+
+
+def test_packet_without_a_prefill_mapping_still_loads(tmp_path):
+    data = copy.deepcopy(VALID)
+    data["sections"].append(_packet(interview_url="https://da.example/i"))
+    corpus = CorpusLoader.load(_write(tmp_path, data))
+    assert corpus.sections[-1].interview_prefill == {}
+
+
 def test_problems_aggregate_into_one_error(tmp_path):
     data = copy.deepcopy(VALID)
     data["deadlines"] = [

--- a/litigant_portal/app/tests/test_topic_flow_prefill.py
+++ b/litigant_portal/app/tests/test_topic_flow_prefill.py
@@ -1,0 +1,114 @@
+"""Prefill payload tests: corpus mapping resolution and the rename. DB-free."""
+
+from litigant_portal.app.topic_flow.prefill import (
+    interview_target,
+    prefill_variables,
+)
+from litigant_portal.app.topic_flow.schema import (
+    Corpus,
+    FactGatherSection,
+    InfoSection,
+    Metadata,
+    PacketOutput,
+    Question,
+)
+
+MAPPING = {"first_name": "current_first", "county": "residence_county"}
+URL = "https://da.example.gov/interview/interview?i=petition.yml"
+
+
+def _corpus(*sections):
+    return Corpus(
+        metadata=Metadata(court="c", topic="t", role="r", title="T"),
+        sections=list(sections) or [_packet()],
+    )
+
+
+def _packet(*, interview_url=URL, mapping=None, id="filing_packet"):
+    return PacketOutput(
+        kind="output",
+        output_type="packet",
+        id=id,
+        heading="Your filing packet",
+        forms=["Petition"],
+        interview_url=interview_url,
+        interview_prefill=MAPPING if mapping is None else mapping,
+    )
+
+
+def test_target_carries_the_launch_url_and_its_mapping():
+    assert interview_target(_corpus()) == (URL, MAPPING)
+
+
+def test_target_is_none_without_a_packet_section():
+    corpus = _corpus(
+        InfoSection(kind="info", id="overview", heading="H", body="B")
+    )
+    assert interview_target(corpus) is None
+
+
+def test_target_is_none_when_the_packet_has_no_interview():
+    assert interview_target(_corpus(_packet(interview_url=None))) is None
+
+
+def test_target_skips_a_packet_without_an_interview():
+    corpus = _corpus(_packet(interview_url=None, id="forms_only"), _packet())
+    assert interview_target(corpus) == (URL, MAPPING)
+
+
+def test_unmapped_packet_yields_an_empty_mapping():
+    assert interview_target(_corpus(_packet(mapping={}))) == (URL, {})
+
+
+def test_variables_are_renamed_to_their_interview_names():
+    answers = {"first_name": "Sandra", "county": "Burleigh"}
+    assert prefill_variables(mapping=MAPPING, answers=answers) == {
+        "current_first": "Sandra",
+        "residence_county": "Burleigh",
+    }
+
+
+def test_an_unanswered_question_is_absent_from_the_payload():
+    payload = prefill_variables(
+        mapping=MAPPING, answers={"first_name": "Sandra"}
+    )
+    assert payload == {"current_first": "Sandra"}
+
+
+def test_an_unmapped_answer_is_not_sent():
+    payload = prefill_variables(
+        mapping=MAPPING, answers={"phone_number": "555-0100"}
+    )
+    assert payload == {}
+
+
+def test_an_empty_mapping_sends_nothing():
+    assert prefill_variables(mapping={}, answers={"first_name": "S"}) == {}
+
+
+def test_no_answers_at_all_sends_nothing():
+    assert prefill_variables(mapping=MAPPING, answers={}) == {}
+
+
+def test_a_date_stays_an_iso_string():
+    mapping = {"name_change_publication_date": "publication_date"}
+    answers = {"name_change_publication_date": "2026-05-01"}
+    assert prefill_variables(mapping=mapping, answers=answers) == {
+        "publication_date": "2026-05-01"
+    }
+
+
+def test_a_question_the_page_never_shows_still_reaches_the_payload():
+    # NEVER_PREFILL governs rendering, not sending.
+    corpus = _corpus(
+        FactGatherSection(
+            kind="fact_gather",
+            id="your_information",
+            questions=[Question(id="first_name", label="First name")],
+        ),
+        _packet(),
+    )
+    _, mapping = interview_target(corpus)
+    assert prefill_variables(
+        mapping=mapping, answers={"first_name": "Sandra"}
+    ) == {"current_first": "Sandra"}

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -292,6 +292,23 @@ def test_packet_with_interview_url_exposes_it_for_the_button():
     assert rendered.context["interview_url"] == url
 
 
+def test_packet_context_carries_the_handoff_url_parts():
+    section = PacketOutput(
+        kind="output",
+        output_type="packet",
+        id="forms",
+        heading="Your packet",
+        forms=["Petition"],
+        interview_url="https://da.example/interview?i=p",
+    )
+    context = render_section(section, _corpus(section), {}).context
+    assert (context["court"], context["topic"], context["role"]) == (
+        "c",
+        "t",
+        "r",
+    )
+
+
 # --- dispatch ---------------------------------------------------------------
 
 

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -110,6 +110,33 @@ def test_fact_gather_never_prefills_a_protected_question(question_id):
     assert q["value"] == ""
 
 
+@pytest.mark.parametrize("question_id", PROTECTED_IDS)
+def test_fact_gather_flags_a_stored_protected_answer_as_saved(question_id):
+    # The page refuses to echo the value, so "saved" is the only signal the
+    # litigant gets that an answer exists — and the clear checkbox rides on it.
+    section = _fg([Question(id=question_id, label="Protected")])
+    rendered = render_section(
+        section, _corpus(section), {question_id: "stored"}
+    )
+    (q,) = rendered.context["questions"]
+    assert q["saved"] is True
+
+
+def test_fact_gather_unanswered_protected_question_is_not_saved():
+    section = _fg([Question(id="first_name", label="First name")])
+    rendered = render_section(section, _corpus(section), {})
+    (q,) = rendered.context["questions"]
+    assert q["saved"] is False
+
+
+def test_fact_gather_a_plain_answered_question_is_not_flagged_saved():
+    # A plain field shows its value, so blank already means "erase it".
+    section = _fg([Question(id="pubcounty", label="County of publication")])
+    rendered = render_section(section, _corpus(section), {"pubcounty": "Cass"})
+    (q,) = rendered.context["questions"]
+    assert q["saved"] is False
+
+
 def test_fact_gather_carries_choice_metadata():
     section = _fg(
         [

--- a/litigant_portal/app/tests/test_topic_flow_schema.py
+++ b/litigant_portal/app/tests/test_topic_flow_schema.py
@@ -120,6 +120,46 @@ def test_packet_interview_url_optional_and_accepted():
     )
 
 
+def _packet(**extra):
+    return {
+        "kind": "output",
+        "output_type": "packet",
+        "id": "p",
+        "heading": "Your packet",
+        "forms": ["Petition for Name Change"],
+        **extra,
+    }
+
+
+def test_packet_prefill_mapping_defaults_to_empty():
+    assert PacketOutput.model_validate(_packet()).interview_prefill == {}
+
+
+def test_packet_prefill_mapping_is_carried_through():
+    mapping = {"first_name": "current_first"}
+    packet = PacketOutput.model_validate(
+        _packet(
+            interview_url="https://da.example/i", interview_prefill=mapping
+        )
+    )
+    assert packet.interview_prefill == mapping
+
+
+@pytest.mark.parametrize(
+    "variable",
+    ["current first", "current-first", "1st_name", "", "os.system"],
+    ids=["space", "hyphen", "leading-digit", "empty", "dotted-path"],
+)
+def test_interview_variable_must_be_a_plain_identifier(variable):
+    with pytest.raises(ValidationError):
+        PacketOutput.model_validate(
+            _packet(
+                interview_url="https://da.example/i",
+                interview_prefill={"first_name": variable},
+            )
+        )
+
+
 def test_packet_form_bare_string_coerces_to_unlinked_form():
     # Authoring shorthand: a plain string is the form name with no link, so
     # existing string-only corpora keep validating unchanged.

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -295,12 +295,13 @@ def test_packet_form_with_url_renders_as_link(client, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_packet_section_renders_interview_link_when_set(client, monkeypatch):
-    # When the corpus sets interview_url, the packet emits the "Fill out your
-    # forms" handoff as an <a> to that url that opens in a new tab (#543). The
-    # {% if ctx.interview_url %} conditional is our code deciding whether the
-    # litigant sees a working docassemble link-out — behavioral, not markup.
-    interview = "https://da.example.gov/interview?i=name_change"
+def test_packet_section_posts_the_handoff_when_an_interview_is_set(
+    client, monkeypatch
+):
+    # The handoff is a POST to our own endpoint, not a link to docassemble:
+    # it creates a session, so a crawler or a reload must not fire it. The
+    # {% if ctx.interview_url %} conditional decides whether the litigant sees
+    # a working handoff at all.
     corpus = Corpus(
         metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
         sections=[
@@ -310,15 +311,18 @@ def test_packet_section_renders_interview_link_when_set(client, monkeypatch):
                 id="filing_packet",
                 heading="Your filing packet",
                 forms=["Petition for Name Change"],
-                interview_url=interview,
+                interview_url="https://da.example.gov/i?i=name_change",
             ),
         ],
     )
     monkeypatch.setattr(pages.registry, "get", lambda *a: corpus)
     flat = re.sub(r"\s+", " ", client.get(URL).content.decode())
     assert re.search(
-        rf'<a[^>]*href="{re.escape(interview)}"[^>]*target="_blank"', flat
+        rf'<form[^>]*method="post"[^>]*action="{re.escape(URL)}interview/"',
+        flat,
     )
+    assert "csrfmiddlewaretoken" in flat
+    assert "Fill out your forms" in flat
 
 
 @pytest.mark.django_db

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -656,6 +656,89 @@ def test_answers_survive_login(client, monkeypatch, variables):
     assert answer.reviewed
 
 
+# --- blank NEVER_PREFILL fields (needs DB) ----------------------------------
+# A protected field renders blank whatever is stored, so its blank submission
+# can't be read as "erase this" — the litigant never saw the value.
+
+
+def _identity_corpus():
+    """A corpus whose fact_gather pairs an optional protected question with a
+    plain one."""
+    return Corpus(
+        metadata=Metadata(court=COURT, topic=TOPIC, role=ROLE, title="T"),
+        sections=[
+            FactGatherSection(
+                kind="fact_gather",
+                id="your_information",
+                heading="Your name",
+                questions=[
+                    Question(id="first_name", label="First name"),
+                    Question(
+                        id="filing_county",
+                        label="County",
+                        type="choice",
+                        choices=["Cass", "Burleigh"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def name_variable(variables):
+    Variable.objects.create(name="first_name", data_type=VariableDataType.TEXT)
+
+
+@pytest.mark.django_db
+def test_blank_protected_field_keeps_a_reviewed_answer(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    client.post(URL, {"first_name": "Sandra", "filing_county": "Cass"})
+    client.post(URL, {"first_name": "", "filing_county": "Burleigh"})
+    assert _values() == {"first_name": "Sandra", "filing_county": "Burleigh"}
+    assert _answers()["first_name"].reviewed
+
+
+@pytest.mark.django_db
+def test_blank_protected_field_keeps_an_unreviewed_answer_unreviewed(
+    client, monkeypatch, name_variable
+):
+    # The AI-written case: saving this section must neither destroy the
+    # assistant's answer nor confirm it on the litigant's behalf.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    _store(client, "first_name", "Sandra", reviewed=False)
+    client.post(URL, {"first_name": "", "filing_county": "Cass"})
+    answer = _answers()["first_name"]
+    assert answer.value == "Sandra"
+    assert not answer.reviewed
+
+
+@pytest.mark.django_db
+def test_typing_a_protected_field_overwrites_it_and_marks_it_reviewed(
+    client, monkeypatch, name_variable
+):
+    # Overwriting is the only correction available for a field the page can't
+    # show, so it has to work.
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    _store(client, "first_name", "Sandra", reviewed=False)
+    client.post(URL, {"first_name": "Alex", "filing_county": "Cass"})
+    answer = _answers()["first_name"]
+    assert answer.value == "Alex"
+    assert answer.reviewed
+
+
+@pytest.mark.django_db
+def test_blank_unprotected_field_still_clears_its_answer(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    client.post(URL, {"first_name": "Sandra", "filing_county": "Cass"})
+    client.post(URL, {"first_name": "", "filing_county": ""})
+    assert _answers()["filing_county"].value is None
+
+
 # --- fact_gather POST validation (#525, needs DB) ---------------------------
 # The handler now validates against the corpus question defs before persisting:
 # empty `required` fields and `choice` answers outside the list are soft-gated

--- a/litigant_portal/app/tests/test_topic_flow_view.py
+++ b/litigant_portal/app/tests/test_topic_flow_view.py
@@ -743,6 +743,71 @@ def test_blank_unprotected_field_still_clears_its_answer(
     assert _answers()["filing_county"].value is None
 
 
+# --- clearing a protected answer (needs DB) -----------------------------------
+# The page never shows a NEVER_PREFILL value, so erasing one takes an explicit
+# checkbox; without it there is no way to remove an unwanted stored answer
+# before it prefills onto a court form.
+
+
+@pytest.mark.django_db
+def test_checking_clear_erases_a_protected_answer(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    client.post(URL, {"first_name": "Sandra", "filing_county": "Cass"})
+    client.post(
+        URL,
+        {"first_name": "", "first_name__clear": "on", "filing_county": "Cass"},
+    )
+    assert _answers()["first_name"].value is None
+
+
+@pytest.mark.django_db
+def test_a_typed_value_wins_over_the_clear_checkbox(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    client.post(URL, {"first_name": "Sandra", "filing_county": "Cass"})
+    client.post(
+        URL,
+        {
+            "first_name": "Alex",
+            "first_name__clear": "on",
+            "filing_county": "Cass",
+        },
+    )
+    assert _answers()["first_name"].value == "Alex"
+
+
+@pytest.mark.django_db
+def test_clear_checkbox_renders_only_beside_a_saved_protected_answer(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    before = client.get(URL).content.decode()
+    assert 'name="first_name__clear"' not in before
+    client.post(URL, {"first_name": "Sandra", "filing_county": "Cass"})
+    after = client.get(URL).content.decode()
+    assert re.search(
+        r'<input[^>]*type="checkbox"[^>]*name="first_name__clear"', after
+    )
+    # The unprotected sibling shows its value, so it never needs the box.
+    assert 'name="filing_county__clear"' not in after
+
+
+@pytest.mark.django_db
+def test_clearing_erases_an_unreviewed_assistant_answer_too(
+    client, monkeypatch, name_variable
+):
+    monkeypatch.setattr(pages.registry, "get", lambda *a: _identity_corpus())
+    _store(client, "first_name", "Sandra", reviewed=False)
+    client.post(
+        URL,
+        {"first_name": "", "first_name__clear": "on", "filing_county": "Cass"},
+    )
+    assert _answers()["first_name"].value is None
+
+
 # --- fact_gather POST validation (#525, needs DB) ---------------------------
 # The handler now validates against the corpus question defs before persisting:
 # empty `required` fields and `choice` answers outside the list are soft-gated

--- a/litigant_portal/app/tests/test_variable_answer_selectors.py
+++ b/litigant_portal/app/tests/test_variable_answer_selectors.py
@@ -1,4 +1,4 @@
-"""Postgres tests: variable_answer_list/variable_answer_map read an identity's answers scoped to that identity and to the requested names."""
+"""Postgres tests: variable_answer_list/variable_answer_map read an identity's answers scoped to that identity, to the requested names, and (with reviewed_only) to confirmed answers."""
 
 import pytest
 from django.test import TestCase
@@ -151,5 +151,98 @@ class VariableAnswerMapTests(TestCase):
         )
         result = variable_answer_map(
             identity=self.identity, names=["old_county", "residence_county"]
+        )
+        self.assertEqual(result, {})
+
+    def test_includes_unreviewed_answers_by_default(self):
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.county,
+            value="Cass",
+            reviewed=False,
+        )
+        result = variable_answer_map(
+            identity=self.identity, names=["residence_county"]
+        )
+        self.assertEqual(result, {"residence_county": "Cass"})
+
+    def test_reviewed_only_includes_a_reviewed_answer(self):
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.county,
+            value="Cass",
+            reviewed=True,
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county"],
+            reviewed_only=True,
+        )
+        self.assertEqual(result, {"residence_county": "Cass"})
+
+    def test_reviewed_only_excludes_an_unreviewed_answer(self):
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.county,
+            value="Cass",
+            reviewed=False,
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county"],
+            reviewed_only=True,
+        )
+        self.assertEqual(result, {})
+
+    def test_reviewed_only_keeps_the_reviewed_answers_of_a_mixed_set(self):
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.county,
+            value="Cass",
+            reviewed=True,
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.city,
+            value="Fargo",
+            reviewed=False,
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county", "residence_city"],
+            reviewed_only=True,
+        )
+        self.assertEqual(result, {"residence_county": "Cass"})
+
+    def test_reviewed_only_still_omits_a_cleared_answer(self):
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=self.county,
+            value=None,
+            reviewed=True,
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["residence_county"],
+            reviewed_only=True,
+        )
+        self.assertEqual(result, {})
+
+    def test_reviewed_only_still_omits_out_of_schema_variables(self):
+        vestigial = Variable.objects.create(
+            name="old_county",
+            data_type=VariableDataType.TEXT,
+            in_schema=False,
+        )
+        VariableAnswer.objects.create(
+            identity=self.identity,
+            variable=vestigial,
+            value="Stark",
+            reviewed=True,
+        )
+        result = variable_answer_map(
+            identity=self.identity,
+            names=["old_county"],
+            reviewed_only=True,
         )
         self.assertEqual(result, {})

--- a/litigant_portal/app/topic_flow/loader.py
+++ b/litigant_portal/app/topic_flow/loader.py
@@ -17,6 +17,7 @@ from litigant_portal.app.topic_flow.schema import (
     Corpus,
     FactGatherSection,
     IcsOutput,
+    PacketOutput,
     ResourcesOutput,
     VcfOutput,
 )
@@ -120,6 +121,18 @@ def _cross_reference_problems(corpus: Corpus) -> list[str]:
                     problems.append(
                         f"output {section.id!r} references unknown "
                         f"contact {ref!r}"
+                    )
+        elif isinstance(section, PacketOutput):
+            if section.interview_prefill and not section.interview_url:
+                problems.append(
+                    f"output {section.id!r} has interview_prefill but no "
+                    "interview_url to send it to"
+                )
+            for ref in section.interview_prefill:
+                if ref not in question_ids:
+                    problems.append(
+                        f"output {section.id!r} prefills {ref!r}, which is "
+                        "not a fact_gather question id"
                     )
         elif isinstance(section, ResourcesOutput):
             for ref in section.resource_ids:

--- a/litigant_portal/app/topic_flow/prefill.py
+++ b/litigant_portal/app/topic_flow/prefill.py
@@ -1,0 +1,33 @@
+"""The variables a flow hands to its docassemble interview.
+
+Pure, like the renderer: the reviewed-only answer read happens at the call
+site, these functions only resolve the corpus mapping and rename what it holds.
+"""
+
+from litigant_portal.app.topic_flow.schema import PacketOutput
+
+
+def interview_target(corpus) -> tuple[str, dict] | None:
+    """``(launch url, {question id: interview variable})``, or None.
+
+    The first packet section carrying an interview_url wins; a corpus with no
+    interview handoff returns None.
+    """
+    for section in corpus.sections:
+        if isinstance(section, PacketOutput) and section.interview_url:
+            return section.interview_url, dict(section.interview_prefill)
+    return None
+
+
+def prefill_variables(*, mapping: dict, answers: dict) -> dict:
+    """``{interview variable: value}`` for the mapped answers we hold.
+
+    An unanswered question is absent rather than blank, so the interview asks
+    it. Values pass through untouched: a stored date is already the ISO string
+    docassemble parses back into a date object.
+    """
+    return {
+        variable: answers[question_id]
+        for question_id, variable in mapping.items()
+        if question_id in answers
+    }

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -216,6 +216,7 @@ def _render_resources(section, corpus, answers):
 
 @renderer("packet")
 def _render_packet(section, corpus, answers):
+    meta = corpus.metadata
     return RenderedSection(
         anchor_id=section.id,
         heading=section.heading,
@@ -225,6 +226,10 @@ def _render_packet(section, corpus, answers):
                 {"name": form.name, "url": form.url} for form in section.forms
             ],
             "interview_url": section.interview_url,
+            # URL parts, as in _render_ics: the template owns {% url %}.
+            "court": meta.court,
+            "topic": meta.topic,
+            "role": meta.role,
         },
     )
 

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -114,6 +114,10 @@ def _render_fact_gather(section, corpus, answers):
             "choices": q.choices,
             "help_text": q.help_text,
             "value": "" if q.id in NEVER_PREFILL else answers.get(q.id, ""),
+            # The blanked-out fields need an explicit clear affordance: the
+            # litigant never sees the stored value, so a blank submission
+            # can't mean "erase it" (see the entry view's POST handler).
+            "saved": q.id in NEVER_PREFILL and q.id in answers,
             "errors": [],
             "autofocus": False,
         }

--- a/litigant_portal/app/topic_flow/schema.py
+++ b/litigant_portal/app/topic_flow/schema.py
@@ -26,6 +26,9 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 # then alphanumeric / underscore / hyphen. Mirrors the chat/prompts slug rule.
 Slug = Annotated[str, Field(pattern=r"^[a-z0-9][a-z0-9_-]*$")]
 
+# docassemble executes these as assignment statements, so identifiers only.
+InterviewVariable = Annotated[str, Field(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")]
+
 
 class _Base(BaseModel):
     # Reject unknown keys so an author's typo fails loudly instead of silently
@@ -154,8 +157,13 @@ class PacketOutput(_Base):
     forms: list[PacketFormEntry] = Field(min_length=1)
     # Optional warm handoff to a docassemble interview that fills these forms.
     # Unset (None) => the packet renders as a plain form list, so existing
-    # corpora are unaffected. v1 is link-out + manual return, no prefill (#543).
+    # corpora are unaffected.
     interview_url: str | None = None
+    # ``{fact_gather question id: interview variable}``; the loader checks
+    # each key resolves. Empty => the interview asks everything.
+    interview_prefill: dict[Slug, InterviewVariable] = Field(
+        default_factory=dict
+    )
 
 
 class ResourcesOutput(_Base):

--- a/litigant_portal/app/urls.py
+++ b/litigant_portal/app/urls.py
@@ -33,6 +33,11 @@ app_patterns = [
         topic_flow_views.topic_flow_download,
         name="topic_flow_download",
     ),
+    path(
+        "t/<slug:court>/<slug:topic>/<slug:role>/interview/",
+        topic_flow_views.topic_flow_interview,
+        name="topic_flow_interview",
+    ),
     path("admin/", pages.admin, name="admin_dashboard"),
     path("profile/", pages.ProfileDetailView.as_view(), name="profile"),
     path(

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -94,13 +94,19 @@ def topic_flow(request, court, topic, role):
         # never lands in the store; valid siblings still save. A blank
         # optional field stores None, which clears the answer — except for a
         # NEVER_PREFILL field, which renders blank whatever is stored, so a
-        # blank submission there means "never shown", not "erase it".
+        # blank submission there means "never shown", not "erase it". Erasing
+        # one takes its explicit clear checkbox; a typed value wins over the
+        # checkbox, since replacing is the stronger intent.
         valid = {}
         for qid, raw in submitted.items():
             if qid in errors:
                 continue
             value = raw.strip() or None
-            if value is None and qid in NEVER_PREFILL:
+            if (
+                value is None
+                and qid in NEVER_PREFILL
+                and f"{qid}__clear" not in request.POST
+            ):
                 continue
             valid[qid] = value
         if valid:

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -92,12 +92,17 @@ def topic_flow(request, court, topic, role):
         # re-render, and a padded date breaks date.fromisoformat in the
         # deadline compute. A blank required field or an out-of-list choice
         # never lands in the store; valid siblings still save. A blank
-        # optional field stores None, which clears the answer.
-        valid = {
-            qid: submitted[qid].strip() or None
-            for qid in submitted
-            if qid not in errors
-        }
+        # optional field stores None, which clears the answer — except for a
+        # NEVER_PREFILL field, which renders blank whatever is stored, so a
+        # blank submission there means "never shown", not "erase it".
+        valid = {}
+        for qid, raw in submitted.items():
+            if qid in errors:
+                continue
+            value = raw.strip() or None
+            if value is None and qid in NEVER_PREFILL:
+                continue
+            valid[qid] = value
         if valid:
             variable_answer_set_many(
                 identity=request.identity, values=valid, reviewed=True

--- a/litigant_portal/app/views/topic_flow.py
+++ b/litigant_portal/app/views/topic_flow.py
@@ -1,11 +1,28 @@
-from django.http import Http404, HttpResponse
+import logging
 
+from django.http import Http404, HttpResponse
+from django.shortcuts import redirect
+from django.views.decorators.http import require_POST
+
+from litigant_portal.app.services.docassemble import (
+    DocassembleError,
+    docassemble_session_create,
+)
 from litigant_portal.app.topic_flow.downloads import (
     build_download,
     find_downloadable,
 )
+from litigant_portal.app.topic_flow.prefill import (
+    interview_target,
+    prefill_variables,
+)
 from litigant_portal.app.topic_flow.registry import registry
-from litigant_portal.app.views.utils import topic_flow_answers
+from litigant_portal.app.views.utils import (
+    topic_flow_answers,
+    topic_flow_reviewed_answers,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def topic_flow_download(request, court, topic, role, output_id):
@@ -35,3 +52,44 @@ def topic_flow_download(request, court, topic, role, output_id):
         f'attachment; filename="{artifact.filename}"'
     )
     return response
+
+
+@require_POST
+def topic_flow_interview(request, court, topic, role):
+    """Start a prefilled docassemble session and send the litigant to it.
+
+    POST because creating the session is a side effect. Only reviewed answers
+    are sent: a prefilled variable skips its interview question, so docassemble
+    never asks the litigant to confirm it.
+
+    Any failure redirects to the plain interview link instead. Unprefilled is a
+    worse handoff than prefilled, but a dead button is worse than both.
+    """
+    corpus = registry.get(court, topic, role)
+    if corpus is None:
+        raise Http404(f"No Topic Flow for {court}/{topic}/{role}")
+
+    target = interview_target(corpus)
+    if target is None:
+        raise Http404(f"No interview handoff for {court}/{topic}/{role}")
+    interview_url, mapping = target
+
+    variables = prefill_variables(
+        mapping=mapping,
+        answers=topic_flow_reviewed_answers(request, list(mapping)),
+    )
+    try:
+        resume_url = docassemble_session_create(
+            interview_url=interview_url, variables=variables
+        )
+    except DocassembleError:
+        logger.warning(
+            "docassemble prefill unavailable for %s/%s/%s; "
+            "falling back to the plain interview link",
+            court,
+            topic,
+            role,
+            exc_info=True,
+        )
+        return redirect(interview_url)
+    return redirect(resume_url)

--- a/litigant_portal/app/views/topic_flow.py
+++ b/litigant_portal/app/views/topic_flow.py
@@ -2,6 +2,8 @@ import logging
 
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
+from django.urls import Resolver404, resolve
+from django.views.csrf import csrf_failure as _django_csrf_failure
 from django.views.decorators.http import require_POST
 
 from litigant_portal.app.services.docassemble import (
@@ -93,3 +95,31 @@ def topic_flow_interview(request, court, topic, role):
         )
         return redirect(interview_url)
     return redirect(resume_url)
+
+
+def csrf_failure(request, reason=""):
+    """CSRF failures on the interview handoff fall back to the plain link.
+
+    A litigant browsing with all cookies blocked never receives the CSRF
+    cookie ``topic_flow_interview``'s form depends on, so the POST 403s in
+    CsrfViewMiddleware before the view's own DocassembleError fallback ever
+    runs — leaving no path to the interview at all. That failure mode hits
+    privacy-hardened phones and locked-down shared/library machines hardest,
+    which is the audience the handoff (#804) is for. Reroute those hits to
+    the plain interview_url the view would have used; anything else keeps
+    Django's default CSRF failure page.
+
+    Wired app-wide via ``CSRF_FAILURE_VIEW`` since Django only supports one
+    such hook, but it only special-cases this one route.
+    """
+    try:
+        match = resolve(request.path)
+    except Resolver404:
+        match = None
+    if match and match.url_name == "topic_flow_interview":
+        kwargs = match.kwargs
+        corpus = registry.get(kwargs["court"], kwargs["topic"], kwargs["role"])
+        target = interview_target(corpus) if corpus else None
+        if target is not None:
+            return redirect(target[0])
+    return _django_csrf_failure(request, reason=reason)

--- a/litigant_portal/app/views/utils.py
+++ b/litigant_portal/app/views/utils.py
@@ -11,27 +11,24 @@ def topic_flow_answers(request, corpus) -> dict:
     """``{question_id: value}`` for this visitor, for the page and downloads.
 
     Reads through the glossary, so a fact the assistant stored shows up
-    here too. Returns empty for a visitor with no session yet rather than
-    touching ``request.identity``, which would mint a session and an
-    identity row for every crawler hitting a flow page.
+    here too.
     """
-    if not request.user.is_authenticated and not request.session.session_key:
-        return {}
-    return variable_answer_map(
-        identity=request.identity, names=question_ids(corpus)
-    )
+    return _answer_map(request, question_ids(corpus))
 
 
 def topic_flow_reviewed_answers(request, names: list[str]) -> dict:
-    """``{question_id: value}`` for confirmed answers only, for the prefill.
+    """``{question_id: value}`` for confirmed answers only, for the prefill."""
+    return _answer_map(request, names, reviewed_only=True)
 
-    Same no-session guard as ``topic_flow_answers``: a fresh guest hands over
-    an empty payload rather than minting an identity row.
-    """
+
+def _answer_map(request, names, *, reviewed_only=False) -> dict:
+    # Returns empty for a visitor with no session yet rather than touching
+    # ``request.identity``, which would mint a session and an identity row
+    # for every crawler hitting a flow page.
     if not request.user.is_authenticated and not request.session.session_key:
         return {}
     return variable_answer_map(
-        identity=request.identity, names=names, reviewed_only=True
+        identity=request.identity, names=names, reviewed_only=reviewed_only
     )
 
 

--- a/litigant_portal/app/views/utils.py
+++ b/litigant_portal/app/views/utils.py
@@ -22,6 +22,19 @@ def topic_flow_answers(request, corpus) -> dict:
     )
 
 
+def topic_flow_reviewed_answers(request, names: list[str]) -> dict:
+    """``{question_id: value}`` for confirmed answers only, for the prefill.
+
+    Same no-session guard as ``topic_flow_answers``: a fresh guest hands over
+    an empty payload rather than minting an identity row.
+    """
+    if not request.user.is_authenticated and not request.session.session_key:
+        return {}
+    return variable_answer_map(
+        identity=request.identity, names=names, reviewed_only=True
+    )
+
+
 def _perm_required(codename: str):
     """Build a JSON guard requiring ``codename``."""
 

--- a/litigant_portal/content/adult-name-change-standard.yml
+++ b/litigant_portal/content/adult-name-change-standard.yml
@@ -187,6 +187,14 @@ sections:
     # plus docassemble's own `interview` route) — confirmed against the live
     # Share link.
     interview_url: 'https://qa.litigantportal.com/interview/interview?i=docassemble.playground1:petition-standard.yml'
+    # Glossary question id -> interview variable. The interview keeps its own
+    # names; only reviewed answers are sent.
+    interview_prefill:
+      first_name: current_first
+      middle_name: current_middle
+      last_name: current_last
+      county: residence_county
+      name_change_publication_date: publication_date
 
   - kind: info
     id: form_gotchas

--- a/litigant_portal/content/adult-name-change-waiver.yml
+++ b/litigant_portal/content/adult-name-change-waiver.yml
@@ -160,6 +160,13 @@ sections:
     # path is /interview/interview?i=... (prefix + docassemble's `interview`
     # route). Confirm the waiver Share link the same way the standard one was.
     interview_url: 'https://qa.litigantportal.com/interview/interview?i=docassemble.playground1:petition-waiver.yml'
+    # Glossary question id -> interview variable. No publication date on this
+    # track, and waiver_reasons is left for the interview to ask.
+    interview_prefill:
+      first_name: current_first
+      middle_name: current_middle
+      last_name: current_last
+      county: residence_county
 
   - kind: info
     id: publication_waiver

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -359,3 +359,10 @@ CORPUS_COURT = os.environ.get("CORPUS_COURT") or None
 
 # Audit window: cleanup_sessions keeps chat activity this many days.
 AUDIT_RETENTION_DAYS = int(os.environ.get("AUDIT_RETENTION_DAYS", "30"))
+
+# docassemble prefill. Without a key the packet button falls back to the
+# plain, unprefilled interview link. The base URL overrides the API root
+# derived from that link, so a dev bench answers for the QA URL the content
+# YAML carries.
+DOCASSEMBLE_BASE_URL = os.environ.get("DOCASSEMBLE_BASE_URL") or None
+DOCASSEMBLE_API_KEY = os.environ.get("DOCASSEMBLE_API_KEY") or None

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -256,6 +256,7 @@ ACCOUNT_SIGNUP_FIELDS = [
 ]  # Required fields
 ACCOUNT_EMAIL_VERIFICATION = "none"  # Disable email verification for now
 ACCOUNT_LOGOUT_ON_GET = False  # Require POST for CSRF protection
+CSRF_FAILURE_VIEW = "litigant_portal.app.views.topic_flow.csrf_failure"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 

--- a/litigant_portal/settings.py
+++ b/litigant_portal/settings.py
@@ -366,3 +366,6 @@ AUDIT_RETENTION_DAYS = int(os.environ.get("AUDIT_RETENTION_DAYS", "30"))
 # YAML carries.
 DOCASSEMBLE_BASE_URL = os.environ.get("DOCASSEMBLE_BASE_URL") or None
 DOCASSEMBLE_API_KEY = os.environ.get("DOCASSEMBLE_API_KEY") or None
+# Set when LP reaches docassemble at an address litigants cannot, e.g. an
+# internal hostname: the resume link is rewritten onto this origin.
+DOCASSEMBLE_PUBLIC_URL = os.environ.get("DOCASSEMBLE_PUBLIC_URL") or None


### PR DESCRIPTION
## What changed

Closes #804.

The packet section's "Fill out your forms" button now hands docassemble the
litigant's confirmed answers instead of a cold start: it posts to a new LP
endpoint that creates a session over the docassemble API, pushes the answers
as interview variables, and redirects onto a one-time resume link. The
litigant lands inside the interview with those questions already answered.

One commit per piece, in dependency order:

- **`multi_user` in both ND interviews** (`a16b03c`). Required from an
  `initial` code block or the resume link cannot decrypt the session (#798).
  The QA playground is a manual upload, so committing this is not deploying it.
- **Blank protected fields stop erasing answers** (`a215546`). A
  `NEVER_PREFILL` field renders blank whatever is stored, so the handler read
  every re-save as "erase this". That was live data loss on main (re-saving
  the publication section destroyed the stored date and its 30-day deadline);
  the name/county questions would have multiplied it by four. Includes the
  `reviewed_only` filter on `variable_answer_map` that the payload reads
  through.
- **The docassemble client** (`ba148f4`). `session/new` → `session`
  (variables, `question: 0`) → `resume_url` (`one_time: 1`, 10-minute
  expiry). Key in a header, answers in POST bodies, nothing in a URL.
  `DOCASSEMBLE_BASE_URL` lets a local bench answer for the QA URL the
  content carries.
- **The name mapping** (`5dc4b0f`). Only 3 of the interview's 19 variables
  share our glossary names, so each flow's packet section carries an
  `interview_prefill` map, validated by the schema (interview names must be
  plain identifiers, since docassemble executes them as assignments) and the
  loader (keys must be that flow's question ids). A CI drift guard parses the
  versioned interviews: mapped variables must exist, checkboxes are never
  mapped, choice values must agree — a preset variable skips interview
  validation, so drift prints wrong values on court forms instead of failing.
- **The endpoint and button swap** (`ab4d477`). POST because session creation
  is a side effect. Only reviewed answers are sent: prefilled variables skip
  their questions, so confirmation has to happen on our side, which is the
  trust boundary the future AI fact-writing relies on. Any
  `DocassembleError` falls back to the plain interview link — no key,
  docassemble down, timeout — so the button never dies, and
  `DOCASSEMBLE_PUBLIC_URL` rewrites resume links minted against an internal
  address.
- **Hardening after review** (`1a29bbe`–`2fae9bb`): a CI guard that every
  handoff interview sets `multi_user` from an `initial` block (the one
  prerequisite whose failure has no fallback); an explicit clear checkbox for
  protected fields, since blank-means-keep had removed the only erase path;
  orphaned-session deletion when creation fails partway (the session already
  holds answers and nothing will ever resume it; #805 covers only downloaded
  packets); and a CSRF failure view so a cookies-blocked litigant gets the
  plain interview instead of a 403 dead end — that audience overlaps heavily
  with ours.

Known limitations, deliberate: `waiver_reasons` is never mapped (checkboxes
DADict, and the sensitive DV answer is better not stored cross-pathway — the
interview re-asks it). Cookie-blocked litigants always get the unprefilled
interview, since their answers live against a session they cannot hold.
`rel="noopener"` sits on a `<form>`, where browser support is patchier than
on anchors; the destination is our own docassemble. Interview packaging
(replacing manual Playground uploads) and a return link from the interview
are drafted as follow-up issues, not in this diff.

## Test plan

- [x] `make pre-commit` green (lint + full suite)
- [x] Manual, against the local bench (`make docassemble-up`, interviews +
  PDFs uploaded, `DOCASSEMBLE_*` set): answer name/county on the standard
  flow, click "Fill out your forms", land inside the interview with those
  questions skipped; finish and download the packet, values printed
  correctly; reuse the resume link from history, rejected (one-time); unset
  the API key, click again, plain interview opens (fallback); waiver track
  prefills name/county and still asks `waiver_reasons`.

---

The shared bar for every PR is the [Definition of Done](https://github.com/freelawproject/litigant-portal/blob/main/docs/wiki/definition-of-done.md). Issue-specific acceptance criteria live on the issue, on top of that baseline.