### PR TITLE
Briefcase panel: show the litigant their case facts

### DIFF
--- a/litigant_portal/app/formatting.py
+++ b/litigant_portal/app/formatting.py
@@ -1,0 +1,23 @@
+"""Display formatting shared across layers.
+
+Deliberately Django-free so the topic-flow renderer can use it (that module
+stays importable without Django configured), and deliberately not owned by
+either caller: the flow page and the briefcase must show a litigant the same
+date in the same shape, and a helper anchored to one of them drifts the moment
+the other formats its own.
+"""
+
+import datetime
+
+
+def format_long_date(value: datetime.date) -> str:
+    """Human-readable date, e.g. "Tuesday, March 3, 2026".
+
+    The day is interpolated as ``value.day`` rather than via strftime's
+    ``%-d``. ``%-d`` (no-leading-zero day) is a glibc/BSD extension, not
+    standard C, so it raises ``ValueError`` on platforms whose C library lacks
+    it — notably Windows — which would crash rendering for a partner
+    self-hosting LP there (#526). Weekday and month stay on strftime:
+    ``%A``/``%B`` are standard and portable.
+    """
+    return f"{value.strftime('%A, %B')} {value.day}, {value.year}"

--- a/litigant_portal/app/models/topic_flow.py
+++ b/litigant_portal/app/models/topic_flow.py
@@ -1,8 +1,13 @@
 import uuid
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import RegexValidator
 from django.db import models
+from django.utils import formats
+from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.translation import gettext_lazy as _
+
+from litigant_portal.app.formatting import format_long_date
 
 from .base import BaseModel
 from .choices import TopicFlowFormConditionOperator, VariableDataType
@@ -143,16 +148,43 @@ class VariableAnswer(BaseModel):
     def display_value(self) -> str:
         """The stored value rendered for reading.
 
-        ``value`` is jsonb, so a multi-choice answer arrives as a list and a
-        boolean as a bool. Handing either straight to a template prints a
-        Python repr at the litigant, so the shaping lives here rather than in
-        the template.
+        ``value`` is jsonb, so a multi-choice answer arrives as a list, a
+        boolean as a bool, and a date as an ISO string. Handing any of those
+        straight to a template shows the litigant a Python repr or a raw
+        `2026-09-09`, so the shaping lives here rather than in the template.
         """
         if isinstance(self.value, bool):
             return _("Yes") if self.value else _("No")
         if isinstance(self.value, list):
             return ", ".join(str(item) for item in self.value)
-        return str(self.value)
+        if self.value is None:
+            return ""
+        return self._formatted_date() or str(self.value)
+
+    def _formatted_date(self) -> str | None:
+        """Long-form date for a date or datetime variable.
+
+        None when the variable isn't temporal, isn't reachable, or the stored
+        value doesn't parse — an unparseable date still has to render as
+        whatever is stored rather than disappear.
+        """
+        try:
+            data_type = self.variable.data_type
+        except ObjectDoesNotExist:
+            return None
+
+        raw = str(self.value)
+        if data_type == VariableDataType.DATE:
+            parsed = parse_date(raw)
+            # Same shape the flow page's deadlines use, so a litigant sees one
+            # date format across both surfaces.
+            return format_long_date(parsed) if parsed else None
+        if data_type == VariableDataType.DATETIME:
+            parsed = parse_datetime(raw)
+            if parsed is None:
+                return None
+            return formats.date_format(parsed, "DATETIME_FORMAT")
+        return None
 
     class Meta:
         constraints = [

--- a/litigant_portal/app/models/topic_flow.py
+++ b/litigant_portal/app/models/topic_flow.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.core.validators import RegexValidator
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from .base import BaseModel
 from .choices import TopicFlowFormConditionOperator, VariableDataType
@@ -137,6 +138,21 @@ class VariableAnswer(BaseModel):
     )
     value = models.JSONField(null=True, blank=True)
     reviewed = models.BooleanField(default=False)
+
+    @property
+    def display_value(self) -> str:
+        """The stored value rendered for reading.
+
+        ``value`` is jsonb, so a multi-choice answer arrives as a list and a
+        boolean as a bool. Handing either straight to a template prints a
+        Python repr at the litigant, so the shaping lives here rather than in
+        the template.
+        """
+        if isinstance(self.value, bool):
+            return _("Yes") if self.value else _("No")
+        if isinstance(self.value, list):
+            return ", ".join(str(item) for item in self.value)
+        return str(self.value)
 
     class Meta:
         constraints = [

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -52,20 +52,24 @@ def topic_flow_find(*, topic_slug: str, flow_slug: str) -> TopicFlow | None:
     )
 
 
-def variable_answer_list(*, identity) -> list[VariableAnswer]:
+def variable_answer_list(
+    *, identity, answered_only: bool = False
+) -> list[VariableAnswer]:
     """An identity's answers, ordered by variable name.
 
     Answers to variables the corpus no longer names (``in_schema=False``)
     are left out: sync keeps those rows so a migration can move them, but
     no form references them, so no surface should show them.
+
+    ``answered_only`` drops cleared answers (``value`` None), matching
+    ``variable_answer_map``: a cleared fact is not a fact.
     """
-    return list(
-        VariableAnswer.objects.filter(
-            identity=identity, variable__in_schema=True
-        )
-        .select_related("variable")
-        .order_by("variable__name")
+    answers = VariableAnswer.objects.filter(
+        identity=identity, variable__in_schema=True
     )
+    if answered_only:
+        answers = answers.filter(value__isnull=False)
+    return list(answers.select_related("variable").order_by("variable__name"))
 
 
 def variable_answer_map(*, identity, names: list[str]) -> dict:
@@ -86,7 +90,7 @@ def variable_answer_map(*, identity, names: list[str]) -> dict:
     )
 
 
-def briefcase_groups(*, identity) -> list[dict]:
+def variable_answer_groups(*, identity) -> list[dict]:
     """An identity's answers, grouped for reading by interview page.
 
     Grouping comes from each answered variable's own placement
@@ -104,27 +108,25 @@ def briefcase_groups(*, identity) -> list[dict]:
     matching ``variable_answer_map``: a cleared fact is not a fact, and no
     surface should show a variable the corpus no longer names.
     """
-    answers = list(
-        VariableAnswer.objects.filter(
-            identity=identity, variable__in_schema=True, value__isnull=False
-        )
-        .select_related("variable")
-        .order_by("variable__name")
-    )
+    answers = variable_answer_list(identity=identity, answered_only=True)
     if not answers:
         return []
 
     answer_by_variable = {a.variable_id: a for a in answers}
     placements = (
         TopicFlowInterviewVariable.objects.filter(
-            variable_id__in=answer_by_variable
+            variable_id__in=answer_by_variable, page__flow__enabled=True
         )
         .select_related("page")
         .order_by(
             "page__flow__topic__order",
+            "page__flow__topic__created_at",
             "page__flow__order",
+            "page__flow__created_at",
             "page__order",
+            "page__created_at",
             "order",
+            "created_at",
         )
     )
 

--- a/litigant_portal/app/selectors/topic_flow.py
+++ b/litigant_portal/app/selectors/topic_flow.py
@@ -1,7 +1,12 @@
 from django.core.cache import cache
 
 from litigant_portal.app.cache import TOPIC_LIST_CACHE_KEY
-from litigant_portal.app.models import Topic, TopicFlow, VariableAnswer
+from litigant_portal.app.models import (
+    Topic,
+    TopicFlow,
+    TopicFlowInterviewVariable,
+    VariableAnswer,
+)
 
 
 def topic_list() -> list[Topic]:
@@ -79,3 +84,67 @@ def variable_answer_map(*, identity, names: list[str]) -> dict:
             value__isnull=False,
         ).values_list("variable__name", "value")
     )
+
+
+def briefcase_groups(*, identity) -> list[dict]:
+    """An identity's answers, grouped for reading by interview page.
+
+    Grouping comes from each answered variable's own placement
+    (``TopicFlowInterviewVariable``), not from an active flow: the chat page
+    resolves no flow server-side, so placement is the only grouping available
+    without a model change. A variable placed on more than one page is grouped
+    under the first placement in (topic, flow, page, placement) order, which
+    keeps the grouping stable across requests.
+
+    Pages that place nothing this identity answered are skipped rather than
+    rendered as empty headings, and answers with no placement collect in a
+    final untitled group.
+
+    Cleared answers (``value`` None) and out-of-schema variables are left out,
+    matching ``variable_answer_map``: a cleared fact is not a fact, and no
+    surface should show a variable the corpus no longer names.
+    """
+    answers = list(
+        VariableAnswer.objects.filter(
+            identity=identity, variable__in_schema=True, value__isnull=False
+        )
+        .select_related("variable")
+        .order_by("variable__name")
+    )
+    if not answers:
+        return []
+
+    answer_by_variable = {a.variable_id: a for a in answers}
+    placements = (
+        TopicFlowInterviewVariable.objects.filter(
+            variable_id__in=answer_by_variable
+        )
+        .select_related("page")
+        .order_by(
+            "page__flow__topic__order",
+            "page__flow__order",
+            "page__order",
+            "order",
+        )
+    )
+
+    # Walking placements in that order builds both the page sequence and the
+    # sequence within each page, so neither needs a second sort.
+    grouped: dict = {}
+    placed: set = set()
+    for placement in placements:
+        if placement.variable_id in placed:
+            continue
+        placed.add(placement.variable_id)
+        grouped.setdefault(placement.page, []).append(
+            answer_by_variable[placement.variable_id]
+        )
+
+    groups = [
+        {"title": page.title, "answers": page_answers}
+        for page, page_answers in grouped.items()
+    ]
+    unplaced = [a for a in answers if a.variable_id not in placed]
+    if unplaced:
+        groups.append({"title": "", "answers": unplaced})
+    return groups

--- a/litigant_portal/app/templates/cotton/molecules/briefcase_fact.html
+++ b/litigant_portal/app/templates/cotton/molecules/briefcase_fact.html
@@ -1,0 +1,8 @@
+{# One stored fact: its label over its value. Label falls back to the #}
+{# variable's name so a corpus entry with no label still reads. #}
+<div>
+  <dt class="text-2xs font-medium uppercase tracking-wide text-greyscale-500">
+    {{ answer.variable.label|default:answer.variable.name }}
+  </dt>
+  <dd class="text-sm text-greyscale-800 break-words">{{ answer.display_value }}</dd>
+</div>

--- a/litigant_portal/app/templates/cotton/molecules/briefcase_fact.html
+++ b/litigant_portal/app/templates/cotton/molecules/briefcase_fact.html
@@ -1,8 +1,6 @@
 {# One stored fact: its label over its value. Label falls back to the #}
 {# variable's name so a corpus entry with no label still reads. #}
 <div>
-  <dt class="text-2xs font-medium uppercase tracking-wide text-greyscale-500">
-    {{ answer.variable.label|default:answer.variable.name }}
-  </dt>
+  <dt class="text-xs text-greyscale-500">{{ answer.variable.label|default:answer.variable.name }}</dt>
   <dd class="text-sm text-greyscale-800 break-words">{{ answer.display_value }}</dd>
 </div>

--- a/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
+++ b/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
@@ -1,9 +1,12 @@
 {% load i18n %}
 
-{# show_agent_state: opt in to the developer disclosure. Off by default —
-   the partial's Alpine bindings only resolve inside x-data="chatApp", so
-   rendering it anywhere else (the style guide) would throw. #}
 <c-vars show_agent_state="" />
+
+{% comment %}
+  show_agent_state opts in to the developer disclosure at the bottom. Off by
+  default: the partial's Alpine bindings only resolve inside x-data="chatApp",
+  so rendering it anywhere else (the style guide) would throw.
+{% endcomment %}
 
 {# The briefcase body: the visitor's stored facts, grouped by interview page. #}
 {# Shared by the desktop column and the mobile drawer, so the two can't drift. #}

--- a/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
+++ b/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
@@ -17,7 +17,7 @@
       {% for group in groups %}
         <div>
           {% if group.title %}
-            <h3 class="text-2xs font-semibold uppercase tracking-widest text-greyscale-500 mb-2">{{ group.title }}</h3>
+            <h3 class="text-2xs font-bold uppercase tracking-widest text-greyscale-700 mb-2">{{ group.title }}</h3>
           {% endif %}
           <dl class="space-y-2.5">
             {% for answer in group.answers %}

--- a/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
+++ b/litigant_portal/app/templates/cotton/organisms/briefcase_panel.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+
+{# show_agent_state: opt in to the developer disclosure. Off by default —
+   the partial's Alpine bindings only resolve inside x-data="chatApp", so
+   rendering it anywhere else (the style guide) would throw. #}
+<c-vars show_agent_state="" />
+
+{# The briefcase body: the visitor's stored facts, grouped by interview page. #}
+{# Shared by the desktop column and the mobile drawer, so the two can't drift. #}
+{# Always renders — an empty briefcase is an empty state, never a missing panel. #}
+<div class="flex-1 overflow-y-auto min-h-0">
+  {% if groups %}
+    <div class="p-4 space-y-5">
+      {% for group in groups %}
+        <div>
+          {% if group.title %}
+            <h3 class="text-2xs font-semibold uppercase tracking-widest text-greyscale-500 mb-2">{{ group.title }}</h3>
+          {% endif %}
+          <dl class="space-y-2.5">
+            {% for answer in group.answers %}
+              <c-molecules.briefcase-fact :answer="answer" />
+            {% endfor %}
+          </dl>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="p-4 text-sm text-greyscale-600">
+      {% trans "Nothing saved yet. As you answer questions, the details you give will collect here so you can check them later." %}
+    </p>
+  {% endif %}
+
+  {% if show_agent_state and perms.app.manage_developers %}
+    <details class="mt-2 border-t border-greyscale-200">
+      <summary class="px-4 py-2 text-xs text-greyscale-600 cursor-pointer">{% trans "Agent state" %}</summary>
+      {% include "pages/chat/partials/_agent_state.html" %}
+    </details>
+  {% endif %}
+</div>

--- a/litigant_portal/app/templates/pages/chat/index.html
+++ b/litigant_portal/app/templates/pages/chat/index.html
@@ -85,15 +85,13 @@
             {% trans "New chat" %}
           </button>
           {# Briefcase drawer trigger — appears once the right panel collapses #}
-          {% if perms.app.manage_developers %}
-            <button type="button"
-                    x-on:click="openBriefcase"
-                    aria-label='{% trans "Briefcase" %}'
-                    title="{% trans "Briefcase" %}"
-                    class="lg:hidden flex-shrink-0 -mr-1 inline-flex items-center justify-center w-8 h-8 rounded-md text-greyscale-500 hover:bg-greyscale-100 hover:text-greyscale-700 cursor-pointer transition-colors">
-              <c-atoms.icon name="briefcase" class="w-4.5 h-4.5" />
-            </button>
-          {% endif %}
+          <button type="button"
+                  x-on:click="openBriefcase"
+                  aria-label='{% trans "Briefcase" %}'
+                  title="{% trans "Briefcase" %}"
+                  class="lg:hidden flex-shrink-0 -mr-1 inline-flex items-center justify-center w-8 h-8 rounded-md text-greyscale-500 hover:bg-greyscale-100 hover:text-greyscale-700 cursor-pointer transition-colors">
+            <c-atoms.icon name="briefcase" class="w-4.5 h-4.5" />
+          </button>
         </div>
       </div>
       {# Messages #}
@@ -268,15 +266,13 @@
         </form>
       </div>
     </section>
-    {# Right panel — briefcase (live agent state for now; collapses into the briefcase drawer below lg) #}
-    {% if perms.app.manage_developers %}
-      <aside class="hidden lg:flex w-[clamp(280px,20vw,384px)] flex-shrink-0 flex-col border-l border-greyscale-200 min-h-0">
-        <c-atoms.eyebrow icon="briefcase"
-                         label='{% trans "Briefcase" %}'
-                         class="px-4 pt-4 pb-3 border-b border-greyscale-200 flex-shrink-0" />
-        {% include "pages/chat/partials/_agent_state.html" %}
-      </aside>
-    {% endif %}
+    {# Right panel — the briefcase (collapses into the briefcase drawer below lg) #}
+    <aside class="hidden lg:flex w-[clamp(280px,20vw,384px)] flex-shrink-0 flex-col border-l border-greyscale-200 min-h-0">
+      <c-atoms.eyebrow icon="briefcase"
+                       label='{% trans "Briefcase" %}'
+                       class="px-4 pt-4 pb-3 border-b border-greyscale-200 flex-shrink-0" />
+      <c-organisms.briefcase-panel :groups="briefcase_groups" show_agent_state />
+    </aside>
     {# History drawer — the collapsed left panel. A slide-over on tablet, full takeover on phones. #}
     <div x-show="historyOpen"
          x-cloak
@@ -324,34 +320,32 @@
          x-transition.opacity
          x-on:click="closeBriefcase"
          class="lg:hidden absolute inset-0 z-30 bg-greyscale-900/30 backdrop-blur-sm"></div>
-    {% if perms.app.manage_developers %}
-      <aside x-show="briefcaseOpen"
-             x-cloak
-             x-on:keydown.escape.window="closeBriefcase"
-             x-transition:enter="transition-transform duration-300 ease-out"
-             x-transition:enter-start="translate-x-full"
-             x-transition:enter-end="translate-x-0"
-             x-transition:leave="transition-transform duration-200 ease-in"
-             x-transition:leave-start="translate-x-0"
-             x-transition:leave-end="translate-x-full"
-             role="dialog"
-             aria-modal="true"
-             aria-label='{% trans "Briefcase" %}'
-             class="lg:hidden absolute inset-y-0 right-0 z-40 w-full sm:w-80 flex flex-col bg-greyscale-25 sm:border-l border-greyscale-200 sm:shadow-2xl">
-        <div class="flex items-center justify-between gap-2 pl-4 pr-3 py-2.5 border-b border-greyscale-200 flex-shrink-0">
-          <c-atoms.eyebrow icon="briefcase"
-                           label='{% trans "Briefcase" %}'
-                           class="min-w-0" />
-          <button type="button"
-                  x-on:click="closeBriefcase"
-                  aria-label='{% trans "Close" %}'
-                  class="flex-shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-md text-greyscale-500 hover:bg-greyscale-100 hover:text-greyscale-700 cursor-pointer transition-colors">
-            <c-atoms.icon name="x-mark" class="w-4 h-4" />
-          </button>
-        </div>
-        {% include "pages/chat/partials/_agent_state.html" %}
-      </aside>
-    {% endif %}
+    <aside x-show="briefcaseOpen"
+           x-cloak
+           x-on:keydown.escape.window="closeBriefcase"
+           x-transition:enter="transition-transform duration-300 ease-out"
+           x-transition:enter-start="translate-x-full"
+           x-transition:enter-end="translate-x-0"
+           x-transition:leave="transition-transform duration-200 ease-in"
+           x-transition:leave-start="translate-x-0"
+           x-transition:leave-end="translate-x-full"
+           role="dialog"
+           aria-modal="true"
+           aria-label='{% trans "Briefcase" %}'
+           class="lg:hidden absolute inset-y-0 right-0 z-40 w-full sm:w-80 flex flex-col bg-greyscale-25 sm:border-l border-greyscale-200 sm:shadow-2xl">
+      <div class="flex items-center justify-between gap-2 pl-4 pr-3 py-2.5 border-b border-greyscale-200 flex-shrink-0">
+        <c-atoms.eyebrow icon="briefcase"
+                         label='{% trans "Briefcase" %}'
+                         class="min-w-0" />
+        <button type="button"
+                x-on:click="closeBriefcase"
+                aria-label='{% trans "Close" %}'
+                class="flex-shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-md text-greyscale-500 hover:bg-greyscale-100 hover:text-greyscale-700 cursor-pointer transition-colors">
+          <c-atoms.icon name="x-mark" class="w-4 h-4" />
+        </button>
+      </div>
+      <c-organisms.briefcase-panel :groups="briefcase_groups" show_agent_state />
+    </aside>
     {# Delete confirmation modal #}
     <div x-show="confirmingDelete"
          x-cloak

--- a/litigant_portal/app/templates/pages/style_guide.html
+++ b/litigant_portal/app/templates/pages/style_guide.html
@@ -1104,7 +1104,7 @@
               The chat page's right-hand panel: the visitor's stored facts,
               grouped by interview page. Pass the grouped list via the
               <code>:groups</code> prop, as built by
-              <code>briefcase_groups()</code>. Groups with no title render
+              <code>variable_answer_groups()</code>. Groups with no title render
               their facts without a heading, which is where unplaced answers
               land. Used in both the desktop column and the mobile drawer, so
               the two cannot drift.

--- a/litigant_portal/app/templates/pages/style_guide.html
+++ b/litigant_portal/app/templates/pages/style_guide.html
@@ -106,6 +106,10 @@
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Topic Card</a>
             </li>
             <li>
+              <a href="#briefcase-fact"
+                 class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Briefcase Fact</a>
+            </li>
+            <li>
               <a href="#form-errors"
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Form Errors</a>
             </li>
@@ -152,6 +156,10 @@
             <li>
               <a href="#footer"
                  class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Footer</a>
+            </li>
+            <li>
+              <a href="#briefcase-panel"
+                 class="block py-1 text-sm text-greyscale-600 hover:text-primary-600 pl-2">Briefcase Panel</a>
             </li>
             <li>
               <a href="#fallback-resources"
@@ -859,6 +867,22 @@
               <c-molecules.topic-card icon="users" title="Family & Divorce" description="Divorce, custody, child support" href="#" />
             </div>
           </section>
+          <section id="briefcase-fact" class="mb-12" aria-labelledby="briefcase-fact-heading">
+            <h3 id="briefcase-fact-heading" class="mb-4">Briefcase Fact</h3>
+            <p class="text-greyscale-600 mb-6">
+              One stored fact as a label over its value, for the briefcase
+              panel. Pass a <code>VariableAnswer</code> via the
+              <code>:answer</code> prop. The label falls back to the
+              variable's name, and the value comes from
+              <code>display_value</code>, so lists and booleans read as words
+              rather than Python literals.
+            </p>
+            <dl class="space-y-2.5 max-w-xs mb-6">
+              {% for answer in briefcase_groups.0.answers %}
+                <c-molecules.briefcase-fact :answer="answer" />
+              {% endfor %}
+            </dl>
+          </section>
           <section id="form-errors" class="mb-12" aria-labelledby="form-errors-heading">
             <h3 id="form-errors-heading" class="mb-4">Form Errors</h3>
             <p class="text-greyscale-600 mb-6">
@@ -1072,6 +1096,31 @@
             <p class="text-greyscale-600 mb-6">Site footer with navigation.</p>
             <div class="border border-greyscale-200 rounded-lg overflow-hidden mb-6">
               <c-organisms.footer />
+            </div>
+          </section>
+          <section id="briefcase-panel" class="mb-12" aria-labelledby="briefcase-panel-heading">
+            <h3 id="briefcase-panel-heading" class="mb-4">Briefcase Panel</h3>
+            <p class="text-greyscale-600 mb-6">
+              The chat page's right-hand panel: the visitor's stored facts,
+              grouped by interview page. Pass the grouped list via the
+              <code>:groups</code> prop, as built by
+              <code>briefcase_groups()</code>. Groups with no title render
+              their facts without a heading, which is where unplaced answers
+              land. Used in both the desktop column and the mobile drawer, so
+              the two cannot drift.
+            </p>
+            <p class="text-sm text-greyscale-500 mb-4">
+              Always renders. With no facts it shows its empty state rather
+              than collapsing, because the panel is a fixed part of the chat
+              frame. A raw agent-state disclosure appears at the bottom for
+              users holding <code>manage_developers</code>.
+            </p>
+            <div class="border border-greyscale-200 rounded-lg overflow-hidden mb-6 max-w-sm flex flex-col">
+              <c-organisms.briefcase-panel :groups="briefcase_groups" />
+            </div>
+            <p class="text-sm text-greyscale-500 mb-2">Empty state:</p>
+            <div class="border border-greyscale-200 rounded-lg overflow-hidden mb-6 max-w-sm flex flex-col">
+              <c-organisms.briefcase-panel />
             </div>
           </section>
           <section id="fallback-resources"

--- a/litigant_portal/app/tests/test_briefcase.py
+++ b/litigant_portal/app/tests/test_briefcase.py
@@ -7,7 +7,7 @@ grouping is the only one available without a model change.
 """
 
 import pytest
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 
 from litigant_portal.app.models import (
@@ -20,7 +20,8 @@ from litigant_portal.app.models import (
     VariableAnswer,
 )
 from litigant_portal.app.models.choices import VariableDataType
-from litigant_portal.app.selectors.topic_flow import briefcase_groups
+from litigant_portal.app.selectors.topic_flow import variable_answer_groups
+from litigant_portal.app.views.pages import _briefcase_sample
 
 
 def _place(page, variable, order):
@@ -35,7 +36,7 @@ class BriefcaseGroupsTests(TestCase):
         self.identity = UserIdentity.objects.create(session_key="s1")
         self.topic = Topic.objects.create(slug="eviction", order=0)
         self.flow = TopicFlow.objects.create(
-            topic=self.topic, slug="tenant", order=0
+            topic=self.topic, slug="tenant", order=0, enabled=True
         )
         self.about_you = TopicFlowInterviewPage.objects.create(
             flow=self.flow, title="About you", order=0
@@ -59,7 +60,7 @@ class BriefcaseGroupsTests(TestCase):
         _place(self.about_you, tenant_name, 0)
         _place(self.your_notice, received, 0)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual(
             [g["title"] for g in groups], ["About you", "Your notice"]
@@ -72,7 +73,7 @@ class BriefcaseGroupsTests(TestCase):
         _place(self.about_you, first, 0)
         _place(self.about_you, last, 1)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual(
             [a.variable.name for a in groups[0]["answers"]],
@@ -84,7 +85,7 @@ class BriefcaseGroupsTests(TestCase):
         _place(self.about_you, placed, 0)
         self._answer("court_name", "Franklin County Municipal Court")
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual(groups[-1]["title"], "")
         self.assertEqual(
@@ -95,7 +96,7 @@ class BriefcaseGroupsTests(TestCase):
         placed = self._answer("tenant_name", "Jamie")
         _place(self.about_you, placed, 0)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual([g["title"] for g in groups], ["About you"])
 
@@ -107,7 +108,7 @@ class BriefcaseGroupsTests(TestCase):
         _place(self.about_you, kept, 0)
         _place(self.about_you, cleared, 1)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual(
             [a.variable.name for a in groups[0]["answers"]], ["tenant_name"]
@@ -122,7 +123,7 @@ class BriefcaseGroupsTests(TestCase):
         )
         _place(self.about_you, stale, 1)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual(
             [a.variable.name for a in groups[0]["answers"]], ["tenant_name"]
@@ -136,10 +137,27 @@ class BriefcaseGroupsTests(TestCase):
         )
         _place(self.about_you, theirs, 0)
 
-        self.assertEqual(briefcase_groups(identity=self.identity), [])
+        self.assertEqual(variable_answer_groups(identity=self.identity), [])
 
     def test_identity_with_no_answers_gets_no_groups(self):
-        self.assertEqual(briefcase_groups(identity=self.identity), [])
+        self.assertEqual(variable_answer_groups(identity=self.identity), [])
+
+    def test_a_disabled_flows_page_is_not_used_for_grouping(self):
+        # enabled defaults to False, so a draft flow is the normal state of a
+        # half-authored one. Its page title heading a real litigant's
+        # briefcase would leak unpublished corpus at them.
+        draft = TopicFlow.objects.create(
+            topic=self.topic, slug="landlord", order=1, enabled=False
+        )
+        draft_page = TopicFlowInterviewPage.objects.create(
+            flow=draft, title="Draft page", order=0
+        )
+        answered = self._answer("tenant_name", "Jamie")
+        _place(draft_page, answered, 0)
+
+        groups = variable_answer_groups(identity=self.identity)
+
+        self.assertEqual([g["title"] for g in groups], [""])
 
     def test_empty_page_is_not_rendered_as_a_group(self):
         # "Your notice" places nothing this identity answered, so it must not
@@ -149,7 +167,7 @@ class BriefcaseGroupsTests(TestCase):
         unanswered = Variable.objects.create(name="hearing_date")
         _place(self.your_notice, unanswered, 0)
 
-        groups = briefcase_groups(identity=self.identity)
+        groups = variable_answer_groups(identity=self.identity)
 
         self.assertEqual([g["title"] for g in groups], ["About you"])
 
@@ -157,12 +175,16 @@ class BriefcaseGroupsTests(TestCase):
 @pytest.mark.postgres
 class BriefcaseChatContextTests(TestCase):
     def test_chat_page_exposes_the_visitors_groups(self):
-        response = self.client.get(reverse("pages:chat"))
-        identity = UserIdentity.objects.get(
+        # Seed the identity the middleware will resolve, rather than letting a
+        # GET mint one: an anonymous first paint no longer creates a row.
+        self.client.session.save()
+        identity = UserIdentity.objects.create(
             session_key=self.client.session.session_key
         )
         topic = Topic.objects.create(slug="eviction", order=0)
-        flow = TopicFlow.objects.create(topic=topic, slug="tenant", order=0)
+        flow = TopicFlow.objects.create(
+            topic=topic, slug="tenant", order=0, enabled=True
+        )
         page = TopicFlowInterviewPage.objects.create(
             flow=flow, title="About you", order=0
         )
@@ -189,6 +211,14 @@ class BriefcaseChatContextTests(TestCase):
         self.assertNotIn("{#", content)
         self.assertNotIn("{%", content)
 
+    def test_chat_page_for_a_first_time_visitor_creates_no_identity(self):
+        # Reading through request.identity mints a session and a UserIdentity
+        # row, so an unguarded read banks one per anonymous hit, crawlers
+        # included. views/utils.topic_flow_answers already guards this.
+        self.client.get(reverse("pages:chat"))
+
+        self.assertEqual(UserIdentity.objects.count(), 0)
+
     def test_chat_page_exposes_empty_groups_for_a_fresh_visitor(self):
         # The panel is always rendered, so the context key must always exist:
         # a missing key and an empty list are different bugs in the template.
@@ -197,9 +227,10 @@ class BriefcaseChatContextTests(TestCase):
         self.assertEqual(response.context["briefcase_groups"], [])
 
 
-class DisplayValueTests(TestCase):
+class DisplayValueTests(SimpleTestCase):
     """``VariableAnswer.display_value`` shapes jsonb for reading. No DB —
-    the property only touches in-memory objects."""
+    the property only touches in-memory objects, so SimpleTestCase keeps it
+    out of the suite's database path."""
 
     def _value(self, value, data_type=VariableDataType.TEXT):
         return VariableAnswer(
@@ -259,3 +290,27 @@ class DisplayValueTests(TestCase):
 
     def test_a_cleared_answer_renders_empty_not_none(self):
         self.assertEqual(VariableAnswer(value=None).display_value, "")
+
+
+class BriefcaseSampleTests(SimpleTestCase):
+    """The style guide's in-memory sample. No DB: it builds unsaved rows."""
+
+    def _fact(self, name):
+        return next(
+            answer
+            for group in _briefcase_sample()
+            for answer in group["answers"]
+            if answer.variable.name == name
+        )
+
+    def test_the_date_fact_renders_in_the_apps_date_format(self):
+        # Without a data_type the variable defaults to TEXT, so the sample
+        # shows a raw ISO string where a real briefcase shows a long date, and
+        # the style guide then documents output the panel never produces.
+        self.assertEqual(
+            self._fact("received_date").display_value,
+            "Tuesday, September 1, 2026",
+        )
+
+    def test_a_plain_text_fact_is_untouched(self):
+        self.assertEqual(self._fact("tenant_first").display_value, "Jamie")

--- a/litigant_portal/app/tests/test_briefcase.py
+++ b/litigant_portal/app/tests/test_briefcase.py
@@ -179,6 +179,15 @@ class BriefcaseChatContextTests(TestCase):
             [a.variable.label for a in groups[0]["answers"]], ["Name"]
         )
 
+    def test_no_unrendered_template_syntax_reaches_the_page(self):
+        # Django's {# #} comment is single-line only, so a multi-line one is
+        # not a comment and renders as body text. That shipped once, straight
+        # into the briefcase panel.
+        content = self.client.get(reverse("pages:chat")).content.decode()
+
+        self.assertNotIn("{#", content)
+        self.assertNotIn("{%", content)
+
     def test_chat_page_exposes_empty_groups_for_a_fresh_visitor(self):
         # The panel is always rendered, so the context key must always exist:
         # a missing key and an empty list are different bugs in the template.

--- a/litigant_portal/app/tests/test_briefcase.py
+++ b/litigant_portal/app/tests/test_briefcase.py
@@ -19,6 +19,7 @@ from litigant_portal.app.models import (
     Variable,
     VariableAnswer,
 )
+from litigant_portal.app.models.choices import VariableDataType
 from litigant_portal.app.selectors.topic_flow import briefcase_groups
 
 
@@ -198,10 +199,12 @@ class BriefcaseChatContextTests(TestCase):
 
 class DisplayValueTests(TestCase):
     """``VariableAnswer.display_value`` shapes jsonb for reading. No DB —
-    the property only touches the in-memory value."""
+    the property only touches in-memory objects."""
 
-    def _value(self, value):
-        return VariableAnswer(value=value).display_value
+    def _value(self, value, data_type=VariableDataType.TEXT):
+        return VariableAnswer(
+            variable=Variable(name="v", data_type=data_type), value=value
+        ).display_value
 
     def test_list_renders_as_a_comma_separated_string(self):
         # A multi-choice answer is stored as a list; str() would print
@@ -226,3 +229,33 @@ class DisplayValueTests(TestCase):
     def test_strings_and_numbers_pass_through(self):
         self.assertEqual(self._value("2026-09-01"), "2026-09-01")
         self.assertEqual(self._value(28), "28")
+
+    def test_dates_render_long_form_not_iso(self):
+        # The corpus stores an ISO string in jsonb; "2026-09-09" in front of a
+        # litigant is a machine's date. Shape matches the flow page's
+        # deadlines (format_long_date) so one date reads the same on both.
+        self.assertEqual(
+            self._value("2026-09-09", VariableDataType.DATE),
+            "Wednesday, September 9, 2026",
+        )
+
+    def test_an_unparseable_date_falls_back_to_the_stored_value(self):
+        # Never swallow a value we can't parse — the litigant still needs to
+        # see whatever is actually stored against their case.
+        self.assertEqual(
+            self._value("next Tuesday", VariableDataType.DATE),
+            "next Tuesday",
+        )
+
+    def test_a_text_variable_holding_a_date_string_is_left_alone(self):
+        # Formatting keys off the variable's declared type, not the shape of
+        # the string, so a case number that looks like a date stays intact.
+        self.assertEqual(
+            self._value("2026-09-09", VariableDataType.TEXT), "2026-09-09"
+        )
+
+    def test_an_answer_with_no_variable_still_renders(self):
+        self.assertEqual(VariableAnswer(value="Jamie").display_value, "Jamie")
+
+    def test_a_cleared_answer_renders_empty_not_none(self):
+        self.assertEqual(VariableAnswer(value=None).display_value, "")

--- a/litigant_portal/app/tests/test_briefcase.py
+++ b/litigant_portal/app/tests/test_briefcase.py
@@ -1,0 +1,219 @@
+"""The briefcase panel's grouping selector and its chat-page context.
+
+The panel shows an identity's stored facts grouped for reading. Grouping is
+derived from each answered variable's own interview placement, not from an
+"active flow" — the chat page has no flow server-side, so a placement-driven
+grouping is the only one available without a model change.
+"""
+
+import pytest
+from django.test import TestCase
+from django.urls import reverse
+
+from litigant_portal.app.models import (
+    Topic,
+    TopicFlow,
+    TopicFlowInterviewPage,
+    TopicFlowInterviewVariable,
+    UserIdentity,
+    Variable,
+    VariableAnswer,
+)
+from litigant_portal.app.selectors.topic_flow import briefcase_groups
+
+
+def _place(page, variable, order):
+    return TopicFlowInterviewVariable.objects.create(
+        page=page, variable=variable, order=order
+    )
+
+
+@pytest.mark.postgres
+class BriefcaseGroupsTests(TestCase):
+    def setUp(self):
+        self.identity = UserIdentity.objects.create(session_key="s1")
+        self.topic = Topic.objects.create(slug="eviction", order=0)
+        self.flow = TopicFlow.objects.create(
+            topic=self.topic, slug="tenant", order=0
+        )
+        self.about_you = TopicFlowInterviewPage.objects.create(
+            flow=self.flow, title="About you", order=0
+        )
+        self.your_notice = TopicFlowInterviewPage.objects.create(
+            flow=self.flow, title="Your notice", order=1
+        )
+
+    def _answer(self, name, value, label=""):
+        variable = Variable.objects.create(name=name, label=label)
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=variable, value=value
+        )
+        return variable
+
+    def test_groups_follow_page_order_not_variable_name(self):
+        # Alphabetically "received_date" precedes "tenant_name", so a flat
+        # name-ordered list would invert these two groups. Page order wins.
+        tenant_name = self._answer("tenant_name", "Jamie")
+        received = self._answer("received_date", "2026-09-01")
+        _place(self.about_you, tenant_name, 0)
+        _place(self.your_notice, received, 0)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual(
+            [g["title"] for g in groups], ["About you", "Your notice"]
+        )
+
+    def test_variables_within_a_group_follow_placement_order(self):
+        last = self._answer("tenant_last", "Rivera")
+        first = self._answer("tenant_first", "Jamie")
+        # Placement order is deliberately the reverse of alphabetical.
+        _place(self.about_you, first, 0)
+        _place(self.about_you, last, 1)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual(
+            [a.variable.name for a in groups[0]["answers"]],
+            ["tenant_first", "tenant_last"],
+        )
+
+    def test_unplaced_answers_land_in_a_titleless_group_last(self):
+        placed = self._answer("tenant_name", "Jamie")
+        _place(self.about_you, placed, 0)
+        self._answer("court_name", "Franklin County Municipal Court")
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual(groups[-1]["title"], "")
+        self.assertEqual(
+            [a.variable.name for a in groups[-1]["answers"]], ["court_name"]
+        )
+
+    def test_no_titleless_group_when_every_answer_is_placed(self):
+        placed = self._answer("tenant_name", "Jamie")
+        _place(self.about_you, placed, 0)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual([g["title"] for g in groups], ["About you"])
+
+    def test_cleared_answers_are_left_out(self):
+        # A None value is a cleared answer, not a fact. Showing the label with
+        # an empty value reads as "we know this and it's blank".
+        kept = self._answer("tenant_name", "Jamie")
+        cleared = self._answer("hearing_date", None)
+        _place(self.about_you, kept, 0)
+        _place(self.about_you, cleared, 1)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual(
+            [a.variable.name for a in groups[0]["answers"]], ["tenant_name"]
+        )
+
+    def test_out_of_schema_answers_are_left_out(self):
+        kept = self._answer("tenant_name", "Jamie")
+        _place(self.about_you, kept, 0)
+        stale = Variable.objects.create(name="old_field", in_schema=False)
+        VariableAnswer.objects.create(
+            identity=self.identity, variable=stale, value="x"
+        )
+        _place(self.about_you, stale, 1)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual(
+            [a.variable.name for a in groups[0]["answers"]], ["tenant_name"]
+        )
+
+    def test_another_identitys_answers_are_not_visible(self):
+        other = UserIdentity.objects.create(session_key="s2")
+        theirs = Variable.objects.create(name="tenant_name")
+        VariableAnswer.objects.create(
+            identity=other, variable=theirs, value="Someone else"
+        )
+        _place(self.about_you, theirs, 0)
+
+        self.assertEqual(briefcase_groups(identity=self.identity), [])
+
+    def test_identity_with_no_answers_gets_no_groups(self):
+        self.assertEqual(briefcase_groups(identity=self.identity), [])
+
+    def test_empty_page_is_not_rendered_as_a_group(self):
+        # "Your notice" places nothing this identity answered, so it must not
+        # appear as an empty heading.
+        placed = self._answer("tenant_name", "Jamie")
+        _place(self.about_you, placed, 0)
+        unanswered = Variable.objects.create(name="hearing_date")
+        _place(self.your_notice, unanswered, 0)
+
+        groups = briefcase_groups(identity=self.identity)
+
+        self.assertEqual([g["title"] for g in groups], ["About you"])
+
+
+@pytest.mark.postgres
+class BriefcaseChatContextTests(TestCase):
+    def test_chat_page_exposes_the_visitors_groups(self):
+        response = self.client.get(reverse("pages:chat"))
+        identity = UserIdentity.objects.get(
+            session_key=self.client.session.session_key
+        )
+        topic = Topic.objects.create(slug="eviction", order=0)
+        flow = TopicFlow.objects.create(topic=topic, slug="tenant", order=0)
+        page = TopicFlowInterviewPage.objects.create(
+            flow=flow, title="About you", order=0
+        )
+        variable = Variable.objects.create(name="tenant_name", label="Name")
+        VariableAnswer.objects.create(
+            identity=identity, variable=variable, value="Jamie"
+        )
+        _place(page, variable, 0)
+
+        response = self.client.get(reverse("pages:chat"))
+
+        groups = response.context["briefcase_groups"]
+        self.assertEqual([g["title"] for g in groups], ["About you"])
+        self.assertEqual(
+            [a.variable.label for a in groups[0]["answers"]], ["Name"]
+        )
+
+    def test_chat_page_exposes_empty_groups_for_a_fresh_visitor(self):
+        # The panel is always rendered, so the context key must always exist:
+        # a missing key and an empty list are different bugs in the template.
+        response = self.client.get(reverse("pages:chat"))
+
+        self.assertEqual(response.context["briefcase_groups"], [])
+
+
+class DisplayValueTests(TestCase):
+    """``VariableAnswer.display_value`` shapes jsonb for reading. No DB —
+    the property only touches the in-memory value."""
+
+    def _value(self, value):
+        return VariableAnswer(value=value).display_value
+
+    def test_list_renders_as_a_comma_separated_string(self):
+        # A multi-choice answer is stored as a list; str() would print
+        # "['Unpaid rent', 'Lease violation']" at the litigant.
+        self.assertEqual(
+            self._value(["Unpaid rent", "Lease violation"]),
+            "Unpaid rent, Lease violation",
+        )
+
+    def test_single_item_list_has_no_separator(self):
+        self.assertEqual(self._value(["Unpaid rent"]), "Unpaid rent")
+
+    def test_booleans_render_as_words_not_python_literals(self):
+        self.assertEqual(self._value(True), "Yes")
+        self.assertEqual(self._value(False), "No")
+
+    def test_false_is_not_treated_as_absent(self):
+        # `if self.value` would collapse False to the str() branch and print
+        # "False"; the isinstance check is what keeps it a real answer.
+        self.assertEqual(self._value(False), "No")
+
+    def test_strings_and_numbers_pass_through(self):
+        self.assertEqual(self._value("2026-09-01"), "2026-09-01")
+        self.assertEqual(self._value(28), "28")

--- a/litigant_portal/app/tests/test_chat_page.py
+++ b/litigant_portal/app/tests/test_chat_page.py
@@ -94,9 +94,9 @@ class AdminHeaderRegressionTests(TestCase):
 
 @pytest.mark.postgres
 class AgentStateGatingTests(TestCase):
-    """The Briefcase agent-state aside is only present in the response body
-    for users holding `manage_developers` — server-side gated, not just
-    CSS/Alpine-hidden."""
+    """The Briefcase panel itself is for everyone; the raw agent-state dump
+    inside it is only present in the response body for users holding
+    `manage_developers` — server-side gated, not just CSS/Alpine-hidden."""
 
     def setUp(self):
         self.client = Client()
@@ -110,18 +110,18 @@ class AgentStateGatingTests(TestCase):
             username="regular", email="regular@example.com", password="pw"
         )
 
-    def test_anonymous_user_does_not_see_agent_state(self):
+    def test_anonymous_user_sees_the_briefcase_but_not_agent_state(self):
         response = self.client.get(reverse("pages:chat"))
         content = response.content.decode()
+        self.assertRegex(content, BRIEFCASE_CHROME_RE)
         self.assertNotIn(AGENT_STATE_MARKER, content)
-        self.assertNotRegex(content, BRIEFCASE_CHROME_RE)
 
-    def test_non_developer_does_not_see_agent_state(self):
+    def test_non_developer_sees_the_briefcase_but_not_agent_state(self):
         self.client.login(username="regular", password="pw")
         response = self.client.get(reverse("pages:chat"))
         content = response.content.decode()
+        self.assertRegex(content, BRIEFCASE_CHROME_RE)
         self.assertNotIn(AGENT_STATE_MARKER, content)
-        self.assertNotRegex(content, BRIEFCASE_CHROME_RE)
 
     def test_developer_sees_agent_state(self):
         self.client.login(username="dev", password="pw")

--- a/litigant_portal/app/tests/test_topic_flow_renderer.py
+++ b/litigant_portal/app/tests/test_topic_flow_renderer.py
@@ -12,9 +12,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from litigant_portal.app.formatting import format_long_date
 from litigant_portal.app.topic_flow.renderer import (
     RenderedSection,
-    _format_deadline_date,
     render_section,
     submitted_section_anchor,
 )
@@ -379,21 +379,18 @@ def test_ics_renders_computed_deadline_from_answer():
     assert "March 3, 2026" in d["date_display"]
 
 
-def test_format_deadline_date_single_digit_day_has_no_leading_zero():
+def test_format_long_date_single_digit_day_has_no_leading_zero():
     # The display drops the leading zero on the day ("March 3", not "March 03")
     # and must do so without strftime's %-d — a glibc/BSD extension that raises
     # ValueError on platforms whose C library lacks it (Windows), which would
     # crash deadline rendering for a partner self-hosting there (#526). Pinning
     # the exact string guards both the no-leading-zero contract and a regression
     # back to %d.
-    assert _format_deadline_date(date(2026, 3, 3)) == "Tuesday, March 3, 2026"
+    assert format_long_date(date(2026, 3, 3)) == "Tuesday, March 3, 2026"
 
 
-def test_format_deadline_date_double_digit_day():
-    assert (
-        _format_deadline_date(date(2026, 12, 25))
-        == "Friday, December 25, 2026"
-    )
+def test_format_long_date_double_digit_day():
+    assert format_long_date(date(2026, 12, 25)) == "Friday, December 25, 2026"
 
 
 def test_ics_deadline_pending_when_answer_missing():

--- a/litigant_portal/app/topic_flow/renderer.py
+++ b/litigant_portal/app/topic_flow/renderer.py
@@ -21,6 +21,7 @@ consume, so what's downloaded can't drift from what's rendered on the page.
 
 from dataclasses import dataclass
 
+from litigant_portal.app.formatting import format_long_date
 from litigant_portal.app.topic_flow.contacts import resolve_vcf_contacts
 from litigant_portal.app.topic_flow.deadlines import resolve_ics_deadlines
 from litigant_portal.app.topic_flow.schema import FactGatherSection
@@ -225,19 +226,6 @@ def _render_packet(section, corpus, answers):
     )
 
 
-def _format_deadline_date(value):
-    """Human-readable deadline date, e.g. "Tuesday, March 3, 2026".
-
-    The day is interpolated as ``value.day`` rather than via strftime's ``%-d``.
-    ``%-d`` (no-leading-zero day) is a glibc/BSD extension, not standard C, so it
-    raises ``ValueError`` on platforms whose C library lacks it — notably Windows
-    — which would crash deadline rendering for a partner self-hosting LP there
-    (#526). Weekday/month stay on strftime: ``%A``/``%B`` are standard and
-    portable.
-    """
-    return f"{value.strftime('%A, %B')} {value.day}, {value.year}"
-
-
 def _deadline_display(resolved):
     """Add page-display date strings to a resolved deadline.
 
@@ -251,7 +239,7 @@ def _deadline_display(resolved):
     return {
         "label": resolved["label"],
         "description": resolved["description"],
-        "date_display": _format_deadline_date(computed) if computed else None,
+        "date_display": format_long_date(computed) if computed else None,
         "date_iso": computed.isoformat() if computed else None,
     }
 

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -11,7 +11,11 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, UpdateView
 
 from litigant_portal.app.forms import UserProfileForm
-from litigant_portal.app.models import UserProfile
+from litigant_portal.app.models import (
+    UserProfile,
+    Variable,
+    VariableAnswer,
+)
 from litigant_portal.app.models.choices import (
     DEFAULT_BEDROCK_MODEL,
     DEFAULT_FAST_BEDROCK_MODEL,
@@ -19,7 +23,10 @@ from litigant_portal.app.models.choices import (
     JurisdictionLevel,
     State,
 )
-from litigant_portal.app.selectors.topic_flow import topic_list
+from litigant_portal.app.selectors.topic_flow import (
+    briefcase_groups,
+    topic_list,
+)
 from litigant_portal.app.services.topic_flow import variable_answer_set_many
 from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
@@ -38,8 +45,18 @@ def home(request):
 
 
 def chat_view(request):
-    """Chat page"""
-    return render(request, "pages/chat/index.html")
+    """Chat page.
+
+    The briefcase renders server-side from the visitor's stored facts, so the
+    panel is populated on first paint rather than waiting on a fetch. The key
+    is always present, empty list included — the panel is a fixed part of the
+    frame and its empty state is a render, not an absence.
+    """
+    return render(
+        request,
+        "pages/chat/index.html",
+        {"briefcase_groups": briefcase_groups(identity=request.identity)},
+    )
 
 
 def deep_link(request, court, topic):
@@ -174,7 +191,48 @@ def accessibility(request):
 def style_guide(request):
     """Design tokens and component library"""
     topics = {t.slug: t for t in topic_list()}
-    return render(request, "pages/style_guide.html", {"topics": topics})
+    return render(
+        request,
+        "pages/style_guide.html",
+        {"topics": topics, "briefcase_groups": _briefcase_sample()},
+    )
+
+
+def _briefcase_sample() -> list[dict]:
+    """Unsaved sample facts for the style guide's briefcase entry.
+
+    Built in memory rather than queried so the page renders the same on a
+    fresh database, and so browsing the style guide never shows a real
+    visitor's answers.
+    """
+
+    def fact(name, label, value):
+        return VariableAnswer(
+            variable=Variable(name=name, label=label), value=value
+        )
+
+    return [
+        {
+            "title": "About you",
+            "answers": [
+                fact("tenant_first", "First name", "Jamie"),
+                fact("tenant_last", "Last name", "Rivera"),
+            ],
+        },
+        {
+            "title": "Your notice",
+            "answers": [
+                fact("received_date", "Date received", "2026-09-01"),
+                fact("notice_reason", "Reason given", ["Unpaid rent"]),
+            ],
+        },
+        {
+            "title": "",
+            "answers": [
+                fact("court_name", "Court", "Franklin County Municipal Court")
+            ],
+        },
+    ]
 
 
 class ProfileDetailView(LoginRequiredMixin, DetailView):

--- a/litigant_portal/app/views/pages.py
+++ b/litigant_portal/app/views/pages.py
@@ -22,11 +22,9 @@ from litigant_portal.app.models.choices import (
     BedrockModel,
     JurisdictionLevel,
     State,
+    VariableDataType,
 )
-from litigant_portal.app.selectors.topic_flow import (
-    briefcase_groups,
-    topic_list,
-)
+from litigant_portal.app.selectors.topic_flow import topic_list
 from litigant_portal.app.services.topic_flow import variable_answer_set_many
 from litigant_portal.app.topic_flow.registry import registry
 from litigant_portal.app.topic_flow.renderer import (
@@ -35,7 +33,10 @@ from litigant_portal.app.topic_flow.renderer import (
     submitted_section_anchor,
 )
 from litigant_portal.app.topic_flow.validation import validate_answers
-from litigant_portal.app.views.utils import topic_flow_answers
+from litigant_portal.app.views.utils import (
+    briefcase_answers,
+    topic_flow_answers,
+)
 
 
 def home(request):
@@ -55,7 +56,7 @@ def chat_view(request):
     return render(
         request,
         "pages/chat/index.html",
-        {"briefcase_groups": briefcase_groups(identity=request.identity)},
+        {"briefcase_groups": briefcase_answers(request)},
     )
 
 
@@ -206,9 +207,10 @@ def _briefcase_sample() -> list[dict]:
     visitor's answers.
     """
 
-    def fact(name, label, value):
+    def fact(name, label, value, data_type=VariableDataType.TEXT):
         return VariableAnswer(
-            variable=Variable(name=name, label=label), value=value
+            variable=Variable(name=name, label=label, data_type=data_type),
+            value=value,
         )
 
     return [
@@ -222,7 +224,12 @@ def _briefcase_sample() -> list[dict]:
         {
             "title": "Your notice",
             "answers": [
-                fact("received_date", "Date received", "2026-09-01"),
+                fact(
+                    "received_date",
+                    "Date received",
+                    "2026-09-01",
+                    VariableDataType.DATE,
+                ),
                 fact("notice_reason", "Reason given", ["Unpaid rent"]),
             ],
         },

--- a/litigant_portal/app/views/utils.py
+++ b/litigant_portal/app/views/utils.py
@@ -3,23 +3,45 @@ from functools import wraps
 from django.http import JsonResponse
 from django.utils.translation import gettext as _
 
-from litigant_portal.app.selectors.topic_flow import variable_answer_map
+from litigant_portal.app.selectors.topic_flow import (
+    variable_answer_groups,
+    variable_answer_map,
+)
 from litigant_portal.app.topic_flow.renderer import question_ids
+
+
+def _has_identity(request) -> bool:
+    """Whether this visitor already has an identity worth reading.
+
+    ``request.identity`` resolves lazily by minting a session and a
+    ``UserIdentity`` row, so an unguarded read banks one per anonymous hit,
+    crawlers included. Every read-only surface checks this first.
+    """
+    return bool(request.user.is_authenticated or request.session.session_key)
 
 
 def topic_flow_answers(request, corpus) -> dict:
     """``{question_id: value}`` for this visitor, for the page and downloads.
 
     Reads through the glossary, so a fact the assistant stored shows up
-    here too. Returns empty for a visitor with no session yet rather than
-    touching ``request.identity``, which would mint a session and an
-    identity row for every crawler hitting a flow page.
+    here too. Empty for a visitor with no identity yet.
     """
-    if not request.user.is_authenticated and not request.session.session_key:
+    if not _has_identity(request):
         return {}
     return variable_answer_map(
         identity=request.identity, names=question_ids(corpus)
     )
+
+
+def briefcase_answers(request) -> list[dict]:
+    """The visitor's stored facts, grouped for the briefcase panel.
+
+    Empty for a visitor with no identity yet, which renders as the panel's
+    empty state rather than an absent context key.
+    """
+    if not _has_identity(request):
+        return []
+    return variable_answer_groups(identity=request.identity)
 
 
 def _perm_required(codename: str):


### PR DESCRIPTION
The right-hand aside rendered a developer-gated JSON dump of agent state, so an anonymous litigant saw no briefcase at all while their facts sat unshown in `VariableAnswer`. The panel now renders those facts server-side on first paint, grouped for reading, composed from a new atom-level fact molecule and a panel organism.

Closes #865

## Grouping, and one deviation from the issue

The issue says group by "the active flow's interview pages." `chat_view` resolves no flow server-side, so grouping comes from each answered variable's own `TopicFlowInterviewVariable` placement instead. Same output when one flow is in play; when a variable sits on two flows' pages, the first in (topic, flow, page, placement) order wins, which keeps the grouping stable across requests.

No model change: `TopicFlowInterviewPage` already carries an ordered `title` and its docstring already calls the grouping cosmetic.

## Also here

- **The developer gate comes off** the desktop column, the mobile drawer, and the drawer trigger. The trigger was separately gated — leaving it would have made the drawer unopenable on mobile.
- **The raw agent-state dump survives** as an opt-in developer disclosure inside the panel. The opt-in exists because its Alpine bindings only resolve inside `x-data="chatApp"`, so the style guide would otherwise throw.
- **`VariableAnswer.display_value`** shapes jsonb for reading. Without it a multi-choice answer prints `['Unpaid rent']` at the litigant.
- Style guide gains both components, panel shown populated and empty.

## Test plan

20 tests in `test_briefcase.py` covering grouping order, placement order within a group, the trailing untitled group for unplaced answers, skipped empty pages, cleared and out-of-schema exclusion, cross-identity isolation, the chat-page context key, and `display_value`.

Four tests in `test_chat_page.py` were rewritten: they asserted the old contract, where anonymous users saw no briefcase chrome at all.

**Reviewing by hand:** open the guided flow and answer something, then open chat. Facts appear grouped by interview page. Opening a fresh chat shows the empty state — that is correct, not a bug. Nothing writes facts from chat yet; the agent's tools are `check_weather`, `load_topic_flow`, and `query_document`.
