### PR TITLE
Document the Docker Desktop to OrbStack switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@
 	   file-issue build-image push-image
 
 # Guard for commands that require the Docker container to be running
-# Surfaces docker's own stderr rather than swallowing it: a missing compose
-# plugin, a stale context and a stopped container all fail here, and only the
-# last one is fixed by `make docker` (see docs/wiki/container-runtime.md).
-require-docker = docker compose exec -T django true || \
-  { echo "Docker check failed (see the error above). If the container is stopped, start it with: make docker"; exit 1; }
+# Holds docker's own stderr rather than swallowing it, and prints it only when
+# the check fails: a missing compose plugin, a stale context and a stopped
+# container all fail here, and only the last one is fixed by `make docker`
+# (see docs/wiki/container-runtime.md). It is held rather than passed straight
+# through because compose warns about every unset variable it interpolates,
+# on the success path too.
+require-docker = err=$$(docker compose exec -T django true 2>&1) || \
+  { echo "$$err"; echo "Docker check failed (see the error above). If the container is stopped, start it with: make docker"; exit 1; }
 
 # Tailwind source + built output (the path base.html resolves via {% static %})
 CSS_SRC = litigant_portal/app/src/main.css

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@
 	   file-issue build-image push-image
 
 # Guard for commands that require the Docker container to be running
-require-docker = docker compose exec -T django true 2>/dev/null || \
-  { echo "Django container isn't running — start it with: make docker"; exit 1; }
+# Surfaces docker's own stderr rather than swallowing it: a missing compose
+# plugin, a stale context and a stopped container all fail here, and only the
+# last one is fixed by `make docker` (see docs/wiki/container-runtime.md).
+require-docker = docker compose exec -T django true || \
+  { echo "Docker check failed (see the error above). If the container is stopped, start it with: make docker"; exit 1; }
 
 # Tailwind source + built output (the path base.html resolves via {% static %})
 CSS_SRC = litigant_portal/app/src/main.css

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ The repo's reference shelf: material you reach for when you need it. Day-to-day 
 | [SECURITY.md](./wiki/SECURITY.md)                                     | Security architecture: production headers, secrets, CSP                                                           |
 | [ai-tone-guide.md](./wiki/ai-tone-guide.md)                           | Tone and philosophy for AI-generated user-facing output                                                           |
 | [audit-transcripts.md](./wiki/audit-transcripts.md)                   | How staff pull AI conversation transcripts, plus the retention policy                                             |
+| [container-runtime.md](./wiki/container-runtime.md)                   | Switching local Docker runtimes (Desktop to OrbStack) and the traps that look identical                           |
 | [frontend-design-principles.md](./wiki/frontend-design-principles.md) | Why LP uses Atomic Design, what it costs, and the component rules                                                 |
 | [issue-conventions.md](./wiki/issue-conventions.md)                   | Issue templates, labels, and the reasoning behind them                                                            |
 | [permissions.md](./wiki/permissions.md)                               | Admin panel permissions: the two permissions, the two groups, and how to check them                               |

--- a/docs/wiki/container-runtime.md
+++ b/docs/wiki/container-runtime.md
@@ -1,0 +1,168 @@
+# Container runtime: Docker Desktop and OrbStack
+
+LP's local environment is plain `docker compose`, so any Docker-compatible runtime works. This page covers switching from Docker Desktop to [OrbStack](https://orbstack.dev/) on macOS, in the order that works, plus four traps that all present the same way.
+
+**The one symptom to recognize:** `make docker` or `make test` reporting that Docker isn't running while the container is visibly running. Four unrelated causes produce it. Jump to [Troubleshooting](#troubleshooting).
+
+## The switch, in order
+
+Do these in sequence. Steps 3 and 6 are coupled: migrating requires Desktop to still be installed, and that is the same condition that stops OrbStack from writing its own CLI plugin links. Clean-uninstall-first and keep-your-volumes are mutually exclusive, so the plugins get repaired afterward rather than avoided.
+
+### 1. Quit Docker Desktop
+
+Quit the app rather than only stopping containers. Two runtimes cannot both own `/var/run/docker.sock`.
+
+### 2. Install OrbStack, leaving Desktop installed
+
+```sh
+brew install --cask orbstack
+```
+
+Launch it once so it sets up its CLI and socket.
+
+### 3. Migrate
+
+OrbStack's migration **copies** rather than moves, so Desktop stays intact as a fallback:
+
+```sh
+orb migrate docker
+```
+
+Images and volumes come across. Locally built images cannot — they exist in no registry, so the migration tries to pull them and fails:
+
+```
+some data failed to migrate: pull container image: [Docker] pull access denied
+for litigant-portal-django, repository does not exist or may require 'docker login'
+```
+
+That is expected for `litigant-portal-django`. It is built from this repo's Dockerfile and comes back on the next build (step 7).
+
+**Decide what you actually need first.** Named volumes hold local Postgres data (disposable — `docker compose down -v` is the documented reset) and the local docassemble bench, which holds Playground work. Anonymous hash volumes and duplicate `postgres_data*` volumes from past upgrades are cruft. To see what is at stake:
+
+```sh
+docker volume ls
+docker run --rm -v <volume>:/v alpine du -sh /v
+```
+
+### 4. Uninstall Docker Desktop
+
+```sh
+brew uninstall --cask docker-desktop
+```
+
+Use the cask uninstaller, not drag-to-trash — the cask handles the launchd agents and the `com.docker.vmnetd` privileged helper.
+
+Then the data directories, which the uninstall leaves behind and which hold the disk space:
+
+```sh
+rm -rf ~/Library/Application\ Support/Docker\ Desktop
+```
+
+`~/Library/Containers/com.docker.docker` and `~/Library/Group Containers/group.com.docker` need Finder. See [TCC on the data directory](#tcc-on-the-data-directory).
+
+**Never remove `~/.docker` wholesale.** It holds the contexts and `config.json` that OrbStack reads. Only the stale context needs clearing:
+
+```sh
+docker context rm desktop-linux
+```
+
+### 5. Remove a Homebrew `docker` formula, if you have one
+
+```sh
+brew list --formula | grep '^docker$'
+```
+
+If it is there, it will shadow OrbStack's `docker` on every login. See [PATH order](#path-order) for why, and for the alternative if you want to keep it.
+
+```sh
+brew uninstall docker
+```
+
+### 6. Repair the CLI plugins, then verify
+
+```sh
+ln -sf /Applications/OrbStack.app/Contents/MacOS/xbin/docker-compose ~/.docker/cli-plugins/docker-compose
+```
+
+List the plugin links still pointing into the deleted app:
+
+```sh
+find ~/.docker/cli-plugins -type l ! -exec test -e {} \; -print
+```
+
+Review that list before adding `-delete`. Then:
+
+```sh
+orbctl doctor
+```
+
+`doctor` checks the `docker` command's location, scans PATH for conflicts, and checks the CLI plugins. It is the fastest way to confirm the switch landed.
+
+### 7. Rebuild and start
+
+```sh
+make docker-up-build
+```
+
+`--build` matters here: the app image is the one thing the migration could not carry.
+
+## Troubleshooting
+
+### `docker: unknown command: docker compose`
+
+The compose CLI plugin is missing. `docker compose` (subcommand) resolves through `~/.docker/cli-plugins/`, which is separate from the standalone `docker-compose` binary — the standalone can work while the subcommand does not.
+
+Docker Desktop installed that plugin as a symlink into `/Applications/Docker.app`, and OrbStack skips writing its own when a file is already present. Uninstall Desktop and the link dangles, with nothing behind it.
+
+```sh
+ls -l ~/.docker/cli-plugins/docker-compose
+```
+
+A target under `/Applications/Docker.app` is the dangling case. Fix with the `ln -sf` in step 6. Every other plugin in that directory (`docker-buildx`, `docker-scout`, `docker-init`, and the rest) dangles the same way and will fail whenever something invokes it.
+
+### PATH order
+
+OrbStack's installer appends to PATH rather than prepending. In `~/.zprofile`:
+
+```sh
+export PATH="$PATH":/Users/you/.orbstack/bin
+```
+
+`.zprofile` runs before `.zshrc`, and `brew shellenv` in `.zshrc` **prepends** `/opt/homebrew/bin`. So a Homebrew `docker` formula lands ahead of OrbStack's on every login:
+
+```sh
+which -a docker
+```
+
+Two paths listed with `/opt/homebrew/bin/docker` first is the shadowing case. Either remove the formula (step 5) or move the OrbStack `source` line out of `~/.zprofile` and into `~/.zshrc` below `brew shellenv`.
+
+The Homebrew `docker` formula is a bare CLI: it ships no `cli-plugins` directory of its own, so once Desktop's plugins are gone it cannot run `docker compose` at all.
+
+### TCC on the data directory
+
+```
+rm: /Users/you/Library/Containers/com.docker.docker: Operation not permitted
+```
+
+This is macOS TCC, not file permissions — `containermanagerd` protects `~/Library/Containers`, and `sudo` does not help. Delete it in Finder (Go → Go to Folder → `~/Library/Containers`), then empty the Trash to actually reclaim the space. Same for `~/Library/Group Containers/group.com.docker`.
+
+Granting your terminal Full Disk Access in System Settings → Privacy & Security also works, if you would rather stay in the shell.
+
+### "Django container isn't running" when it is
+
+`make test` and the other container targets share a guard:
+
+```make
+require-docker = docker compose exec -T django true 2>/dev/null || \
+  { echo "Django container isn't running — start it with: make docker"; exit 1; }
+```
+
+Anything that makes `docker compose exec` fail produces that message, a missing compose plugin included. Run the command yourself to see the real error:
+
+```sh
+docker compose exec -T django true; echo "exit=$?"
+```
+
+### Different behavior between two terminal windows
+
+A shell opened before the switch carries the old PATH. `exec zsh` reloads the profile in place — note that it replaces the shell process, so anything chained after it with `&&` is discarded.

--- a/docs/wiki/container-runtime.md
+++ b/docs/wiki/container-runtime.md
@@ -148,20 +148,18 @@ This is macOS TCC, not file permissions — `containermanagerd` protects `~/Libr
 
 Granting your terminal Full Disk Access in System Settings → Privacy & Security also works, if you would rather stay in the shell.
 
-### "Django container isn't running" when it is
+### "Docker check failed" when the container is running
 
 `make test` and the other container targets share a guard:
 
 ```make
-require-docker = docker compose exec -T django true 2>/dev/null || \
-  { echo "Django container isn't running — start it with: make docker"; exit 1; }
+require-docker = err=$$(docker compose exec -T django true 2>&1) || \
+  { echo "$$err"; echo "Docker check failed (see the error above). If the container is stopped, start it with: make docker"; exit 1; }
 ```
 
-Anything that makes `docker compose exec` fail produces that message, a missing compose plugin included. Run the command yourself to see the real error:
+Anything that makes `docker compose exec` fail lands here, a missing compose plugin included — so the message names the stopped-container case without assuming it, and docker's own error prints directly above it.
 
-```sh
-docker compose exec -T django true; echo "exit=$?"
-```
+The output is held in `err` rather than passed straight through because `docker-compose.yml` interpolates `SITE_PASSWORD`, `SUPERUSER_EMAIL` and `SUPERUSER_PASSWORD`, none of which the documented `.env.example` setup defines. Compose warns about each one on stderr on every invocation, success included, so an unconditional pass-through would print three warnings before every guarded target.
 
 ### Different behavior between two terminal windows
 


### PR DESCRIPTION
LP's local environment is plain `docker compose`, so any compatible runtime works — but switching from Docker Desktop to OrbStack has four traps that all present identically: `make docker` reporting that Docker isn't running while the container is visibly running.

Closes #868

## The doc

`docs/wiki/container-runtime.md` gives the sequence, then a troubleshooting section keyed on the symptom rather than the cause, since from the terminal the four are indistinguishable.

The non-obvious part is the ordering. Migration copies from an installed Docker Desktop, and that is the same condition under which OrbStack skips writing its own CLI plugin symlinks. Clean-uninstall-first and keep-your-volumes are mutually exclusive, so the plugins get repaired afterward instead of avoided.

The four traps:

- **Dangling CLI plugins.** `~/.docker/cli-plugins/*` are symlinks into `/Applications/Docker.app`. Uninstalling Desktop leaves all of them broken, and OrbStack never wrote its own `docker-compose` because Desktop's was already there. Symptom is `docker: unknown command: docker compose`.
- **PATH order.** OrbStack's `~/.zprofile` line appends its bin; `brew shellenv` runs later in `.zshrc` and prepends `/opt/homebrew/bin`. A Homebrew `docker` formula shadows OrbStack's on every login and survives the Desktop uninstall, because it was never part of Desktop.
- **TCC on the data directory.** `~/Library/Containers/com.docker.docker` is protected by `containermanagerd`, so `sudo rm -rf` returns "Operation not permitted" and Finder is the way through. That directory is where the reclaimed disk lives.
- **`~/.docker` is not disposable.** It holds the contexts and `config.json` OrbStack reads; only the stale `desktop-linux` context needs clearing.

## The code change

`require-docker` in the Makefile ran `docker compose exec -T django true 2>/dev/null` and printed "Django container isn't running" for *any* failure — including a missing compose plugin, which is the one cause `make docker` cannot fix. It now lets docker's stderr through before the hint.

Tradeoff worth a look: any docker warning on a healthy system now prints on every guarded target.

## Test plan

Documentation plus a Makefile message. Every command in the doc was run during the switch that produced it. To verify the Makefile change, stop the container and run `make test` — the real error appears above the hint.
