### PR TITLE
Fail startup when a deployed environment has no site password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,10 @@ services:
       - POSTGRES_PASSWORD=postgres
       - REDIS_URL=redis://redis:6379/0
       - ALLOWED_HOSTS=localhost,portal.localhost,127.0.0.1,0.0.0.0
+      # Empty by default: the gate is off in local dev by design. The
+      # site_password system check errors if it's blank anywhere else.
+      - SITE_PASSWORD=${SITE_PASSWORD:-}
       # AI Chat configuration
-      - SITE_PASSWORD=${SITE_PASSWORD}
       - AWS_BEARER_TOKEN_BEDROCK=${AWS_BEARER_TOKEN_BEDROCK}
       - SUPERUSER_EMAIL=${SUPERUSER_EMAIL}
       - SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}

--- a/docs/wiki/SECURITY.md
+++ b/docs/wiki/SECURITY.md
@@ -29,6 +29,24 @@ Secrets are set in the `.env` file and exported to the environment. See `.env.ex
 
 ---
 
+## Site password gate
+
+`SITE_PASSWORD` puts a password wall in front of every page (`SitePasswordMiddleware`; static, media, and `/api/` are exempt). It is temporary, and it is the only thing keeping a pre-launch portal off the open web.
+
+**A blank value disables it.** That is the local-dev default and a silent failure anywhere else, so the `litigant_portal.E001` system check errors at startup when `DEPLOYMENT_ENV` is anything other than `dev` and the password is blank or whitespace. A failing check stops the deploy rather than serving an open site.
+
+Unrecognized `DEPLOYMENT_ENV` values count as deployed. `settings.py` keeps an unknown value as-is and only warns, so the check tests for "not dev" rather than "qa or prod" — a typo in the environment label fails closed instead of waving the gate through.
+
+**To take the wall down deliberately**, add the id to `SILENCED_SYSTEM_CHECKS`:
+
+```python
+SILENCED_SYSTEM_CHECKS = ["litigant_portal.E001"]
+```
+
+That makes going public an explicit, reviewable change with a name attached, rather than a secret quietly going missing.
+
+---
+
 ## Content Security Policy (CSP)
 
 CSP prevents XSS attacks by controlling which resources can load.

--- a/litigant_portal/app/apps.py
+++ b/litigant_portal/app/apps.py
@@ -9,6 +9,7 @@ class AppConfig(DjangoAppConfig):
     def ready(self):
         import litigant_portal.app.checks.corpus  # noqa: F401
         import litigant_portal.app.checks.prompts  # noqa: F401
+        import litigant_portal.app.checks.site_password  # noqa: F401
         import litigant_portal.app.topic_flow.checks  # noqa: F401
         from litigant_portal.app import signals
 

--- a/litigant_portal/app/checks/site_password.py
+++ b/litigant_portal/app/checks/site_password.py
@@ -1,0 +1,45 @@
+"""Django system check for the temporary site-wide password gate.
+
+``SitePasswordMiddleware`` disables itself when ``SITE_PASSWORD`` is empty,
+which is the right default for local development and a silent failure anywhere
+else: a dropped secret or a typo takes the wall down and serves a pre-launch
+portal to the public, with nothing louder than a compose warning at boot.
+
+This check turns that into a startup failure. Taking the wall down on purpose
+means silencing the check by id, which is a reviewable config change with a
+name attached rather than a value quietly going missing.
+"""
+
+from django.conf import settings
+from django.core.checks import Error, Tags, register
+
+SITE_PASSWORD_CHECK_ID = "litigant_portal.E001"
+
+# Anything that isn't local development counts as deployed. settings.py keeps
+# an unrecognized DEPLOYMENT_ENV as-is and only warns, so testing for "not dev"
+# fails closed where testing for "qa or prod" would wave a typo through.
+_LOCAL_ENV = "dev"
+
+
+@register(Tags.security, deploy=False)
+def check_site_password_set_when_deployed(app_configs, **kwargs):
+    """Error when a deployed environment has no usable site password."""
+    if getattr(settings, "DEPLOYMENT_ENV", _LOCAL_ENV) == _LOCAL_ENV:
+        return []
+
+    password = getattr(settings, "SITE_PASSWORD", "") or ""
+    if password.strip():
+        return []
+
+    return [
+        Error(
+            "SITE_PASSWORD is blank, so the site-wide password gate is off "
+            "and every page is public.",
+            hint=(
+                "Set SITE_PASSWORD in this environment. If the portal is "
+                "meant to be public, take the gate down deliberately by "
+                f"adding '{SITE_PASSWORD_CHECK_ID}' to SILENCED_SYSTEM_CHECKS."
+            ),
+            id=SITE_PASSWORD_CHECK_ID,
+        )
+    ]

--- a/litigant_portal/app/tests/test_site_password_check.py
+++ b/litigant_portal/app/tests/test_site_password_check.py
@@ -1,0 +1,57 @@
+"""The deployed-environment guard on the site-password gate.
+
+`SitePasswordMiddleware` treats a blank `SITE_PASSWORD` as "no gate", which is
+right in dev and silently serves a pre-launch portal to the public anywhere
+else. The check turns that into a failed startup.
+"""
+
+from django.core.checks import Error
+from django.test import TestCase, override_settings
+
+from litigant_portal.app.checks.site_password import (
+    SITE_PASSWORD_CHECK_ID,
+    check_site_password_set_when_deployed,
+)
+
+
+class SitePasswordCheckTests(TestCase):
+    def _run(self):
+        return check_site_password_set_when_deployed(app_configs=None)
+
+    @override_settings(DEPLOYMENT_ENV="prod", SITE_PASSWORD="")
+    def test_blank_gate_in_prod_is_an_error(self):
+        errors = self._run()
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], Error)
+        self.assertEqual(errors[0].id, SITE_PASSWORD_CHECK_ID)
+
+    @override_settings(DEPLOYMENT_ENV="qa", SITE_PASSWORD="")
+    def test_blank_gate_in_qa_is_an_error(self):
+        self.assertEqual(len(self._run()), 1)
+
+    @override_settings(DEPLOYMENT_ENV="dev", SITE_PASSWORD="")
+    def test_blank_gate_in_dev_is_fine(self):
+        # The dev default. Erroring here would make every fresh clone fail to
+        # start, which is how a check gets silenced permanently.
+        self.assertEqual(self._run(), [])
+
+    @override_settings(DEPLOYMENT_ENV="prod", SITE_PASSWORD="a-real-password")
+    def test_gate_set_in_prod_passes(self):
+        self.assertEqual(self._run(), [])
+
+    @override_settings(DEPLOYMENT_ENV="prod", SITE_PASSWORD="   ")
+    def test_whitespace_only_gate_is_an_error(self):
+        # `not password` in the middleware is False for "   ", so the gate is
+        # live and every visitor is locked out by an unguessable value. That's
+        # a different failure from a blank gate, and just as much a typo.
+        self.assertEqual(len(self._run()), 1)
+
+    @override_settings(DEPLOYMENT_ENV="prod", SITE_PASSWORD=None)
+    def test_unset_gate_in_prod_is_an_error(self):
+        self.assertEqual(len(self._run()), 1)
+
+    @override_settings(DEPLOYMENT_ENV="staging", SITE_PASSWORD="")
+    def test_unrecognized_environment_is_treated_as_deployed(self):
+        # settings.py keeps an unknown DEPLOYMENT_ENV as-is and only warns, so
+        # the check must fail closed rather than read "not qa or prod" as dev.
+        self.assertEqual(len(self._run()), 1)


### PR DESCRIPTION
`SitePasswordMiddleware` gates on `not password`, so a blank `SITE_PASSWORD` disables the site-wide wall and serves every page. That is the right default in local dev and a silent failure anywhere else: a dropped secret or a typo takes the gate down, with nothing louder than a compose warning scrolling past at boot.

```
WARN[0000] The "SITE_PASSWORD" variable is not set. Defaulting to a blank string.
```

Closes #870, sub-issue of #861.

## What changes

A system check (`litigant_portal.E001`) errors at startup when the environment is deployed and the password is blank or whitespace-only. Checks already run on startup and every management command, so this stops a deploy rather than serving an open site.

Whitespace-only is its own failure, not a variant of blank: `not password` reads `"   "` as a *live* gate, so every visitor is locked out by a value nobody can type.

Compose now declares the empty dev default explicitly (`${SITE_PASSWORD:-}`). That only makes sense alongside the check — on its own it would remove the one signal there was.

## One deviation from the issue

#870 says the check should fire for `qa` or `prod`. It fires for anything that isn't `dev`. `settings.py` keeps an unrecognized `DEPLOYMENT_ENV` as-is and only warns, so matching the two known labels would wave `DEPLOYMENT_ENV=staging` through with the wall down. Failing closed matches how `ALLOWED_HOSTS` already behaves.

## Taking the wall down on purpose

```python
SILENCED_SYSTEM_CHECKS = ["litigant_portal.E001"]
```

Going public becomes an explicit config change with a name attached, rather than a secret quietly going missing. Documented in `docs/wiki/SECURITY.md`.

## Test plan

Seven tests in `test_site_password_check.py`: blank in prod and qa error, blank in dev passes, a set password in prod passes, whitespace-only errors, unset errors, and an unrecognized environment is treated as deployed.

**Before merging, worth confirming:** whether QA and prod actually have `SITE_PASSWORD` set. That question is still open pending cluster access. If either is running blank today, this turns an open site into a failed boot — which is the intent, but better to know now than during a deploy.
