### PR TITLE
QA deploy is dispatch-only, defaulting to main

### DIFF
--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,15 +1,12 @@
 name: Deploy to QA (EKS)
 
 on:
-  push:
-    branches:
-      - qa
   workflow_dispatch:
     inputs:
       deploy_ref:
         description: 'Branch or tag to build and deploy to QA'
         required: true
-        default: 'qa'
+        default: 'main'
 
 env:
   AWS_REGION: us-west-2


### PR DESCRIPTION
## What changed

Closes #883.

`qa-deploy.yml` triggers on `workflow_dispatch` only, and `deploy_ref` defaults to `main` instead of `qa`.

```diff
 on:
-  push:
-    branches:
-      - qa
   workflow_dispatch:
     inputs:
       deploy_ref:
         description: 'Branch or tag to build and deploy to QA'
         required: true
-        default: 'qa'
+        default: 'main'
```

## Why

The deploy model is CI/CD on main plus one manual dispatch that can target any ref, for QA or any other environment. The push trigger contradicted that.

It also named `origin/qa`, which is 512 commits behind main (tip `2e5c3ff`, 2026-05-27, from the May `383-qa-deploy-branch-trigger` work). With `deploy_ref` defaulting to `'qa'`, a dispatch that took the default built that May branch.

The trigger was inert either way: Actions runs the workflow file from the pushed branch, and `qa-deploy.yml` is not on `qa` — that branch carries `cd.yml`, `lint.yml`, `stale.yml`, `tests.yml`.

## Notes

- The `|| github.sha` fallback on `ref:` stays. Under dispatch-only it is always the input, but it costs nothing and keeps the diff minimal.
- Deleting the `qa` branch is a separate call, out of scope here.
- No test: CI config, not application code.
